### PR TITLE
enforce identifier length limits for location ingest

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -16,6 +16,11 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const (
+	maxVehicleIDLength = 64
+	maxTripIDLength    = 128
+)
+
 // LocationReport is the JSON payload for incoming location data.
 type LocationReport struct {
 	VehicleID string  `json:"vehicle_id"`
@@ -31,6 +36,12 @@ type LocationReport struct {
 func (r *LocationReport) validate() error {
 	if r.VehicleID == "" {
 		return fmt.Errorf("vehicle_id is required")
+	}
+	if len(r.VehicleID) > maxVehicleIDLength {
+		return fmt.Errorf("vehicle_id exceeds maximum length of %d", maxVehicleIDLength)
+	}
+	if len(r.TripID) > maxTripIDLength {
+		return fmt.Errorf("trip_id exceeds maximum length of %d", maxTripIDLength)
 	}
 	if r.Latitude == 0 && r.Longitude == 0 {
 		return fmt.Errorf("latitude and longitude cannot both be zero (likely GPS error)")

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -204,6 +205,16 @@ func TestHandlePostLocation_Validation(t *testing.T) {
 			name: "zero timestamp",
 			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: 0},
 			want: "timestamp must be positive",
+		},
+		{
+			name: "vehicle_id too long",
+			loc:  LocationReport{VehicleID: strings.Repeat("v", maxVehicleIDLength+1), Latitude: 1, Longitude: 2, Timestamp: 100},
+			want: "vehicle_id exceeds maximum length",
+		},
+		{
+			name: "trip_id too long",
+			loc:  LocationReport{VehicleID: "bus-1", TripID: strings.Repeat("t", maxTripIDLength+1), Latitude: 1, Longitude: 2, Timestamp: 100},
+			want: "trip_id exceeds maximum length",
 		},
 	}
 


### PR DESCRIPTION
## Summary
Add identifier length validation for `POST /api/v1/locations` to reject overly long IDs early.

## Changes
- Add max length limits:
  - `vehicle_id`: 64
  - `trip_id`: 128
- Return `400` when either field exceeds its maximum length.
- Add tests covering oversized `vehicle_id` and `trip_id`.

## Why
This hardens the ingest endpoint against unbounded identifier payloads and keeps request validation predictable.

## Validation
go test -run TestHandlePostLocation ./...
go test ./...

<img width="417" height="55" alt="image" src="https://github.com/user-attachments/assets/1be01ed5-1dde-4f51-8c60-fd9d14b5e4c6" />

