### PR TITLE
add per-ip rate limiting for location ingest

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,8 @@ func main() {
 	startTime := time.Now()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/locations", handlePostLocation(store, tracker))
+	limiter := newIPRateLimiter(defaultRateLimitRPS, defaultRateLimitBurst)
+	mux.Handle("POST /api/v1/locations", rateLimitMiddleware(limiter, handlePostLocation(store, tracker)))
 	mux.HandleFunc("GET /gtfs-rt/vehicle-positions", handleGetFeed(tracker))
 	mux.HandleFunc("GET /api/v1/admin/status", handleAdminStatus(tracker, startTime))
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	defaultRateLimitRPS   = 5
+	defaultRateLimitBurst = 10
+)
+
+type rateLimitEntry struct {
+	windowStart time.Time
+	count       int
+}
+
+type ipRateLimiter struct {
+	mu      sync.Mutex
+	entries map[string]*rateLimitEntry
+	limit   int
+}
+
+func newIPRateLimiter(rps, burst int) *ipRateLimiter {
+	limit := rps + burst
+	if limit <= 0 {
+		limit = 1
+	}
+
+	return &ipRateLimiter{
+		entries: make(map[string]*rateLimitEntry),
+		limit:   limit,
+	}
+}
+
+func (l *ipRateLimiter) allow(ip string, now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry, ok := l.entries[ip]
+	if !ok {
+		l.entries[ip] = &rateLimitEntry{windowStart: now, count: 1}
+		return true
+	}
+
+	if now.Sub(entry.windowStart) >= time.Second {
+		entry.windowStart = now
+		entry.count = 1
+		return true
+	}
+
+	if entry.count >= l.limit {
+		return false
+	}
+	entry.count++
+	return true
+}
+
+func rateLimitMiddleware(limiter *ipRateLimiter, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !limiter.allow(clientIP(r), time.Now()) {
+			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil || host == "" {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimitMiddleware_AllowsUnderLimit(t *testing.T) {
+	limiter := newIPRateLimiter(1, 1) // 2 req/s
+	called := 0
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		w.WriteHeader(http.StatusCreated)
+	})
+	handler := rateLimitMiddleware(limiter, next)
+
+	req1 := httptest.NewRequest("POST", "/api/v1/locations", nil)
+	req1.RemoteAddr = "10.0.0.1:1111"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	req2 := httptest.NewRequest("POST", "/api/v1/locations", nil)
+	req2.RemoteAddr = "10.0.0.1:1111"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusCreated, w1.Code)
+	assert.Equal(t, http.StatusCreated, w2.Code)
+	assert.Equal(t, 2, called)
+}
+
+func TestRateLimitMiddleware_RejectsBurst(t *testing.T) {
+	limiter := newIPRateLimiter(1, 0) // 1 req/s
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	handler := rateLimitMiddleware(limiter, next)
+
+	req1 := httptest.NewRequest("POST", "/api/v1/locations", nil)
+	req1.RemoteAddr = "10.0.0.2:2222"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	req2 := httptest.NewRequest("POST", "/api/v1/locations", nil)
+	req2.RemoteAddr = "10.0.0.2:2222"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusCreated, w1.Code)
+	assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+}


### PR DESCRIPTION
## Summary
Add a lightweight per-IP rate limiter for `POST /api/v1/locations` to reduce ingestion abuse.

## Changes
- Introduce fixed-window, in-memory per-IP limiter middleware.
- Apply limiter only to `POST /api/v1/locations`.
- Return `429` with `{"error":"rate limit exceeded"}` when limit is exceeded.
- Add unit tests for:
  - requests under limit are allowed
  - burst beyond limit is rejected

## Why
This adds a basic guardrail against high-rate request floods on the ingest endpoint while keeping implementation simple.

## Validation

go test -run 'TestRateLimitMiddleware|TestHandlePostLocation' ./...
go test ./...

<img width="435" height="51" alt="image" src="https://github.com/user-attachments/assets/c36eedb6-8922-4821-b591-b115dd83fa5f" />
