### PR TITLE
Security pr rate limit env

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,8 @@ func main() {
 	startTime := time.Now()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/locations", handlePostLocation(store, tracker))
+	limiter := newIPRateLimiter(defaultRateLimitRPS, defaultRateLimitBurst)
+	mux.Handle("POST /api/v1/locations", rateLimitMiddleware(limiter, handlePostLocation(store, tracker)))
 	mux.HandleFunc("GET /gtfs-rt/vehicle-positions", handleGetFeed(tracker))
 	mux.HandleFunc("GET /api/v1/admin/status", handleAdminStatus(tracker, startTime))
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 )
@@ -18,6 +19,8 @@ func main() {
 	readTimeout := envDurationOrDefault("READ_TIMEOUT", 15*time.Second)
 	writeTimeout := envDurationOrDefault("WRITE_TIMEOUT", 15*time.Second)
 	idleTimeout := envDurationOrDefault("IDLE_TIMEOUT", 60*time.Second)
+	rateLimitRPS := envIntOrDefault("RATE_LIMIT_RPS", defaultRateLimitRPS)
+	rateLimitBurst := envIntOrDefault("RATE_LIMIT_BURST", defaultRateLimitBurst)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -50,7 +53,7 @@ func main() {
 	startTime := time.Now()
 
 	mux := http.NewServeMux()
-	limiter := newIPRateLimiter(defaultRateLimitRPS, defaultRateLimitBurst)
+	limiter := newIPRateLimiter(rateLimitRPS, rateLimitBurst)
 	mux.Handle("POST /api/v1/locations", rateLimitMiddleware(limiter, handlePostLocation(store, tracker)))
 	mux.HandleFunc("GET /gtfs-rt/vehicle-positions", handleGetFeed(tracker))
 	mux.HandleFunc("GET /api/v1/admin/status", handleAdminStatus(tracker, startTime))
@@ -98,6 +101,18 @@ func envDurationOrDefault(key string, fallback time.Duration) time.Duration {
 			return fallback
 		}
 		return d
+	}
+	return fallback
+}
+
+func envIntOrDefault(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			log.Printf("invalid int for %s: %q, using default %d", key, v, fallback)
+			return fallback
+		}
+		return n
 	}
 	return fallback
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestEnvIntOrDefault_UsesFallbackOnMissing(t *testing.T) {
+	t.Setenv("RATE_LIMIT_RPS", "")
+	got := envIntOrDefault("RATE_LIMIT_RPS", 7)
+	if got != 7 {
+		t.Fatalf("expected fallback 7, got %d", got)
+	}
+}
+
+func TestEnvIntOrDefault_UsesFallbackOnInvalid(t *testing.T) {
+	t.Setenv("RATE_LIMIT_RPS", "abc")
+	got := envIntOrDefault("RATE_LIMIT_RPS", 7)
+	if got != 7 {
+		t.Fatalf("expected fallback 7 on invalid input, got %d", got)
+	}
+}
+
+func TestEnvIntOrDefault_UsesFallbackOnNonPositive(t *testing.T) {
+	t.Setenv("RATE_LIMIT_RPS", "0")
+	got := envIntOrDefault("RATE_LIMIT_RPS", 7)
+	if got != 7 {
+		t.Fatalf("expected fallback 7 on non-positive input, got %d", got)
+	}
+}
+
+func TestEnvIntOrDefault_UsesEnvWhenValid(t *testing.T) {
+	t.Setenv("RATE_LIMIT_RPS", "12")
+	got := envIntOrDefault("RATE_LIMIT_RPS", 7)
+	if got != 12 {
+		t.Fatalf("expected 12, got %d", got)
+	}
+}

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	defaultRateLimitRPS   = 5
+	defaultRateLimitBurst = 10
+)
+
+type rateLimitEntry struct {
+	windowStart time.Time
+	count       int
+}
+
+type ipRateLimiter struct {
+	mu      sync.Mutex
+	entries map[string]*rateLimitEntry
+	limit   int
+}
+
+func newIPRateLimiter(rps, burst int) *ipRateLimiter {
+	limit := rps + burst
+	if limit <= 0 {
+		limit = 1
+	}
+
+	return &ipRateLimiter{
+		entries: make(map[string]*rateLimitEntry),
+		limit:   limit,
+	}
+}
+
+func (l *ipRateLimiter) allow(ip string, now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry, ok := l.entries[ip]
+	if !ok {
+		l.entries[ip] = &rateLimitEntry{windowStart: now, count: 1}
+		return true
+	}
+
+	if now.Sub(entry.windowStart) >= time.Second {
+		entry.windowStart = now
+		entry.count = 1
+		return true
+	}
+
+	if entry.count >= l.limit {
+		return false
+	}
+	entry.count++
+	return true
+}
+
+func rateLimitMiddleware(limiter *ipRateLimiter, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !limiter.allow(clientIP(r), time.Now()) {
+			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil || host == "" {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -10,28 +10,36 @@ import (
 const (
 	defaultRateLimitRPS   = 5
 	defaultRateLimitBurst = 10
+	defaultRateLimitTTL   = 10 * time.Minute
 )
 
 type rateLimitEntry struct {
-	windowStart time.Time
-	count       int
+	tokens     float64
+	lastRefill time.Time
+	lastSeen   time.Time
 }
 
 type ipRateLimiter struct {
 	mu      sync.Mutex
 	entries map[string]*rateLimitEntry
-	limit   int
+	rate    float64
+	burst   float64
+	ttl     time.Duration
 }
 
 func newIPRateLimiter(rps, burst int) *ipRateLimiter {
-	limit := rps + burst
-	if limit <= 0 {
-		limit = 1
+	if rps <= 0 {
+		rps = 1
+	}
+	if burst <= 0 {
+		burst = 1
 	}
 
 	return &ipRateLimiter{
 		entries: make(map[string]*rateLimitEntry),
-		limit:   limit,
+		rate:    float64(rps),
+		burst:   float64(burst),
+		ttl:     defaultRateLimitTTL,
 	}
 }
 
@@ -39,23 +47,43 @@ func (l *ipRateLimiter) allow(ip string, now time.Time) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	l.cleanupExpiredLocked(now)
+
 	entry, ok := l.entries[ip]
 	if !ok {
-		l.entries[ip] = &rateLimitEntry{windowStart: now, count: 1}
+		l.entries[ip] = &rateLimitEntry{
+			tokens:     l.burst - 1,
+			lastRefill: now,
+			lastSeen:   now,
+		}
 		return true
 	}
 
-	if now.Sub(entry.windowStart) >= time.Second {
-		entry.windowStart = now
-		entry.count = 1
-		return true
+	elapsed := now.Sub(entry.lastRefill).Seconds()
+	if elapsed > 0 {
+		entry.tokens += elapsed * l.rate
+		if entry.tokens > l.burst {
+			entry.tokens = l.burst
+		}
+		entry.lastRefill = now
 	}
 
-	if entry.count >= l.limit {
+	if entry.tokens < 1 {
+		entry.lastSeen = now
 		return false
 	}
-	entry.count++
+
+	entry.tokens--
+	entry.lastSeen = now
 	return true
+}
+
+func (l *ipRateLimiter) cleanupExpiredLocked(now time.Time) {
+	for ip, entry := range l.entries {
+		if now.Sub(entry.lastSeen) > l.ttl {
+			delete(l.entries, ip)
+		}
+	}
 }
 
 func rateLimitMiddleware(limiter *ipRateLimiter, next http.Handler) http.Handler {

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimitMiddleware_AllowsUnderLimit(t *testing.T) {
+	limiter := newIPRateLimiter(1, 1) // 2 req/s
+	called := 0
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		w.WriteHeader(http.StatusCreated)
+	})
+	handler := rateLimitMiddleware(limiter, next)
+
+	req1 := httptest.NewRequest("POST", "/api/v1/locations", nil)
+	req1.RemoteAddr = "10.0.0.1:1111"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	req2 := httptest.NewRequest("POST", "/api/v1/locations", nil)
+	req2.RemoteAddr = "10.0.0.1:1111"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusCreated, w1.Code)
+	assert.Equal(t, http.StatusCreated, w2.Code)
+	assert.Equal(t, 2, called)
+}
+
+func TestRateLimitMiddleware_RejectsBurst(t *testing.T) {
+	limiter := newIPRateLimiter(1, 0) // 1 req/s
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	handler := rateLimitMiddleware(limiter, next)
+
+	req1 := httptest.NewRequest("POST", "/api/v1/locations", nil)
+	req1.RemoteAddr = "10.0.0.2:2222"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	req2 := httptest.NewRequest("POST", "/api/v1/locations", nil)
+	req2.RemoteAddr = "10.0.0.2:2222"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusCreated, w1.Code)
+	assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+}

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRateLimitMiddleware_AllowsUnderLimit(t *testing.T) {
-	limiter := newIPRateLimiter(1, 1) // 2 req/s
+	limiter := newIPRateLimiter(2, 2) // 2 tokens/s, burst capacity 2
 	called := 0
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called++
@@ -33,7 +34,7 @@ func TestRateLimitMiddleware_AllowsUnderLimit(t *testing.T) {
 }
 
 func TestRateLimitMiddleware_RejectsBurst(t *testing.T) {
-	limiter := newIPRateLimiter(1, 0) // 1 req/s
+	limiter := newIPRateLimiter(1, 1) // single immediate token, then block until refill
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	})
@@ -51,4 +52,21 @@ func TestRateLimitMiddleware_RejectsBurst(t *testing.T) {
 
 	assert.Equal(t, http.StatusCreated, w1.Code)
 	assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+}
+
+func TestIPRateLimiter_CleansUpExpiredEntries(t *testing.T) {
+	limiter := newIPRateLimiter(1, 1)
+	limiter.ttl = time.Millisecond
+
+	now := time.Now()
+	limiter.entries["10.0.0.1"] = &rateLimitEntry{
+		tokens:     0,
+		lastRefill: now.Add(-time.Second),
+		lastSeen:   now.Add(-time.Second),
+	}
+
+	allowed := limiter.allow("10.0.0.2", now)
+	assert.True(t, allowed)
+	_, exists := limiter.entries["10.0.0.1"]
+	assert.False(t, exists, "expired limiter entry should be evicted")
 }


### PR DESCRIPTION
## Summary
Make ingest rate limiting configurable via environment variables.

## Changes
- Read rate-limit settings from env in `main`:
  - `RATE_LIMIT_RPS`
  - `RATE_LIMIT_BURST`
- Add `envIntOrDefault` helper:
  - uses fallback for missing, invalid, or non-positive values
  - uses env value when valid
- Keep existing defaults when env vars are not set.

## Why
This keeps the basic protection from PR-S5 while letting deployments tune limits without code changes.

## Validation

go test -run 'TestEnvIntOrDefault|TestRateLimitMiddleware' ./...
go test ./...

<img width="432" height="46" alt="image" src="https://github.com/user-attachments/assets/a49b59c9-97c1-490d-b006-0bde2d1c84fd" />
