### PR TITLE
feat(auth): implement secure refresh token mechanism

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +14,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -38,10 +42,17 @@ type LoginRequest struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
 }
-
-// LoginResponse is returned on a successful login.
 type LoginResponse struct {
-	Token string `json:"token"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type RefreshResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
+type RefreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
 }
 
 // UserFetcher is the store interface needed by the login handler.
@@ -49,7 +60,29 @@ type UserFetcher interface {
 	GetUserByEmail(ctx context.Context, email string) (*User, error)
 }
 
-func handleLogin(fetcher UserFetcher, secret []byte) http.HandlerFunc {
+type RefreshTokenCreator interface {
+	CreateRefreshToken(ctx context.Context, id string, userID int64, tokenHash string, issuedAt time.Time, expiresAt time.Time) error
+}
+
+type LoginStore interface {
+	UserFetcher
+	RefreshTokenCreator
+}
+
+type RefreshTokenGetter interface {
+	GetRefreshToken(ctx context.Context, tokenHash string) (*RefreshToken, error)
+}
+
+type UserByIDFetcher interface {
+	GetUserByID(ctx context.Context, userID int64) (*User, error)
+}
+
+type RefreshStore interface {
+	RefreshTokenGetter
+	UserByIDFetcher
+}
+
+func handleLogin(deps LoginStore, secret []byte, accessTTL, refreshTTL time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, 1<<10)
 
@@ -64,7 +97,7 @@ func handleLogin(fetcher UserFetcher, secret []byte) http.HandlerFunc {
 			return
 		}
 
-		user, err := fetcher.GetUserByEmail(r.Context(), req.Email)
+		user, err := deps.GetUserByEmail(r.Context(), req.Email)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				_ = bcrypt.CompareHashAndPassword(dummyHash, []byte(req.Password)) // timing side-channel prevention
@@ -87,26 +120,107 @@ func handleLogin(fetcher UserFetcher, secret []byte) http.HandlerFunc {
 			return
 		}
 
-		tokenStr, err := generateJWT(user, secret)
+		accessToken, err := generateJWT(user, secret, accessTTL)
 		if err != nil {
 			log.Printf("login: failed to generate JWT: %v", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}
 
-		writeJSON(w, http.StatusOK, LoginResponse{Token: tokenStr})
+		rawToken, tokenHash, err := generateRefreshToken()
+		if err != nil {
+			log.Printf("login: failed to generate refresh token: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		now := time.Now()
+		if err := deps.CreateRefreshToken(r.Context(), uuid.New().String(), user.ID, tokenHash, now, now.Add(refreshTTL)); err != nil {
+			log.Printf("login: failed to store refresh token: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, LoginResponse{AccessToken: accessToken, RefreshToken: rawToken})
 	}
 }
 
-// generateJWT creates a signed JWT valid for 24 hours.
-func generateJWT(user *User, secret []byte) (string, error) {
+func generateRefreshToken() (token string, hash string, err error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("generate refresh token: %w", err)
+	}
+	token = base64.RawURLEncoding.EncodeToString(b)
+	sum := sha256.Sum256([]byte(token))
+	hash = fmt.Sprintf("%x", sum)
+	return token, hash, nil
+}
+
+func handleRefreshToken(deps RefreshStore, secret []byte, accessTTL time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<10)
+
+		var req RefreshRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			return
+		}
+
+		if req.RefreshToken == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "refresh_token is required"})
+			return
+		}
+
+		sum := sha256.Sum256([]byte(req.RefreshToken))
+		tokenHash := fmt.Sprintf("%x", sum)
+
+		rt, err := deps.GetRefreshToken(r.Context(), tokenHash)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid refresh token"})
+				return
+			}
+			log.Printf("refresh: database error: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		if rt.Revoked {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "refresh token has been revoked"})
+			return
+		}
+
+		if time.Now().After(rt.ExpiresAt) {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "refresh token has expired"})
+			return
+		}
+
+		user, err := deps.GetUserByID(r.Context(), rt.UserID)
+		if err != nil {
+			log.Printf("refresh: failed to fetch user: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		accessToken, err := generateJWT(user, secret, accessTTL)
+		if err != nil {
+			log.Printf("refresh: failed to generate JWT: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, RefreshResponse{AccessToken: accessToken})
+	}
+}
+
+func generateJWT(user *User, secret []byte, ttl time.Duration) (string, error) {
 	now := time.Now()
 
 	claims := jwt.MapClaims{
 		"sub":   fmt.Sprintf("%d", user.ID),
 		"email": user.Email,
 		"role":  user.Role,
-		"exp":   now.Add(24 * time.Hour).Unix(),
+		"exp":   now.Add(ttl).Unix(),
 		"iat":   now.Unix(),
 		"iss":   "vehicle-positions-api",
 	}

--- a/auth.go
+++ b/auth.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -104,7 +104,7 @@ func handleLogin(deps LoginStore, secret []byte, accessTTL, refreshTTL time.Dura
 				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid email or password"})
 				return
 			}
-			log.Printf("login: database error: %v", err)
+			slog.Error("login: database error", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}
@@ -115,28 +115,28 @@ func handleLogin(deps LoginStore, secret []byte, accessTTL, refreshTTL time.Dura
 				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid email or password"})
 				return
 			}
-			log.Printf("login: bcrypt error: %v", err)
+			slog.Error("login: bcrypt error", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}
 
 		accessToken, err := generateJWT(user, secret, accessTTL)
 		if err != nil {
-			log.Printf("login: failed to generate JWT: %v", err)
+			slog.Error("login: failed to generate jwt", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}
 
 		rawToken, tokenHash, err := generateRefreshToken()
 		if err != nil {
-			log.Printf("login: failed to generate refresh token: %v", err)
+			slog.Error("login: failed to generate refresh token", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}
 
 		now := time.Now()
 		if err := deps.CreateRefreshToken(r.Context(), uuid.New().String(), user.ID, tokenHash, now, now.Add(refreshTTL)); err != nil {
-			log.Printf("login: failed to store refresh token: %v", err)
+			slog.Error("login: failed to store refresh token", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}
@@ -180,7 +180,7 @@ func handleRefreshToken(deps RefreshStore, secret []byte, accessTTL time.Duratio
 				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid refresh token"})
 				return
 			}
-			log.Printf("refresh: database error: %v", err)
+			slog.Error("refresh: database error", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}
@@ -197,14 +197,14 @@ func handleRefreshToken(deps RefreshStore, secret []byte, accessTTL time.Duratio
 
 		user, err := deps.GetUserByID(r.Context(), rt.UserID)
 		if err != nil {
-			log.Printf("refresh: failed to fetch user: %v", err)
+			slog.Error("refresh: failed to fetch user", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}
 
 		accessToken, err := generateJWT(user, secret, accessTTL)
 		if err != nil {
-			log.Printf("refresh: failed to generate JWT: %v", err)
+			slog.Error("refresh: failed to generate jwt", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}
@@ -248,7 +248,7 @@ func requireAuth(secret []byte) func(http.Handler) http.Handler {
 			}, jwt.WithValidMethods([]string{"HS256"}), jwt.WithIssuer("vehicle-positions-api"))
 
 			if err != nil || !token.Valid {
-				log.Printf("auth: token validation failed: %v", err)
+				slog.Warn("auth: token validation failed", "error", err)
 				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid token"})
 				return
 			}

--- a/auth_test.go
+++ b/auth_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockUserStore implements UserFetcher for tests.
 type mockUserStore struct {
-	user *User
-	err  error
+	user             *User
+	err              error
+	createRefreshErr error
 }
 
 var testSecret = []byte("super-secret-test-key-32-bytes!!")
@@ -29,6 +29,10 @@ func (m *mockUserStore) GetUserByEmail(ctx context.Context, email string) (*User
 		return nil, m.err
 	}
 	return m.user, nil
+}
+
+func (m *mockUserStore) CreateRefreshToken(_ context.Context, _ string, _ int64, _ string, _, _ time.Time) error {
+	return m.createRefreshErr
 }
 
 func postLogin(handler http.HandlerFunc, email, password string) *httptest.ResponseRecorder {
@@ -48,7 +52,7 @@ func TestHandleLogin_Success(t *testing.T) {
 		Role:         "driver",
 	}}
 
-	handler := handleLogin(store, testSecret)
+	handler := handleLogin(store, testSecret, 15*time.Minute, 7*24*time.Hour)
 	w := postLogin(handler, "driver@test.com", "password")
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -56,7 +60,8 @@ func TestHandleLogin_Success(t *testing.T) {
 	var resp LoginResponse
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err)
-	assert.NotEmpty(t, resp.Token)
+	assert.NotEmpty(t, resp.AccessToken)
+	assert.NotEmpty(t, resp.RefreshToken)
 }
 
 func TestHandleLogin_WrongPassword(t *testing.T) {
@@ -67,7 +72,7 @@ func TestHandleLogin_WrongPassword(t *testing.T) {
 		Role:         "driver",
 	}}
 
-	handler := handleLogin(store, testSecret)
+	handler := handleLogin(store, testSecret, 15*time.Minute, 7*24*time.Hour)
 	w := postLogin(handler, "driver@test.com", "wrongpassword")
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -81,7 +86,7 @@ func TestHandleLogin_WrongPassword(t *testing.T) {
 func TestHandleLogin_UserNotFound(t *testing.T) {
 	store := &mockUserStore{err: pgx.ErrNoRows}
 
-	handler := handleLogin(store, testSecret)
+	handler := handleLogin(store, testSecret, 15*time.Minute, 7*24*time.Hour)
 	w := postLogin(handler, "nobody@test.com", "password")
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -89,7 +94,7 @@ func TestHandleLogin_UserNotFound(t *testing.T) {
 
 func TestHandleLogin_MissingFields(t *testing.T) {
 	store := &mockUserStore{}
-	handler := handleLogin(store, testSecret)
+	handler := handleLogin(store, testSecret, 15*time.Minute, 7*24*time.Hour)
 
 	tests := []struct {
 		name     string
@@ -111,7 +116,7 @@ func TestHandleLogin_MissingFields(t *testing.T) {
 
 func TestHandleLogin_InvalidJSON(t *testing.T) {
 	store := &mockUserStore{}
-	handler := handleLogin(store, testSecret)
+	handler := handleLogin(store, testSecret, 15*time.Minute, 7*24*time.Hour)
 
 	req := httptest.NewRequest("POST", "/api/v1/auth/login", bytes.NewReader([]byte("{bad json")))
 	req.Header.Set("Content-Type", "application/json")
@@ -188,7 +193,7 @@ func TestRequireAuth_ExpiredToken(t *testing.T) {
 }
 
 func TestRequireAuth_ValidToken(t *testing.T) {
-	token, err := generateJWT(&User{ID: 1, Email: "driver@test.com", Role: "driver"}, testSecret)
+	token, err := generateJWT(&User{ID: 1, Email: "driver@test.com", Role: "driver"}, testSecret, 15*time.Minute)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("POST", "/api/v1/locations", nil)
@@ -214,7 +219,7 @@ func TestRequireAuth_ValidToken(t *testing.T) {
 func TestGenerateJWT_Claims(t *testing.T) {
 	user := &User{ID: 42, Email: "driver@transit.com", Role: "driver"}
 
-	tokenStr, err := generateJWT(user, testSecret)
+	tokenStr, err := generateJWT(user, testSecret, 15*time.Minute)
 	require.NoError(t, err)
 
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
@@ -239,7 +244,7 @@ func TestRequireAuth_WrongSecret(t *testing.T) {
 	wrongSecret := []byte("the-wrong-secret-key-32-bytes-!!")
 
 	user := &User{ID: 1, Email: "hacker@evil.com", Role: "admin"}
-	tokenStr, _ := generateJWT(user, wrongSecret)
+	tokenStr, _ := generateJWT(user, wrongSecret, 15*time.Minute)
 
 	req := httptest.NewRequest("POST", "/api/v1/locations", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenStr)
@@ -267,4 +272,104 @@ func TestRequireAuth_AlgorithmConfusion(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+type mockRefreshStore struct {
+	token   *RefreshToken
+	getErr  error
+	user    *User
+	userErr error
+}
+
+func (m *mockRefreshStore) GetRefreshToken(_ context.Context, _ string) (*RefreshToken, error) {
+	return m.token, m.getErr
+}
+
+func (m *mockRefreshStore) GetUserByID(_ context.Context, _ int64) (*User, error) {
+	return m.user, m.userErr
+}
+
+func postRefresh(handler http.HandlerFunc, refreshToken string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(RefreshRequest{RefreshToken: refreshToken})
+	req := httptest.NewRequest("POST", "/api/v1/auth/refresh", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler(w, req)
+	return w
+}
+
+func TestHandleRefreshToken_Success(t *testing.T) {
+	user := &User{ID: 1, Email: "driver@test.com", Role: "driver"}
+	store := &mockRefreshStore{
+		token: &RefreshToken{
+			UserID:    1,
+			ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
+			Revoked:   false,
+		},
+		user: user,
+	}
+
+	handler := handleRefreshToken(store, testSecret, 15*time.Minute)
+	w := postRefresh(handler, "somevalidtoken")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp RefreshResponse
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.AccessToken)
+}
+
+func TestHandleRefreshToken_RevokedToken(t *testing.T) {
+	store := &mockRefreshStore{
+		token: &RefreshToken{
+			UserID:    1,
+			ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
+			Revoked:   true,
+		},
+	}
+
+	handler := handleRefreshToken(store, testSecret, 15*time.Minute)
+	w := postRefresh(handler, "sometoken")
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]string
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "refresh token has been revoked", resp["error"])
+}
+
+func TestHandleRefreshToken_ExpiredToken(t *testing.T) {
+	store := &mockRefreshStore{
+		token: &RefreshToken{
+			UserID:    1,
+			ExpiresAt: time.Now().Add(-1 * time.Hour),
+			Revoked:   false,
+		},
+	}
+
+	handler := handleRefreshToken(store, testSecret, 15*time.Minute)
+	w := postRefresh(handler, "sometoken")
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]string
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "refresh token has expired", resp["error"])
+}
+
+func TestHandleRefreshToken_TokenNotFound(t *testing.T) {
+	store := &mockRefreshStore{getErr: pgx.ErrNoRows}
+
+	handler := handleRefreshToken(store, testSecret, 15*time.Minute)
+	w := postRefresh(handler, "unknowntoken")
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var resp map[string]string
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.Equal(t, "invalid refresh token", resp["error"])
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       PORT: "8080"
       DATABASE_URL: "postgres://postgres:postgres@db:5432/vehicle_positions?sslmode=disable"
       STALENESS_THRESHOLD: "5m"
+      JWT_SECRET: "this-is-a-local-dev-secret-1234567890"
+      ACCESS_TOKEN_TTL: "15m"
+      REFRESH_TOKEN_TTL: "168h"
     depends_on:
       db:
         condition: service_healthy

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/MobilityData/gtfs-realtime-bindings/golang/gtfs v1.0.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.48.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/golang-migrate/migrate/v4 v4.19.1 h1:OCyb44lFuQfYXYLx1SCxPZQGU7mcaZ7g
 github.com/golang-migrate/migrate/v4 v4.19.1/go.mod h1:CTcgfjxhaUtsLipnLoQRWCrjYXycRz/g5+RWDuYgPrE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/main.go
+++ b/main.go
@@ -33,6 +33,9 @@ func main() {
 	}
 	jwtSecret := []byte(jwtSecretStr)
 
+	accessTTL := envDurationOrDefault("ACCESS_TOKEN_TTL", 15*time.Minute)
+	refreshTTL := envDurationOrDefault("REFRESH_TOKEN_TTL", 7*24*time.Hour)
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
@@ -69,7 +72,8 @@ func main() {
 	startTime := time.Now()
 
 	mux := http.NewServeMux()
-	mux.Handle("POST /api/v1/auth/login", handleLogin(store, jwtSecret))
+	mux.Handle("POST /api/v1/auth/login", handleLogin(store, jwtSecret, accessTTL, refreshTTL))
+	mux.Handle("POST /api/v1/auth/refresh", handleRefreshToken(store, jwtSecret, accessTTL))
 	mux.HandleFunc("GET /gtfs-rt/vehicle-positions", handleGetFeed(tracker))
 	// TODO: protect with requireAuth once auth lands
 	mux.HandleFunc("GET /api/v1/admin/status", handleAdminStatus(tracker, startTime))

--- a/migrations/000007_add_refresh_tokens.down.sql
+++ b/migrations/000007_add_refresh_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS refresh_tokens;

--- a/migrations/000007_add_refresh_tokens.up.sql
+++ b/migrations/000007_add_refresh_tokens.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE refresh_tokens (
+    id UUID PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    token_hash TEXT UNIQUE NOT NULL,
+    issued_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked BOOLEAN DEFAULT FALSE
+);

--- a/store_refresh_tokens.go
+++ b/store_refresh_tokens.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type RefreshToken struct {
+	ID        string
+	UserID    int64
+	TokenHash string
+	IssuedAt  time.Time
+	ExpiresAt time.Time
+	Revoked   bool
+}
+
+func (s *Store) CreateRefreshToken(ctx context.Context, id string, userID int64, tokenHash string, issuedAt time.Time, expiresAt time.Time) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO refresh_tokens (id, user_id, token_hash, issued_at, expires_at) VALUES ($1, $2, $3, $4, $5)`,
+		id, userID, tokenHash, issuedAt, expiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("create refresh token: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetRefreshToken(ctx context.Context, tokenHash string) (*RefreshToken, error) {
+	var rt RefreshToken
+	err := s.pool.QueryRow(ctx,
+		`SELECT id, user_id, token_hash, issued_at, expires_at, revoked FROM refresh_tokens WHERE token_hash = $1`,
+		tokenHash,
+	).Scan(
+		&rt.ID,
+		&rt.UserID,
+		&rt.TokenHash,
+		&rt.IssuedAt,
+		&rt.ExpiresAt,
+		&rt.Revoked,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get refresh token: %w", err)
+	}
+	return &rt, nil
+}
+
+func (s *Store) RevokeRefreshToken(ctx context.Context, tokenHash string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE refresh_tokens SET revoked = TRUE WHERE token_hash = $1`,
+		tokenHash,
+	)
+	if err != nil {
+		return fmt.Errorf("revoke refresh token: %w", err)
+	}
+	return nil
+}

--- a/store_users.go
+++ b/store_users.go
@@ -5,6 +5,28 @@ import (
 	"fmt"
 )
 
+func (s *Store) GetUserByID(ctx context.Context, userID int64) (*User, error) {
+	query := `
+		SELECT id, name, email, password_hash, role, created_at, updated_at
+		FROM users
+		WHERE id = $1
+	`
+	var u User
+	err := s.pool.QueryRow(ctx, query, userID).Scan(
+		&u.ID,
+		&u.Name,
+		&u.Email,
+		&u.PasswordHash,
+		&u.Role,
+		&u.CreatedAt,
+		&u.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get user by id: %w", err)
+	}
+	return &u, nil
+}
+
 // GetUserByEmail fetches a user by email address. (Returns an error if no user is found)
 func (s *Store) GetUserByEmail(ctx context.Context, email string) (*User, error) {
 	query := `


### PR DESCRIPTION
This PR introduces a secure refresh token mechanism to the existing JWT authentication system. Referencing PR #29, this update ensures that access tokens can maintain a strict, short-lived expiration while allowing users to seamlessly maintain their sessions. This is designed to be consumed by a frontend wrapper that automatically catches 401 expiries, fetches a new access token, and retries the original request. By separating access from session longevity, the system is significantly hardened against token theft.

The refresh token is generated as an opaque, cryptographically secure random string rather than a secondary JWT. Before storing the refresh token, it is hashed, ensuring that a database compromise does not lead to session hijacking. The token storage schema leverages the UUID implementation introduced in PR #58 for primary key generation. Standard Time-to-Live limits are enforced through new environment variables, defaulting to fifteen minutes for the access token and seven days for the refresh token.

Tests are added in auth_test.go. As a future scope, this architecture easily supports the addition of refresh token rotation.