### PR TITLE
feat: GTFS-RT feed validation & E012 compliance fix

### DIFF
--- a/feed_validation_test.go
+++ b/feed_validation_test.go
@@ -212,7 +212,7 @@ func TestFeedValidation_E026_BoundaryCoordinates(t *testing.T) {
 func TestFeedValidation_E027_ValidBearing(t *testing.T) {
 	now := time.Now().Unix()
 	vehicles := []*VehicleState{
-		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Bearing: 180, Timestamp: now},
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Bearing: float64ptr(180), Timestamp: now},
 	}
 	feed := buildFeed(vehicles)
 	violations := validateFeedCompliance(t, feed)
@@ -222,10 +222,10 @@ func TestFeedValidation_E027_ValidBearing(t *testing.T) {
 func TestFeedValidation_E027_BearingBoundaries(t *testing.T) {
 	now := time.Now().Unix()
 	vehicles := []*VehicleState{
-		{VehicleID: "north", Latitude: 1, Longitude: 2, Bearing: 0, Timestamp: now},
-		{VehicleID: "east", Latitude: 3, Longitude: 4, Bearing: 90, Timestamp: now},
-		{VehicleID: "south", Latitude: 5, Longitude: 6, Bearing: 180, Timestamp: now},
-		{VehicleID: "wrap", Latitude: 7, Longitude: 8, Bearing: 360, Timestamp: now},
+		{VehicleID: "north", Latitude: 1, Longitude: 2, Bearing: float64ptr(0), Timestamp: now},
+		{VehicleID: "east", Latitude: 3, Longitude: 4, Bearing: float64ptr(90), Timestamp: now},
+		{VehicleID: "south", Latitude: 5, Longitude: 6, Bearing: float64ptr(180), Timestamp: now},
+		{VehicleID: "wrap", Latitude: 7, Longitude: 8, Bearing: float64ptr(360), Timestamp: now},
 	}
 	feed := buildFeed(vehicles)
 
@@ -325,8 +325,8 @@ func TestFeedValidation_W002_VehicleIDPopulated(t *testing.T) {
 func TestFeedValidation_SpeedNonNegative(t *testing.T) {
 	now := time.Now().Unix()
 	vehicles := []*VehicleState{
-		{VehicleID: "stationary", Latitude: 1, Longitude: 2, Speed: 0, Timestamp: now},
-		{VehicleID: "moving", Latitude: 3, Longitude: 4, Speed: 15.5, Timestamp: now},
+		{VehicleID: "stationary", Latitude: 1, Longitude: 2, Speed: float64ptr(0), Timestamp: now},
+		{VehicleID: "moving", Latitude: 3, Longitude: 4, Speed: float64ptr(15.5), Timestamp: now},
 	}
 	feed := buildFeed(vehicles)
 	violations := validateFeedCompliance(t, feed)
@@ -355,16 +355,16 @@ func TestFeedValidation_FullFeedCompliance(t *testing.T) {
 			TripID:    "route_5_0830",
 			Latitude:  -1.2921,
 			Longitude: 36.8219,
-			Bearing:   180.0,
-			Speed:     8.5,
+			Bearing:   float64ptr(180.0),
+			Speed:     float64ptr(8.5),
 			Timestamp: now,
 		},
 		{
 			VehicleID: "vehicle-100",
 			Latitude:  -1.3000,
 			Longitude: 36.8300,
-			Bearing:   0.0, // heading north — valid
-			Speed:     0.0, // stationary — valid
+			Bearing:   float64ptr(0.0), // heading north — valid
+			Speed:     float64ptr(0.0), // stationary — valid
 			Timestamp: now - 30,
 		},
 		{
@@ -372,8 +372,8 @@ func TestFeedValidation_FullFeedCompliance(t *testing.T) {
 			TripID:    "route_10_0900",
 			Latitude:  40.7128,
 			Longitude: -74.0060,
-			Bearing:   270.0,
-			Speed:     12.5,
+			Bearing:   float64ptr(270.0),
+			Speed:     float64ptr(12.5),
 			Timestamp: now - 5,
 		},
 	}
@@ -423,7 +423,7 @@ func TestFeedValidation_FeedSerializesCleanly(t *testing.T) {
 	now := time.Now().Unix()
 	vehicles := []*VehicleState{
 		{VehicleID: "bus-1", TripID: "trip-1", Latitude: -1.29, Longitude: 36.82,
-			Bearing: 180, Speed: 8.5, Timestamp: now},
+			Bearing: float64ptr(180), Speed: float64ptr(8.5), Timestamp: now},
 	}
 	feed := buildFeed(vehicles)
 

--- a/feed_validation_test.go
+++ b/feed_validation_test.go
@@ -1,0 +1,446 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/MobilityData/gtfs-realtime-bindings/golang/gtfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// validateFeedCompliance checks a FeedMessage against applicable
+// MobilityData GTFS-RT validator rules for VehiclePosition feeds.
+// Returns a slice of rule violation strings. Empty = compliant.
+//
+// This helper exercises buildFeed() — the real production function —
+// through the lens of every applicable validator rule.
+func validateFeedCompliance(t *testing.T, feed *gtfs.FeedMessage) []string {
+	t.Helper()
+	var violations []string
+
+	// E038: valid GTFS-RT version
+	if v := feed.Header.GetGtfsRealtimeVersion(); v != "1.0" && v != "2.0" {
+		violations = append(violations, "E038: invalid gtfs_realtime_version: "+v)
+	}
+
+	// E048: header timestamp required for v2.0
+	if feed.Header.Timestamp == nil || *feed.Header.Timestamp == 0 {
+		violations = append(violations, "E048: header timestamp missing or zero")
+	}
+
+	// E049: incrementality required for v2.0
+	if feed.Header.Incrementality == nil {
+		violations = append(violations, "E049: incrementality missing")
+	}
+
+	headerTs := feed.Header.GetTimestamp()
+	now := uint64(time.Now().Unix())
+	seenIDs := make(map[string]struct{})
+
+	for _, entity := range feed.Entity {
+		id := entity.GetId()
+
+		// E052: unique entity IDs
+		if _, exists := seenIDs[id]; exists {
+			violations = append(violations, fmt.Sprintf("E052: duplicate entity id %q", id))
+		}
+		seenIDs[id] = struct{}{}
+
+		vp := entity.GetVehicle()
+		if vp == nil {
+			continue
+		}
+
+		// W002: vehicle.id populated
+		if vp.GetVehicle().GetId() == "" {
+			violations = append(violations, fmt.Sprintf("W002: vehicle.id empty for entity %q", id))
+		}
+
+		// W001: timestamp populated
+		entityTs := vp.GetTimestamp()
+		if entityTs == 0 {
+			violations = append(violations, fmt.Sprintf("W001: timestamp zero for entity %q", id))
+		}
+
+		// E001: POSIX seconds (not milliseconds)
+		if entityTs > 10_000_000_000 {
+			violations = append(violations, fmt.Sprintf("E001: timestamp looks like ms for entity %q", id))
+		}
+
+		// E012: header timestamp >= entity timestamp
+		if entityTs > headerTs {
+			violations = append(violations, fmt.Sprintf("E012: entity %q ts %d > header ts %d", id, entityTs, headerTs))
+		}
+
+		// E050: not >60s in future
+		if entityTs > now+60 {
+			violations = append(violations, fmt.Sprintf("E050: entity %q timestamp >60s in future", id))
+		}
+
+		pos := vp.GetPosition()
+		if pos != nil {
+			// E026: valid WGS84 coordinates
+			if lat := pos.GetLatitude(); lat < -90 || lat > 90 {
+				violations = append(violations, fmt.Sprintf("E026: latitude %f out of range for %q", lat, id))
+			}
+			if lon := pos.GetLongitude(); lon < -180 || lon > 180 {
+				violations = append(violations, fmt.Sprintf("E026: longitude %f out of range for %q", lon, id))
+			}
+
+			// E027: bearing 0..360 (inclusive per MobilityData E027 rule).
+			// buildFeed() always sets Bearing via proto.Float32(), so pos.Bearing
+			// is never nil in current production output. The nil guard is retained
+			// for forward-compatibility if Bearing becomes a pointer type.
+			if pos.Bearing != nil {
+				if b := pos.GetBearing(); b < 0 || b > 360 {
+					violations = append(violations, fmt.Sprintf("E027: bearing %f out of range for %q", b, id))
+				}
+			}
+
+			// Speed non-negative (no formal validator rule number).
+			if pos.Speed != nil && pos.GetSpeed() < 0 {
+				violations = append(violations, fmt.Sprintf("speed: must be non-negative for entity %q", id))
+			}
+		}
+
+		// E039: no is_deleted in FULL_DATASET
+		if entity.IsDeleted != nil && *entity.IsDeleted {
+			violations = append(violations, fmt.Sprintf("E039: is_deleted set for %q", id))
+		}
+	}
+
+	// E050: header timestamp not >60s in future
+	if headerTs > now+60 {
+		violations = append(violations, "E050: header timestamp >60s in future")
+	}
+
+	return violations
+}
+
+// --- Individual rule tests ---
+
+func TestFeedValidation_E001_TimestampsInPOSIXSeconds(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+
+	entityTs := feed.Entity[0].Vehicle.GetTimestamp()
+	assert.Less(t, entityTs, uint64(10_000_000_000), "E001: timestamp should be in seconds, not ms")
+
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations)
+}
+
+func TestFeedValidation_E012_HeaderTimestampGEEntityTimestamps(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now - 30},
+		{VehicleID: "bus-2", Latitude: 3, Longitude: 4, Timestamp: now - 10},
+	}
+	feed := buildFeed(vehicles)
+
+	headerTs := feed.Header.GetTimestamp()
+	for _, e := range feed.Entity {
+		assert.GreaterOrEqual(t, headerTs, e.Vehicle.GetTimestamp(),
+			"E012: header must be >= entity %s", e.GetId())
+	}
+}
+
+func TestFeedValidation_E012_FutureEntityTimestamp(t *testing.T) {
+	// Vehicle with timestamp 2 minutes in the future (within 5min ingest window).
+	// Header must be >= this timestamp.
+	futureTs := time.Now().Unix() + 120
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: futureTs},
+	}
+	feed := buildFeed(vehicles)
+
+	headerTs := feed.Header.GetTimestamp()
+	entityTs := feed.Entity[0].Vehicle.GetTimestamp()
+
+	assert.GreaterOrEqual(t, headerTs, entityTs,
+		"E012: header timestamp must be >= entity timestamp")
+}
+
+func TestFeedValidation_E012_AllPastEntities(t *testing.T) {
+	// All vehicles have past timestamps.
+	// Header should be approximately time.Now(), not dragged down.
+	pastTs := time.Now().Unix() - 60
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: pastTs},
+	}
+	feed := buildFeed(vehicles)
+
+	headerTs := feed.Header.GetTimestamp()
+	now := uint64(time.Now().Unix())
+
+	// Header should be close to now, not the past entity timestamp.
+	// Delta of 5 seconds accounts for CI environments under load.
+	assert.InDelta(t, float64(now), float64(headerTs), 5, "header should be close to now for past entities")
+	assert.GreaterOrEqual(t, headerTs, uint64(pastTs), "E012: header >= entity")
+}
+
+func TestFeedValidation_E026_ValidCoordinates(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "nairobi", Latitude: -1.2921, Longitude: 36.8219, Timestamp: now},
+		{VehicleID: "nyc", Latitude: 40.7128, Longitude: -74.0060, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations)
+}
+
+func TestFeedValidation_E026_BoundaryCoordinates(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "north-pole", Latitude: 90, Longitude: 0.001, Timestamp: now},
+		{VehicleID: "south-pole", Latitude: -90, Longitude: 0.001, Timestamp: now},
+		{VehicleID: "dateline-east", Latitude: 0.001, Longitude: 180, Timestamp: now},
+		{VehicleID: "dateline-west", Latitude: 0.001, Longitude: -180, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations, "boundary coordinates should be valid")
+}
+
+func TestFeedValidation_E027_ValidBearing(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Bearing: 180, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations)
+}
+
+func TestFeedValidation_E027_BearingBoundaries(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "north", Latitude: 1, Longitude: 2, Bearing: 0, Timestamp: now},
+		{VehicleID: "east", Latitude: 3, Longitude: 4, Bearing: 90, Timestamp: now},
+		{VehicleID: "south", Latitude: 5, Longitude: 6, Bearing: 180, Timestamp: now},
+		{VehicleID: "wrap", Latitude: 7, Longitude: 8, Bearing: 360, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations, "all bearings 0-360 should be valid")
+}
+
+func TestFeedValidation_E038_ValidVersion(t *testing.T) {
+	feed := buildFeed(nil)
+	assert.Equal(t, "2.0", feed.Header.GetGtfsRealtimeVersion())
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations)
+}
+
+func TestFeedValidation_E039_NoIsDeletedInFullDataset(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+
+	for _, e := range feed.Entity {
+		assert.Nil(t, e.IsDeleted, "E039: is_deleted must not be set in FULL_DATASET")
+	}
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations)
+}
+
+func TestFeedValidation_E048_HeaderTimestampPopulated(t *testing.T) {
+	feed := buildFeed(nil)
+	assert.NotNil(t, feed.Header.Timestamp, "E048: header timestamp required for v2.0")
+	assert.NotZero(t, feed.Header.GetTimestamp())
+}
+
+func TestFeedValidation_E049_IncrementalityPopulated(t *testing.T) {
+	feed := buildFeed(nil)
+	assert.NotNil(t, feed.Header.Incrementality, "E049: incrementality required for v2.0")
+	assert.Equal(t, gtfs.FeedHeader_FULL_DATASET, feed.Header.GetIncrementality())
+}
+
+func TestFeedValidation_E050_TimestampsNotFarFuture(t *testing.T) {
+	// Use current timestamps — these should never trigger E050.
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now},
+		{VehicleID: "bus-2", Latitude: 3, Longitude: 4, Timestamp: now - 30},
+	}
+	feed := buildFeed(vehicles)
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations, "current/past timestamps should not trigger E050")
+
+	// Note: The ingest window allows timestamps up to now+300s, but E050
+	// rejects >now+60s. This is a known limitation documented in the plan.
+	// We do NOT test with now+120 here because it would legitimately fail E050.
+}
+
+func TestFeedValidation_E052_UniqueVehicleIDs(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now},
+		{VehicleID: "bus-2", Latitude: 3, Longitude: 4, Timestamp: now},
+		{VehicleID: "bus-3", Latitude: 5, Longitude: 6, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations, "unique IDs should not trigger E052")
+}
+
+func TestFeedValidation_W001_TimestampsPopulated(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+
+	for _, e := range feed.Entity {
+		assert.NotZero(t, e.Vehicle.GetTimestamp(), "W001: entity timestamp must be populated")
+	}
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations)
+}
+
+func TestFeedValidation_W002_VehicleIDPopulated(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+
+	for _, e := range feed.Entity {
+		assert.NotEmpty(t, e.Vehicle.GetVehicle().GetId(), "W002: vehicle.id must be populated")
+	}
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations)
+}
+
+func TestFeedValidation_SpeedNonNegative(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "stationary", Latitude: 1, Longitude: 2, Speed: 0, Timestamp: now},
+		{VehicleID: "moving", Latitude: 3, Longitude: 4, Speed: 15.5, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations, "zero and positive speeds should be valid")
+}
+
+// --- Composite tests ---
+
+func TestFeedValidation_EmptyFeedValid(t *testing.T) {
+	feed := buildFeed(nil)
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations, "empty feed should be valid: %v", violations)
+
+	assert.Equal(t, "2.0", feed.Header.GetGtfsRealtimeVersion())
+	assert.NotNil(t, feed.Header.Timestamp)
+	assert.NotZero(t, feed.Header.GetTimestamp())
+	assert.Empty(t, feed.Entity)
+}
+
+func TestFeedValidation_FullFeedCompliance(t *testing.T) {
+	// 3 realistic vehicles — mix of with/without trips, varying fields.
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{
+			VehicleID: "vehicle-042",
+			TripID:    "route_5_0830",
+			Latitude:  -1.2921,
+			Longitude: 36.8219,
+			Bearing:   180.0,
+			Speed:     8.5,
+			Timestamp: now,
+		},
+		{
+			VehicleID: "vehicle-100",
+			Latitude:  -1.3000,
+			Longitude: 36.8300,
+			Bearing:   0.0, // heading north — valid
+			Speed:     0.0, // stationary — valid
+			Timestamp: now - 30,
+		},
+		{
+			VehicleID: "vehicle-200",
+			TripID:    "route_10_0900",
+			Latitude:  40.7128,
+			Longitude: -74.0060,
+			Bearing:   270.0,
+			Speed:     12.5,
+			Timestamp: now - 5,
+		},
+	}
+
+	feed := buildFeed(vehicles)
+
+	// Run full compliance check
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations, "feed should pass all validator rules: %v", violations)
+
+	// Verify structure
+	require.Len(t, feed.Entity, 3)
+	assert.Equal(t, "2.0", feed.Header.GetGtfsRealtimeVersion())
+	assert.Equal(t, gtfs.FeedHeader_FULL_DATASET, feed.Header.GetIncrementality())
+
+	// Verify trip assignment
+	var withTrip, withoutTrip int
+	for _, e := range feed.Entity {
+		if e.Vehicle.Trip != nil {
+			withTrip++
+		} else {
+			withoutTrip++
+		}
+	}
+	assert.Equal(t, 2, withTrip, "two vehicles should have trips")
+	assert.Equal(t, 1, withoutTrip, "one vehicle should have no trip")
+}
+
+func TestFeedValidation_ZeroTimestampVehicleSkipped(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "valid", Latitude: 1, Longitude: 2, Timestamp: now},
+		{VehicleID: "zero-ts", Latitude: 3, Longitude: 4, Timestamp: 0},
+		{VehicleID: "negative-ts", Latitude: 5, Longitude: 6, Timestamp: -100},
+	}
+	feed := buildFeed(vehicles)
+
+	// Only the valid vehicle should appear in the feed
+	require.Len(t, feed.Entity, 1)
+	assert.Equal(t, "valid", feed.Entity[0].GetId())
+
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations)
+}
+
+func TestFeedValidation_FeedSerializesCleanly(t *testing.T) {
+	now := time.Now().Unix()
+	vehicles := []*VehicleState{
+		{VehicleID: "bus-1", TripID: "trip-1", Latitude: -1.29, Longitude: 36.82,
+			Bearing: 180, Speed: 8.5, Timestamp: now},
+	}
+	feed := buildFeed(vehicles)
+
+	// Verify protobuf round-trip: marshal then unmarshal
+	data, err := proto.Marshal(feed)
+	require.NoError(t, err, "feed must serialize to protobuf")
+
+	var decoded gtfs.FeedMessage
+	err = proto.Unmarshal(data, &decoded)
+	require.NoError(t, err, "feed must deserialize from protobuf")
+
+	require.Len(t, decoded.Entity, 1)
+	assert.Equal(t, "bus-1", decoded.Entity[0].GetId())
+	assert.Equal(t, float32(-1.29), decoded.Entity[0].Vehicle.Position.GetLatitude())
+	assert.Equal(t, "trip-1", decoded.Entity[0].Vehicle.Trip.GetTripId())
+
+	// Verify the deserialized feed also passes compliance
+	violations := validateFeedCompliance(t, &decoded)
+	assert.Empty(t, violations, "round-tripped feed should be compliant: %v", violations)
+}

--- a/feed_validation_test.go
+++ b/feed_validation_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,9 +92,8 @@ func validateFeedCompliance(t *testing.T, feed *gtfs.FeedMessage) []string {
 			}
 
 			// E027: bearing 0..360 (inclusive per MobilityData E027 rule).
-			// buildFeed() always sets Bearing via proto.Float32(), so pos.Bearing
-			// is never nil in current production output. The nil guard is retained
-			// for forward-compatibility if Bearing becomes a pointer type.
+			// Bearing is optional; buildFeed() leaves pos.Bearing nil when the
+			// source vehicle has no bearing, so the nil guard is required.
 			if pos.Bearing != nil {
 				if b := pos.GetBearing(); b < 0 || b > 360 {
 					violations = append(violations, fmt.Sprintf("E027: bearing %f out of range for %q", b, id))
@@ -152,9 +152,9 @@ func TestFeedValidation_E012_HeaderTimestampGEEntityTimestamps(t *testing.T) {
 }
 
 func TestFeedValidation_E012_FutureEntityTimestamp(t *testing.T) {
-	// Vehicle with timestamp 2 minutes in the future (within 5min ingest window).
-	// Header must be >= this timestamp.
-	futureTs := time.Now().Unix() + 120
+	// Use now+30 — within E050's 60s window — so the full compliance
+	// checker can run without triggering E050 on the header.
+	futureTs := time.Now().Unix() + 30
 	vehicles := []*VehicleState{
 		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: futureTs},
 	}
@@ -165,6 +165,9 @@ func TestFeedValidation_E012_FutureEntityTimestamp(t *testing.T) {
 
 	assert.GreaterOrEqual(t, headerTs, entityTs,
 		"E012: header timestamp must be >= entity timestamp")
+
+	violations := validateFeedCompliance(t, feed)
+	assert.Empty(t, violations)
 }
 
 func TestFeedValidation_E012_AllPastEntities(t *testing.T) {
@@ -276,10 +279,24 @@ func TestFeedValidation_E050_TimestampsNotFarFuture(t *testing.T) {
 	feed := buildFeed(vehicles)
 	violations := validateFeedCompliance(t, feed)
 	assert.Empty(t, violations, "current/past timestamps should not trigger E050")
+}
 
-	// Note: The ingest window allows timestamps up to now+300s, but E050
-	// rejects >now+60s. This is a known limitation documented in the plan.
-	// We do NOT test with now+120 here because it would legitimately fail E050.
+func TestFeedValidation_E050_RejectsEntityFarInFuture(t *testing.T) {
+	now := time.Now().Unix()
+	feed := buildFeed([]*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now + 120},
+	})
+	violations := validateFeedCompliance(t, feed)
+	require.NotEmpty(t, violations)
+	joined := strings.Join(violations, "|")
+	assert.Contains(t, joined, "E050:")
+}
+
+func TestFeedValidation_E050_IngestWindowGap(t *testing.T) {
+	// Ingest allows now+300s but E050 rejects >now+60s.
+	// A vehicle at now+120 passes ingest but fails E050.
+	// This test pins the known gap so it stays visible in CI.
+	t.Skip("known limitation: ingest accepts now+300s but E050 rejects >now+60s — tracked for follow-up")
 }
 
 func TestFeedValidation_E052_UniqueVehicleIDs(t *testing.T) {
@@ -292,6 +309,30 @@ func TestFeedValidation_E052_UniqueVehicleIDs(t *testing.T) {
 	feed := buildFeed(vehicles)
 	violations := validateFeedCompliance(t, feed)
 	assert.Empty(t, violations, "unique IDs should not trigger E052")
+}
+
+func TestFeedValidation_E052_RejectsDuplicateIDs(t *testing.T) {
+	now := time.Now().Unix()
+	feed := buildFeed([]*VehicleState{
+		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now},
+	})
+	// Inject a separate duplicate entity to exercise the E052 branch.
+	// buildFeed() deduplicates by design (one VehicleState per VehicleID).
+	dup := &gtfs.FeedEntity{
+		Id: proto.String("bus-1"),
+		Vehicle: &gtfs.VehiclePosition{
+			Vehicle:   &gtfs.VehicleDescriptor{Id: proto.String("bus-1")},
+			Position:  &gtfs.Position{Latitude: proto.Float32(1), Longitude: proto.Float32(2)},
+			Timestamp: proto.Uint64(uint64(now)),
+		},
+	}
+	feed.Entity = append(feed.Entity, dup)
+
+	violations := validateFeedCompliance(t, feed)
+	require.NotEmpty(t, violations)
+	joined := strings.Join(violations, "|")
+	assert.Contains(t, joined, "E052:")
+	assert.Contains(t, joined, "bus-1")
 }
 
 func TestFeedValidation_W001_TimestampsPopulated(t *testing.T) {

--- a/feed_validation_test.go
+++ b/feed_validation_test.go
@@ -16,8 +16,7 @@ import (
 // MobilityData GTFS-RT validator rules for VehiclePosition feeds.
 // Returns a slice of rule violation strings. Empty = compliant.
 //
-// This helper exercises buildFeed() — the real production function —
-// through the lens of every applicable validator rule.
+// Callers typically build a feed via buildFeed() and pass the result here.
 func validateFeedCompliance(t *testing.T, feed *gtfs.FeedMessage) []string {
 	t.Helper()
 	var violations []string
@@ -295,7 +294,7 @@ func TestFeedValidation_E050_RejectsEntityFarInFuture(t *testing.T) {
 func TestFeedValidation_E050_IngestWindowGap(t *testing.T) {
 	// Ingest allows now+300s but E050 rejects >now+60s.
 	// A vehicle at now+120 passes ingest but fails E050.
-	// This test pins the known gap so it stays visible in CI.
+	// Placeholder documenting the gap; skipped pending follow-up — no assertion is made.
 	t.Skip("known limitation: ingest accepts now+300s but E050 rejects >now+60s — tracked for follow-up")
 }
 
@@ -316,8 +315,8 @@ func TestFeedValidation_E052_RejectsDuplicateIDs(t *testing.T) {
 	feed := buildFeed([]*VehicleState{
 		{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: now},
 	})
-	// Inject a separate duplicate entity to exercise the E052 branch.
-	// buildFeed() deduplicates by design (one VehicleState per VehicleID).
+	// The Tracker dedups by VehicleID upstream (tracker.go), so buildFeed
+	// never emits duplicate IDs in practice — inject a raw entity to exercise E052.
 	dup := &gtfs.FeedEntity{
 		Id: proto.String("bus-1"),
 		Vehicle: &gtfs.VehiclePosition{

--- a/handlers.go
+++ b/handlers.go
@@ -64,6 +64,12 @@ func (r *LocationReport) validate() error {
 	if r.Timestamp < now-int64(maxTimestampSkew.Seconds()) || r.Timestamp > now+int64(maxTimestampSkew.Seconds()) {
 		return fmt.Errorf("timestamp must be within %d minutes of server time", int(maxTimestampSkew.Minutes()))
 	}
+	if r.Bearing != nil && (*r.Bearing < 0 || *r.Bearing > 360) {
+		return fmt.Errorf("bearing must be between 0 and 360 (inclusive)")
+	}
+	if r.Speed != nil && *r.Speed < 0 {
+		return fmt.Errorf("speed must be non-negative")
+	}
 	return nil
 }
 
@@ -169,15 +175,20 @@ func buildFeed(vehicles []*VehicleState) *gtfs.FeedMessage {
 	version := "2.0"
 	inc := gtfs.FeedHeader_FULL_DATASET
 
-	feed := &gtfs.FeedMessage{
-		Header: &gtfs.FeedHeader{
-			GtfsRealtimeVersion: &version,
-			Incrementality:      &inc,
-			Timestamp:           &now,
-		},
-	}
+	// E012 (gtfs-realtime-validator): header.timestamp must be >= all entity timestamps.
+	headerTimestamp := now
 
+	var entities []*gtfs.FeedEntity
 	for _, v := range vehicles {
+		if v.Timestamp <= 0 {
+			slog.Warn("buildFeed: skipping vehicle with non-positive timestamp", "vehicle_id", v.VehicleID, "timestamp", v.Timestamp)
+			continue
+		}
+		ts := uint64(v.Timestamp)
+		if ts > headerTimestamp {
+			headerTimestamp = ts
+		}
+
 		position := &gtfs.Position{
 			Latitude:  proto.Float32(float32(v.Latitude)),
 			Longitude: proto.Float32(float32(v.Longitude)),
@@ -196,7 +207,7 @@ func buildFeed(vehicles []*VehicleState) *gtfs.FeedMessage {
 					Id: proto.String(v.VehicleID),
 				},
 				Position:  position,
-				Timestamp: proto.Uint64(uint64(v.Timestamp)),
+				Timestamp: proto.Uint64(ts),
 			},
 		}
 
@@ -205,10 +216,17 @@ func buildFeed(vehicles []*VehicleState) *gtfs.FeedMessage {
 				TripId: proto.String(v.TripID),
 			}
 		}
-		feed.Entity = append(feed.Entity, entity)
+		entities = append(entities, entity)
 	}
 
-	return feed
+	return &gtfs.FeedMessage{
+		Header: &gtfs.FeedHeader{
+			GtfsRealtimeVersion: &version,
+			Incrementality:      &inc,
+			Timestamp:           &headerTimestamp,
+		},
+		Entity: entities,
+	}
 }
 
 type adminStatusResponse struct {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -106,6 +106,11 @@ func TestBuildFeed_WithVehicles(t *testing.T) {
 
 	require.NotNil(t, bus2)
 	assert.Nil(t, bus2.Vehicle.Trip, "bus-2 has no trip, Trip should be nil")
+
+	// E012: header timestamp must be >= max entity timestamp.
+	// 1752566500 is the larger of the two vehicle timestamps above (bus-2).
+	assert.GreaterOrEqual(t, feed.Header.GetTimestamp(), uint64(1752566500),
+		"header timestamp must be >= max entity timestamp (E012)")
 }
 
 func TestGetFeed_Protobuf(t *testing.T) {
@@ -234,6 +239,36 @@ func TestHandlePostLocation_Validation(t *testing.T) {
 			name: "timestamp too far in future",
 			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: time.Now().Unix() + 600},
 			want: "timestamp must be within 5 minutes of server time",
+		},
+		{
+			name: "bearing negative",
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Bearing: float64ptr(-1), Timestamp: time.Now().Unix()},
+			want: "bearing must be between 0 and 360 (inclusive)",
+		},
+		{
+			name: "bearing too high",
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Bearing: float64ptr(361), Timestamp: time.Now().Unix()},
+			want: "bearing must be between 0 and 360 (inclusive)",
+		},
+		{
+			name: "speed negative",
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Speed: float64ptr(-5), Timestamp: time.Now().Unix()},
+			want: "speed must be non-negative",
+		},
+		{
+			name: "bearing just below zero",
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Bearing: float64ptr(-0.001), Timestamp: time.Now().Unix()},
+			want: "bearing must be between 0 and 360 (inclusive)",
+		},
+		{
+			name: "bearing just above 360",
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Bearing: float64ptr(360.001), Timestamp: time.Now().Unix()},
+			want: "bearing must be between 0 and 360 (inclusive)",
+		},
+		{
+			name: "speed just below zero",
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Speed: float64ptr(-0.001), Timestamp: time.Now().Unix()},
+			want: "speed must be non-negative",
 		},
 	}
 
@@ -792,7 +827,7 @@ func TestBuildFeed_PreservesExplicitZeroBearingAndSpeed(t *testing.T) {
 			Longitude: 2,
 			Bearing:   &zero,
 			Speed:     &zero,
-			Timestamp: 100,
+			Timestamp: time.Now().Unix(),
 		},
 	}
 
@@ -813,7 +848,7 @@ func TestBuildFeed_OmitsUnsetBearingAndSpeed(t *testing.T) {
 			VehicleID: "bus-1",
 			Latitude:  1,
 			Longitude: 2,
-			Timestamp: 100,
+			Timestamp: time.Now().Unix(),
 		},
 	}
 
@@ -825,4 +860,44 @@ func TestBuildFeed_OmitsUnsetBearingAndSpeed(t *testing.T) {
 	assert.Equal(t, float32(2), pos.GetLongitude())
 	assert.Nil(t, pos.Bearing)
 	assert.Nil(t, pos.Speed)
+}
+
+func TestHandlePostLocation_BearingSpeedBoundaries(t *testing.T) {
+	tracker := NewTracker(5 * time.Minute)
+	defer tracker.Stop()
+
+	tests := []struct {
+		name string
+		sub  string
+		loc  LocationReport
+	}{
+		{"bearing exactly 0 (north)", "driver-bearing-0", LocationReport{
+			VehicleID: "bus-1", Latitude: 1, Longitude: 2,
+			Bearing: float64ptr(0), Timestamp: time.Now().Unix()}},
+		{"bearing exactly 360", "driver-bearing-360", LocationReport{
+			VehicleID: "bus-2", Latitude: 1, Longitude: 2,
+			Bearing: float64ptr(360), Timestamp: time.Now().Unix()}},
+		{"bearing 359.99", "driver-bearing-359", LocationReport{
+			VehicleID: "bus-3", Latitude: 1, Longitude: 2,
+			Bearing: float64ptr(359.99), Timestamp: time.Now().Unix()}},
+		{"speed exactly 0 (stationary)", "driver-speed-0", LocationReport{
+			VehicleID: "bus-4", Latitude: 1, Longitude: 2,
+			Speed: float64ptr(0), Timestamp: time.Now().Unix()}},
+		{"nil bearing (not provided)", "driver-bearing-nil", LocationReport{
+			VehicleID: "bus-5", Latitude: 1, Longitude: 2,
+			Timestamp: time.Now().Unix()}},
+		{"nil speed (not provided)", "driver-speed-nil", LocationReport{
+			VehicleID: "bus-6", Latitude: 1, Longitude: 2,
+			Timestamp: time.Now().Unix()}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mStore := &mockStore{}
+			handler := handlePostLocation(mStore, tracker, NewVehicleRateLimiter())
+			w := postLocationWithClaims(handler, tc.loc, jwt.MapClaims{"sub": tc.sub})
+			assert.Equal(t, http.StatusCreated, w.Code, "boundary value should be accepted")
+			assert.True(t, mStore.saved, "boundary value should have been saved")
+		})
+	}
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -115,7 +115,7 @@ func TestBuildFeed_WithVehicles(t *testing.T) {
 
 func TestGetFeed_Protobuf(t *testing.T) {
 	tracker := NewTracker(5 * time.Minute)
-	tracker.Update(&LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: 100})
+	tracker.Update(&LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: time.Now().Unix()})
 
 	handler := handleGetFeed(tracker)
 	w := getFeed(handler, "")
@@ -132,7 +132,7 @@ func TestGetFeed_Protobuf(t *testing.T) {
 
 func TestGetFeed_JSON(t *testing.T) {
 	tracker := NewTracker(5 * time.Minute)
-	tracker.Update(&LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: 100})
+	tracker.Update(&LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: time.Now().Unix()})
 
 	handler := handleGetFeed(tracker)
 	w := getFeed(handler, "format=json")
@@ -162,16 +162,17 @@ func TestGetFeed_Empty(t *testing.T) {
 
 func TestGetFeed_StaleExcluded(t *testing.T) {
 	tracker := NewTracker(1 * time.Millisecond)
-	tracker.Update(&LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: 100})
-	time.Sleep(5 * time.Millisecond)
+	tracker.Update(&LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: time.Now().Unix()})
 
 	handler := handleGetFeed(tracker)
-	w := getFeed(handler, "")
-
-	var feed gtfs.FeedMessage
-	err := proto.Unmarshal(w.Body.Bytes(), &feed)
-	require.NoError(t, err)
-	assert.Empty(t, feed.Entity, "stale vehicle should be excluded from feed")
+	assert.Eventually(t, func() bool {
+		w := getFeed(handler, "")
+		var feed gtfs.FeedMessage
+		if err := proto.Unmarshal(w.Body.Bytes(), &feed); err != nil {
+			return false
+		}
+		return len(feed.Entity) == 0
+	}, 100*time.Millisecond, 2*time.Millisecond, "stale vehicle should be excluded from feed")
 }
 
 func TestHandlePostLocation_Validation(t *testing.T) {
@@ -187,27 +188,27 @@ func TestHandlePostLocation_Validation(t *testing.T) {
 	}{
 		{
 			name: "missing vehicle_id",
-			loc:  LocationReport{Latitude: 1, Longitude: 2, Timestamp: 100},
+			loc:  LocationReport{Latitude: 1, Longitude: 2, Timestamp: time.Now().Unix()},
 			want: "vehicle_id is required",
 		},
 		{
 			name: "latitude too high",
-			loc:  LocationReport{VehicleID: "bus-1", Latitude: 91, Longitude: 2, Timestamp: 100},
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: 91, Longitude: 2, Timestamp: time.Now().Unix()},
 			want: "latitude must be between -90 and 90",
 		},
 		{
 			name: "latitude too low",
-			loc:  LocationReport{VehicleID: "bus-1", Latitude: -91, Longitude: 2, Timestamp: 100},
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: -91, Longitude: 2, Timestamp: time.Now().Unix()},
 			want: "latitude must be between -90 and 90",
 		},
 		{
 			name: "longitude too high",
-			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 181, Timestamp: 100},
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 181, Timestamp: time.Now().Unix()},
 			want: "longitude must be between -180 and 180",
 		},
 		{
 			name: "reject null coordinates (0,0)",
-			loc:  LocationReport{VehicleID: "bus-1", Latitude: 0, Longitude: 0, Timestamp: 100},
+			loc:  LocationReport{VehicleID: "bus-1", Latitude: 0, Longitude: 0, Timestamp: time.Now().Unix()},
 			want: "latitude and longitude cannot both be zero (likely GPS error)",
 		},
 		{
@@ -314,8 +315,8 @@ func TestHandleAdminStatus_WithVehicles(t *testing.T) {
 	tracker := NewTracker(5 * time.Minute)
 	defer tracker.Stop()
 
-	tracker.Update(&LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: 100})
-	tracker.Update(&LocationReport{VehicleID: "bus-2", Latitude: 3, Longitude: 4, Timestamp: 200})
+	tracker.Update(&LocationReport{VehicleID: "bus-1", Latitude: 1, Longitude: 2, Timestamp: time.Now().Unix()})
+	tracker.Update(&LocationReport{VehicleID: "bus-2", Latitude: 3, Longitude: 4, Timestamp: time.Now().Unix()})
 
 	handler := handleAdminStatus(tracker, time.Now())
 	req := httptest.NewRequest("GET", "/api/v1/admin/status", nil)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -63,6 +63,10 @@ func TestBuildFeed_Empty(t *testing.T) {
 }
 
 func TestBuildFeed_WithVehicles(t *testing.T) {
+	now := time.Now().Unix()
+	bus1Ts := now - 100
+	bus2Ts := now
+
 	vehicles := []*VehicleState{
 		{
 			VehicleID: "bus-1",
@@ -71,13 +75,13 @@ func TestBuildFeed_WithVehicles(t *testing.T) {
 			Longitude: 36.82,
 			Bearing:   float64ptr(180),
 			Speed:     float64ptr(8.5),
-			Timestamp: 1752566400,
+			Timestamp: bus1Ts,
 		},
 		{
 			VehicleID: "bus-2",
 			Latitude:  -1.30,
 			Longitude: 36.83,
-			Timestamp: 1752566500,
+			Timestamp: bus2Ts,
 		},
 	}
 
@@ -85,7 +89,6 @@ func TestBuildFeed_WithVehicles(t *testing.T) {
 
 	require.Len(t, feed.Entity, 2)
 
-	// Find bus-1
 	var bus1, bus2 *gtfs.FeedEntity
 	for _, e := range feed.Entity {
 		switch e.GetId() {
@@ -101,15 +104,14 @@ func TestBuildFeed_WithVehicles(t *testing.T) {
 	assert.Equal(t, float32(36.82), bus1.Vehicle.Position.GetLongitude())
 	assert.Equal(t, float32(180), bus1.Vehicle.Position.GetBearing())
 	assert.Equal(t, float32(8.5), bus1.Vehicle.Position.GetSpeed())
-	assert.Equal(t, uint64(1752566400), bus1.Vehicle.GetTimestamp())
+	assert.Equal(t, uint64(bus1Ts), bus1.Vehicle.GetTimestamp())
 	assert.Equal(t, "route-5", bus1.Vehicle.Trip.GetTripId())
 
 	require.NotNil(t, bus2)
 	assert.Nil(t, bus2.Vehicle.Trip, "bus-2 has no trip, Trip should be nil")
 
 	// E012: header timestamp must be >= max entity timestamp.
-	// 1752566500 is the larger of the two vehicle timestamps above (bus-2).
-	assert.GreaterOrEqual(t, feed.Header.GetTimestamp(), uint64(1752566500),
+	assert.GreaterOrEqual(t, feed.Header.GetTimestamp(), uint64(bus2Ts),
 		"header timestamp must be >= max entity timestamp (E012)")
 }
 


### PR DESCRIPTION
Summary

  - Fix E012: header timestamp now guaranteed >= all entity timestamps
  - Add bearing (0-360) and speed (>= 0) ingest validation per GTFS-RT spec
  - Add 21-test spec-validation suite covering all 12 MobilityData validator rules
  - Fix pre-existing test quality issues (realistic timestamps, assert.Eventually)

  Why

  Milestone 1 exit criteria requires the feed to pass the https://github.com/MobilityData/gtfs-realtime-validator without errors. An audit found two violations:

  1. E012 — Header timestamp could be less than entity timestamps when vehicles report future times (within 5-min ingest window). Fixed with max(now, maxEntityTimestamp).
  2. E027 — No bearing/speed validation, so invalid values could reach the feed. Fixed with ingest range checks.

  What Changed

  - handlers.go: E012 fix in buildFeed(), bearing/speed validation in validate(), skip zero-timestamp vehicles
  - feed_validation_test.go: New file — validateFeedCompliance helper + 21 tests for E001, E012, E026, E027, E038, E039, E048, E049, E050, E052, W001, W002
  - handlers_test.go: E012 assertion, 6 rejection cases, boundary acceptance test, fix Timestamp: 100 and time.Sleep

  Known Limitations

  - E027: Zero-value ambiguity (0.0 = North vs not-provided) pending PR #45
  - E050: Ingest allows ±5min but E050 threshold is 60s — documented, not changed here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced bearing (0–360°) and non-negative speed validation.
  * Feed header timestamp now computed from entity timestamps; feeds skip vehicles with non-positive timestamps.

* **Tests**
  * Added a comprehensive GTFS-RT feed validation suite covering many rules, boundary conditions, and edge cases.
  * New tests for bearing/speed boundary handling and improved feed-building and staleness behavior checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->