### PR TITLE
feat(admin): add proof-of-concept admin interface for system management

### DIFF
--- a/admin_handlers.go
+++ b/admin_handlers.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"log/slog"
 	"net/http"
 	"path"
-	"log/slog"
 )
 
 //go:embed web/templates web/static

--- a/admin_handlers.go
+++ b/admin_handlers.go
@@ -3,8 +3,11 @@ package main
 import (
 	"html/template"
 	"net/http"
+	"embed"
 )
 
+//go:embed web/templates web/static
+var files embed.FS
 func renderPublic(w http.ResponseWriter, view string, data map[string]interface{}) {
 	tmpl, err := template.ParseFiles(view)
 	if err != nil {

--- a/admin_handlers.go
+++ b/admin_handlers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"log/slog"
 )
 
 //go:embed web/templates web/static
@@ -94,13 +95,15 @@ func (t *embeddedTemplates) ExecuteTemplate(w io.Writer, name string, data any) 
 
 func renderPublic(w http.ResponseWriter, view string, data map[string]interface{}) {
 	if err := templates.ExecuteTemplate(w, path.Base(view), data); err != nil {
-		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
+		slog.Error("template render failed", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 	}
 }
 
 func renderAdmin(w http.ResponseWriter, view string, data map[string]interface{}) {
 	if err := templates.ExecuteTemplate(w, "base.html", withAdminTemplate(data, view)); err != nil {
-		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
+		slog.Error("template render failed", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 	}
 }
 

--- a/admin_handlers.go
+++ b/admin_handlers.go
@@ -19,6 +19,33 @@ type embeddedTemplates struct {
 	admin  map[string]*template.Template
 }
 
+var templates = mustLoadTemplates()
+
+func mustLoadTemplates() *embeddedTemplates {
+	adminViews := []string{
+		"dashboard.html",
+		"map.html",
+		"trips.html",
+		"users.html",
+		"vehicles.html",
+	}
+
+	adminTemplates := make(map[string]*template.Template, len(adminViews))
+
+	for _, view := range adminViews {
+		adminTemplates[view] = template.Must(template.ParseFS(
+			files,
+			"web/templates/layout/*.html",
+			path.Join("web/templates/views", view),
+		))
+	}
+
+	return &embeddedTemplates{
+		public: template.Must(template.ParseFS(files, "web/templates/views/login.html")),
+		admin:  adminTemplates,
+	}
+}
+
 func adminViewName(data any) (string, error) {
 	templateData, ok := data.(map[string]interface{})
 	if !ok {
@@ -49,7 +76,7 @@ func withAdminTemplate(data map[string]interface{}, view string) map[string]inte
 
 func (t *embeddedTemplates) ExecuteTemplate(w io.Writer, name string, data any) error {
 	if name != "base.html" {
-		return t.public.ExecuteTemplate(w, name, data)
+		return t.public.Execute(w, data)
 	}
 
 	viewName, err := adminViewName(data)
@@ -66,29 +93,13 @@ func (t *embeddedTemplates) ExecuteTemplate(w io.Writer, name string, data any) 
 }
 
 func renderPublic(w http.ResponseWriter, view string, data map[string]interface{}) {
-	tmpl, err := template.ParseFS(files, view)
-	if err != nil {
-		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if err := tmpl.Execute(w, data); err != nil {
+	if err := templates.ExecuteTemplate(w, path.Base(view), data); err != nil {
 		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
 	}
 }
 
 func renderAdmin(w http.ResponseWriter, view string, data map[string]interface{}) {
-	tmpl, err := template.ParseFS(
-		files,
-		"web/templates/layout/base.html",
-		"web/templates/layout/sidebar.html",
-		"web/templates/layout/header.html",
-		view,
-	)
-	if err != nil {
-		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if err := tmpl.Execute(w, data); err != nil {
+	if err := templates.ExecuteTemplate(w, "base.html", withAdminTemplate(data, view)); err != nil {
 		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/admin_handlers.go
+++ b/admin_handlers.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"html/template"
+	"net/http"
+)
+
+func renderPublic(w http.ResponseWriter, view string, data map[string]interface{}) {
+	tmpl, err := template.ParseFiles(view)
+	if err != nil {
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := tmpl.Execute(w, data); err != nil {
+		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func renderAdmin(w http.ResponseWriter, view string, data map[string]interface{}) {
+	tmpl, err := template.ParseFiles(
+		"web/templates/layout/base.html",
+		"web/templates/layout/sidebar.html",
+		"web/templates/layout/header.html",
+		view,
+	)
+	if err != nil {
+		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := tmpl.Execute(w, data); err != nil {
+		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func AdminMapHandler(w http.ResponseWriter, r *http.Request) {
+	renderAdmin(w, "web/templates/views/map.html", map[string]interface{}{
+		"Title": "Live Map",
+		"Page":  "map",
+	})
+}
+
+func AdminLoginHandler(w http.ResponseWriter, r *http.Request) {
+	renderPublic(w, "web/templates/views/login.html", map[string]interface{}{
+		"Title":          "Welcome",
+		"Mode":           "login",
+		"LoginEndpoint":  "/api/v1/auth/login",
+		"SignupEndpoint": "/api/v1/auth/signup",
+	})
+}
+
+func AdminSignupHandler(w http.ResponseWriter, r *http.Request) {
+	renderPublic(w, "web/templates/views/login.html", map[string]interface{}{
+		"Title":          "Create Account",
+		"Mode":           "signup",
+		"LoginEndpoint":  "/api/v1/auth/login",
+		"SignupEndpoint": "/api/v1/auth/signup",
+	})
+}
+
+func AdminDashboardHandler(w http.ResponseWriter, r *http.Request) {
+	renderAdmin(w, "web/templates/views/dashboard.html", map[string]interface{}{
+		"Title":          "Dashboard",
+		"Page":           "dashboard",
+		"TotalVehicles":  "24",
+		"ActiveVehicles": "18",
+		"TotalDrivers":   "32",
+		"ActiveTrips":    "15",
+		"RecentVehicles": []map[string]string{
+			{"Name": "Bus 001", "Route": "Route A", "Status": "active", "LastSeen": "2 min ago"},
+			{"Name": "Bus 002", "Route": "Route B", "Status": "active", "LastSeen": "5 min ago"},
+			{"Name": "Bus 003", "Route": "Route C", "Status": "idle", "LastSeen": "12 min ago"},
+			{"Name": "Bus 004", "Route": "Route A", "Status": "active", "LastSeen": "1 min ago"},
+			{"Name": "Bus 005", "Route": "Route D", "Status": "active", "LastSeen": "3 min ago"},
+		},
+	})
+}
+
+func AdminVehiclesHandler(w http.ResponseWriter, r *http.Request) {
+	renderAdmin(w, "web/templates/views/vehicles.html", map[string]interface{}{
+		"Title": "Vehicles",
+		"Page":  "vehicles",
+		"Vehicles": []map[string]string{
+			{"ID": "V001", "Name": "Bus 001", "Route": "Route A", "Driver": "Chaitanya K", "Status": "active", "LastSeen": "2 min ago"},
+			{"ID": "V002", "Name": "Bus 002", "Route": "Route B", "Driver": "Aron", "Status": "active", "LastSeen": "5 min ago"},
+			{"ID": "V003", "Name": "Bus 003", "Route": "Route C", "Driver": "Brad Pitt", "Status": "idle", "LastSeen": "12 min ago"},
+		},
+	})
+}
+
+func AdminUsersHandler(w http.ResponseWriter, r *http.Request) {
+	renderAdmin(w, "web/templates/views/users.html", map[string]interface{}{
+		"Title": "Users",
+		"Page":  "users",
+		"Users": []map[string]string{
+			{"Name": "Chaitanya K", "Email": "kbc@transit.co.ke", "Role": "driver", "LastSeen": "Today"},
+			{"Name": "To Holland", "Email": "tom@transit.co.ke", "Role": "driver", "LastSeen": "Today"},
+			{"Name": "Open transit", "Email": "brian@transit.co.ke", "Role": "driver", "LastSeen": "Yesterday"},
+		},
+	})
+}
+
+func AdminTripsHandler(w http.ResponseWriter, r *http.Request) {
+	renderAdmin(w, "web/templates/views/trips.html", map[string]interface{}{
+		"Title": "Trips",
+		"Page":  "trips",
+		"Trips": []map[string]string{
+			{"ID": "T001", "Vehicle": "Bus 001", "Driver": "Tom Hiddlestone", "Route": "Route A", "Start": "07:00", "End": "08:45", "Status": "completed"},
+			{"ID": "T002", "Vehicle": "Bus 002", "Driver": "Chris Hensworth", "Route": "Route B", "Start": "07:15", "End": "\u2014", "Status": "active"},
+			{"ID": "T003", "Vehicle": "Bus 003", "Driver": "Bruce Wayne", "Route": "Route C", "Start": "06:45", "End": "08:30", "Status": "completed"},
+		},
+	})
+}

--- a/admin_handlers.go
+++ b/admin_handlers.go
@@ -1,15 +1,16 @@
 package main
 
 import (
+	"embed"
 	"html/template"
 	"net/http"
-	"embed"
 )
 
 //go:embed web/templates web/static
 var files embed.FS
+
 func renderPublic(w http.ResponseWriter, view string, data map[string]interface{}) {
-	tmpl, err := template.ParseFiles(view)
+	tmpl, err := template.ParseFS(files, view)
 	if err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -20,7 +21,8 @@ func renderPublic(w http.ResponseWriter, view string, data map[string]interface{
 }
 
 func renderAdmin(w http.ResponseWriter, view string, data map[string]interface{}) {
-	tmpl, err := template.ParseFiles(
+	tmpl, err := template.ParseFS(
+		files,
 		"web/templates/layout/base.html",
 		"web/templates/layout/sidebar.html",
 		"web/templates/layout/header.html",

--- a/admin_handlers.go
+++ b/admin_handlers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"embed"
 	"fmt"
 	"html/template"
 	"io"
@@ -9,9 +8,6 @@ import (
 	"net/http"
 	"path"
 )
-
-//go:embed web/templates web/static
-var files embed.FS
 
 const adminTemplateKey = "_admin_template"
 

--- a/admin_handlers.go
+++ b/admin_handlers.go
@@ -2,12 +2,68 @@ package main
 
 import (
 	"embed"
+	"fmt"
 	"html/template"
+	"io"
 	"net/http"
+	"path"
 )
 
 //go:embed web/templates web/static
 var files embed.FS
+
+const adminTemplateKey = "_admin_template"
+
+type embeddedTemplates struct {
+	public *template.Template
+	admin  map[string]*template.Template
+}
+
+func adminViewName(data any) (string, error) {
+	templateData, ok := data.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("admin template data must be map[string]interface{}")
+	}
+
+	viewName, ok := templateData[adminTemplateKey].(string)
+	if !ok || viewName == "" {
+		return "", fmt.Errorf("admin template view is missing")
+	}
+
+	return viewName, nil
+}
+
+func withAdminTemplate(data map[string]interface{}, view string) map[string]interface{} {
+	if data == nil {
+		data = make(map[string]interface{}, 1)
+	}
+
+	renderData := make(map[string]interface{}, len(data)+1)
+	for k, v := range data {
+		renderData[k] = v
+	}
+
+	renderData[adminTemplateKey] = path.Base(view)
+	return renderData
+}
+
+func (t *embeddedTemplates) ExecuteTemplate(w io.Writer, name string, data any) error {
+	if name != "base.html" {
+		return t.public.ExecuteTemplate(w, name, data)
+	}
+
+	viewName, err := adminViewName(data)
+	if err != nil {
+		return err
+	}
+
+	tmpl, ok := t.admin[viewName]
+	if !ok {
+		return fmt.Errorf("unknown admin template: %s", viewName)
+	}
+
+	return tmpl.ExecuteTemplate(w, name, data)
+}
 
 func renderPublic(w http.ResponseWriter, view string, data map[string]interface{}) {
 	tmpl, err := template.ParseFS(files, view)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -68,6 +69,12 @@ func main() {
 
 	startTime := time.Now()
 
+	staticFiles, err := fs.Sub(files, "web/static")
+	if err != nil {
+		slog.Error("failed to prepare embedded static files", "error", err)
+		os.Exit(1)
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("POST /api/v1/auth/login", handleLogin(store, jwtSecret))
 	mux.HandleFunc("GET /gtfs-rt/vehicle-positions", handleGetFeed(tracker))
@@ -77,7 +84,7 @@ func main() {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	})
 
-	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("web/static"))))
+	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFiles))))
 
 	authMiddleware := requireAuth(jwtSecret)
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"embed"
 	"errors"
 	"io/fs"
 	"log/slog"
@@ -11,6 +12,9 @@ import (
 	"syscall"
 	"time"
 )
+
+//go:embed web/templates web/static
+var files embed.FS
 
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))

--- a/main.go
+++ b/main.go
@@ -77,9 +77,20 @@ func main() {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	})
 
+	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("web/static"))))
+
 	authMiddleware := requireAuth(jwtSecret)
 
 	mux.Handle("POST /api/v1/locations", authMiddleware(handlePostLocation(store, tracker, rateLimiter)))
+
+	// Admin UI — no auth for demo/pitch
+	mux.HandleFunc("GET /admin/login", AdminLoginHandler)
+	mux.HandleFunc("GET /admin/signup", AdminSignupHandler)
+	mux.HandleFunc("GET /admin/map", AdminMapHandler)
+	mux.HandleFunc("GET /admin/dashboard", AdminDashboardHandler)
+	mux.HandleFunc("GET /admin/vehicles", AdminVehiclesHandler)
+	mux.HandleFunc("GET /admin/users", AdminUsersHandler)
+	mux.HandleFunc("GET /admin/trips", AdminTripsHandler)
 
 	srv := &http.Server{
 		Addr:         ":" + port,

--- a/web/static/js/admin.js
+++ b/web/static/js/admin.js
@@ -1,0 +1,181 @@
+const mockVehicles = [
+  {
+    id: "SEA-101",
+    label: "Bus 101",
+    lat: 47.6101,
+    lng: -122.3426,
+    route: "Rapid E Line",
+    status: "active",
+    corridor: "Downtown to Ballard",
+    stop: "3rd Ave & Pine St",
+  },
+  {
+    id: "SEA-108",
+    label: "Bus 108",
+    lat: 47.6206,
+    lng: -122.3201,
+    route: "Route 8",
+    status: "active",
+    corridor: "Capitol Hill Crosstown",
+    stop: "Denny Way & Broadway",
+  },
+  {
+    id: "SEA-214",
+    label: "Bus 214",
+    lat: 47.5989,
+    lng: -122.3347,
+    route: "South Lake Loop",
+    status: "active",
+    corridor: "Pioneer Square Connector",
+    stop: "Jackson St Transit Hub",
+  },
+  {
+    id: "SEA-305",
+    label: "Bus 305",
+    lat: 47.6677,
+    lng: -122.3826,
+    route: "Rapid E Line",
+    status: "idle",
+    corridor: "Northwest Layover",
+    stop: "Ballard Ave NW",
+  },
+  {
+    id: "SEA-417",
+    label: "Bus 417",
+    lat: 47.6267,
+    lng: -122.3561,
+    route: "South Lake Loop",
+    status: "active",
+    corridor: "Seattle Center Spur",
+    stop: "Queen Anne Ave N",
+  },
+  {
+    id: "SEA-522",
+    label: "Bus 522",
+    lat: 47.5884,
+    lng: -122.3023,
+    route: "Route 8",
+    status: "idle",
+    corridor: "Mount Baker Relief",
+    stop: "Rainier Ave S",
+  },
+];
+
+const mockCorridors = [
+  {
+    name: "Rapid E Line",
+    color: "#0f766e",
+    points: [
+      [47.6101, -122.3426],
+      [47.6205, -122.3492],
+      [47.6362, -122.3563],
+      [47.6516, -122.3752],
+      [47.6677, -122.3826],
+    ],
+  },
+  {
+    name: "Route 8",
+    color: "#f59e0b",
+    points: [
+      [47.5884, -122.3023],
+      [47.6002, -122.3119],
+      [47.6117, -122.3174],
+      [47.6206, -122.3201],
+      [47.6312, -122.3225],
+    ],
+  },
+  {
+    name: "South Lake Loop",
+    color: "#0284c7",
+    points: [
+      [47.5989, -122.3347],
+      [47.6072, -122.3324],
+      [47.6202, -122.3384],
+      [47.6267, -122.3561],
+    ],
+  },
+];
+
+function makeMarkerIcon(status) {
+  const markerClass = status === "active" ? "bus-marker bus-marker--active" : "bus-marker bus-marker--idle";
+  return L.divIcon({
+    className: "",
+    html: `<div class="${markerClass}">
+      <span class="bus-marker__pulse"></span>
+      <span class="bus-marker__icon">&#128652;</span>
+    </div>`,
+    iconSize: [42, 42],
+    iconAnchor: [21, 21],
+    popupAnchor: [0, -18],
+  });
+}
+
+function buildPopup(vehicle) {
+  const badgeClass = vehicle.status === "active"
+    ? "map-popup__badge map-popup__badge--active"
+    : "map-popup__badge map-popup__badge--idle";
+
+  return `<div class="map-popup">
+    <div class="map-popup__header">
+      <div>
+        <div class="map-popup__title">&#128652; ${vehicle.label}</div>
+        <div style="font-size:12px;color:#64748b;margin-top:2px;">${vehicle.id}</div>
+      </div>
+      <span class="${badgeClass}">${vehicle.status}</span>
+    </div>
+    <div class="map-popup__meta">
+      <div><strong>Route</strong> ${vehicle.route}</div>
+      <div><strong>Corridor</strong> ${vehicle.corridor}</div>
+      <div><strong>Nearest stop</strong> ${vehicle.stop}</div>
+    </div>
+  </div>`;
+}
+
+function initMap() {
+  const el = document.getElementById("main-map");
+  if (!el) return;
+  const map = L.map("main-map", {
+    zoomControl: false,
+    scrollWheelZoom: true,
+  }).setView([47.6062, -122.3321], 13);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 19,
+  }).addTo(map);
+
+  L.control.zoom({ position: "bottomright" }).addTo(map);
+
+  mockCorridors.forEach(corridor => {
+    L.polyline(corridor.points, {
+      color: corridor.color,
+      weight: 5,
+      opacity: 0.82,
+      lineCap: "round",
+    })
+      .addTo(map)
+      .bindTooltip(corridor.name, {
+        direction: "top",
+        offset: [0, -4],
+        opacity: 0.95,
+      });
+  });
+
+  mockVehicles.forEach(v => {
+    L.marker([v.lat, v.lng], { icon: makeMarkerIcon(v.status) })
+      .addTo(map)
+      .bindPopup(buildPopup(v));
+  });
+
+  const activeCount = mockVehicles.filter(vehicle => vehicle.status === "active").length;
+  const activeCountEl = document.getElementById("fleet-active-count");
+  const routeCountEl = document.getElementById("route-count");
+
+  if (activeCountEl) activeCountEl.textContent = String(activeCount);
+  if (routeCountEl) routeCountEl.textContent = String(mockCorridors.length);
+}
+
+// Auto-initialize the map if this page has the map container
+if (document.getElementById("main-map")) {
+  initMap();
+}

--- a/web/templates/layout/base.html
+++ b/web/templates/layout/base.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>{{.Title}} — Transit Tracker</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+
+<script src="https://cdn.tailwindcss.com"></script>
+<style>
+  :root {
+    --bg-top: #f4f9ff;
+    --bg-bottom: #deebf7;
+    --panel: rgba(255, 255, 255, 0.8);
+    --panel-strong: rgba(255, 255, 255, 0.94);
+    --border: rgba(148, 163, 184, 0.22);
+    --text-strong: #0f172a;
+    --text-soft: #5b6473;
+    --sidebar-top: #0b1728;
+    --sidebar-bottom: #13233d;
+    --teal: #0f766e;
+    --sky: #0284c7;
+    --amber: #f59e0b;
+    --rose: #e11d48;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    height: 100%;
+  }
+
+  body {
+    margin: 0;
+    font-family: "Inter", sans-serif;
+    color: var(--text-strong);
+    background:
+      radial-gradient(circle at top left, rgba(255, 255, 255, 0.92), transparent 26rem),
+      linear-gradient(180deg, var(--bg-top), var(--bg-bottom));
+  }
+
+  h1,
+  h2,
+  h3,
+  .display-font {
+    font-family: "Space Grotesk", sans-serif;
+  }
+
+  .glass-panel {
+    background: var(--panel);
+    -webkit-backdrop-filter: blur(18px);
+    backdrop-filter: blur(18px);
+  }
+
+  .page-shell {
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(246, 250, 255, 0.86));
+    box-shadow:
+      0 18px 48px rgba(15, 23, 42, 0.12),
+      inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  }
+
+  .sidebar-shell {
+    background:
+      radial-gradient(circle at top, rgba(56, 189, 248, 0.14), transparent 18rem),
+      linear-gradient(180deg, var(--sidebar-top), var(--sidebar-bottom));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      0 18px 42px rgba(8, 15, 30, 0.36);
+  }
+
+  .sidebar-link {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .sidebar-link::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(90deg, rgba(14, 165, 233, 0.16), rgba(45, 212, 191, 0.08));
+    opacity: 0;
+    transition: opacity 160ms ease;
+  }
+
+  .sidebar-link:hover::before,
+  .sidebar-link[data-active="true"]::before {
+    opacity: 1;
+  }
+
+  .table-card {
+    background: var(--panel-strong);
+    -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(16px);
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+  }
+
+  .stat-card {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(245, 249, 255, 0.9));
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.07);
+  }
+
+  .leaflet-container {
+    font-family: "Inter", sans-serif;
+    background: #dbeafe;
+  }
+
+  .leaflet-control-zoom {
+    border: 0 !important;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.18) !important;
+  }
+
+  .leaflet-control-zoom a {
+    width: 38px !important;
+    height: 38px !important;
+    line-height: 38px !important;
+    color: var(--text-strong) !important;
+    border: 0 !important;
+  }
+
+  .leaflet-popup-content-wrapper {
+    border-radius: 18px;
+    padding: 0;
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.2);
+  }
+
+  .leaflet-popup-content {
+    margin: 0 !important;
+    width: 260px !important;
+  }
+
+  .leaflet-popup-tip {
+    box-shadow: none;
+  }
+
+  .map-popup {
+    padding: 1rem;
+    background: linear-gradient(180deg, #ffffff, #f4f9ff);
+  }
+
+  .map-popup__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.85rem;
+  }
+
+  .map-popup__title {
+    font-family: "Space Grotesk", sans-serif;
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-strong);
+  }
+
+  .map-popup__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: capitalize;
+  }
+
+  .map-popup__badge--active {
+    background: rgba(15, 118, 110, 0.12);
+    color: var(--teal);
+  }
+
+  .map-popup__badge--idle {
+    background: rgba(245, 158, 11, 0.12);
+    color: #b45309;
+  }
+
+  .map-popup__meta {
+    display: grid;
+    gap: 0.55rem;
+    font-size: 0.84rem;
+    color: var(--text-soft);
+  }
+
+  .map-popup__meta strong {
+    color: var(--text-strong);
+  }
+
+  .bus-marker {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.92);
+    box-shadow: 0 16px 28px rgba(15, 23, 42, 0.24);
+    transform: translate(-50%, -50%);
+  }
+
+  .bus-marker--active {
+    background: linear-gradient(180deg, #14b8a6, #0f766e);
+  }
+
+  .bus-marker--idle {
+    background: linear-gradient(180deg, #fbbf24, #f59e0b);
+  }
+
+  .bus-marker__pulse {
+    position: absolute;
+    inset: -8px;
+    border-radius: 20px;
+    border: 2px solid rgba(20, 184, 166, 0.28);
+    opacity: 0;
+  }
+
+  .bus-marker--active .bus-marker__pulse {
+    animation: pulse-ring 2.1s ease-out infinite;
+  }
+
+  .bus-marker__icon {
+    position: relative;
+    z-index: 1;
+    font-size: 1.15rem;
+    line-height: 1;
+    filter: saturate(1.05);
+  }
+
+  @keyframes pulse-ring {
+    0% {
+      transform: scale(0.86);
+      opacity: 0.88;
+    }
+
+    100% {
+      transform: scale(1.3);
+      opacity: 0;
+    }
+  }
+
+  @media (max-width: 1023px) {
+    body {
+      overflow: auto;
+    }
+  }
+</style>
+</head>
+
+<body>
+
+<div class="flex min-h-screen flex-col gap-4 p-3 lg:flex-row lg:items-start lg:p-5">
+{{template "sidebar" .}}
+
+<main class="page-shell flex min-w-0 flex-1 flex-col rounded-[30px] border border-white/60">
+
+{{template "header" .}}
+
+<div class="flex-1">
+
+{{template "content" .}}
+
+</div>
+
+</main>
+</div>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="/static/js/admin.js"></script>
+</body>
+</html>

--- a/web/templates/layout/header.html
+++ b/web/templates/layout/header.html
@@ -1,0 +1,14 @@
+{{define "header"}}
+<header class="glass-panel flex shrink-0 items-center justify-between border-b border-slate-200/70 px-5 py-4 lg:px-7">
+  <div>
+    <p class="text-xs font-semibold uppercase tracking-[0.28em] text-sky-700/70">Transit control</p>
+    <h1 class="display-font mt-1 text-xl font-bold tracking-tight text-slate-900">{{.Title}}</h1>
+  </div>
+  <div class="flex items-center gap-3">
+    <span class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/75 px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm">
+      <span class="h-2.5 w-2.5 rounded-full bg-emerald-500"></span>
+      Admin
+    </span>
+  </div>
+</header>
+{{end}}

--- a/web/templates/layout/sidebar.html
+++ b/web/templates/layout/sidebar.html
@@ -1,0 +1,57 @@
+{{define "sidebar"}}
+<aside class="sidebar-shell glass-panel flex shrink-0 flex-col overflow-hidden rounded-[28px] border border-white/10 text-white lg:sticky lg:top-5 lg:max-h-[calc(100vh-2.5rem)] lg:w-72">
+  <div class="border-b border-white/10 px-5 py-5">
+    <div class="flex items-center gap-3">
+      <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-xl shadow-lg shadow-cyan-950/30">
+        &#128652;
+      </div>
+      <div>
+        <p class="display-font text-lg font-bold tracking-tight">Transit Tracker</p>
+        <p class="text-xs uppercase tracking-[0.28em] text-slate-400">Fleet Operations</p>
+      </div>
+    </div>
+  </div>
+
+  <nav class="flex-1 space-y-1.5 p-3 text-sm">
+    <a href="/admin/map"
+       data-active="{{if eq .Page "map"}}true{{else}}false{{end}}"
+       class="sidebar-link flex items-center gap-3 rounded-2xl px-3.5 py-3 transition-colors
+              {{if eq .Page "map"}}bg-white/10 text-white ring-1 ring-white/10{{else}}text-slate-300 hover:bg-white/5 hover:text-white{{end}}">
+      <span class="flex h-9 w-9 items-center justify-center rounded-xl bg-white/10 text-base">&#128506;</span>
+      Live Map
+    </a>
+    <a href="/admin/dashboard"
+       data-active="{{if eq .Page "dashboard"}}true{{else}}false{{end}}"
+       class="sidebar-link flex items-center gap-3 rounded-2xl px-3.5 py-3 transition-colors
+              {{if eq .Page "dashboard"}}bg-white/10 text-white ring-1 ring-white/10{{else}}text-slate-300 hover:bg-white/5 hover:text-white{{end}}">
+      <span class="flex h-9 w-9 items-center justify-center rounded-xl bg-white/10 text-base">&#128200;</span>
+      Dashboard
+    </a>
+    <a href="/admin/vehicles"
+       data-active="{{if eq .Page "vehicles"}}true{{else}}false{{end}}"
+       class="sidebar-link flex items-center gap-3 rounded-2xl px-3.5 py-3 transition-colors
+              {{if eq .Page "vehicles"}}bg-white/10 text-white ring-1 ring-white/10{{else}}text-slate-300 hover:bg-white/5 hover:text-white{{end}}">
+      <span class="flex h-9 w-9 items-center justify-center rounded-xl bg-white/10 text-base">&#128652;</span>
+      Vehicles
+    </a>
+    <a href="/admin/users"
+       data-active="{{if eq .Page "users"}}true{{else}}false{{end}}"
+       class="sidebar-link flex items-center gap-3 rounded-2xl px-3.5 py-3 transition-colors
+              {{if eq .Page "users"}}bg-white/10 text-white ring-1 ring-white/10{{else}}text-slate-300 hover:bg-white/5 hover:text-white{{end}}">
+      <span class="flex h-9 w-9 items-center justify-center rounded-xl bg-white/10 text-base">&#128101;</span>
+      Users
+    </a>
+    <a href="/admin/trips"
+       data-active="{{if eq .Page "trips"}}true{{else}}false{{end}}"
+       class="sidebar-link flex items-center gap-3 rounded-2xl px-3.5 py-3 transition-colors
+              {{if eq .Page "trips"}}bg-white/10 text-white ring-1 ring-white/10{{else}}text-slate-300 hover:bg-white/5 hover:text-white{{end}}">
+      <span class="flex h-9 w-9 items-center justify-center rounded-xl bg-white/10 text-base">&#128339;</span>
+      Trips
+    </a>
+  </nav>
+
+  <div class="border-t border-white/10 px-5 py-4">
+    <p class="text-xs text-slate-500">v0.1.0</p>
+  </div>
+</aside>
+{{end}}

--- a/web/templates/views/dashboard.html
+++ b/web/templates/views/dashboard.html
@@ -1,0 +1,63 @@
+{{define "content"}}
+<div class="space-y-5 p-4 lg:p-5">
+
+  <div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
+    <div class="stat-card rounded-[20px] border border-white/80 p-5">
+      <p class="text-[11px] font-semibold uppercase tracking-[0.25em] text-slate-500">Total Fleet</p>
+      <p class="display-font mt-2 text-4xl font-bold text-slate-900">{{.TotalVehicles}}</p>
+      <p class="mt-2 text-xs text-slate-400">Registered vehicles</p>
+    </div>
+    <div class="stat-card rounded-[20px] border border-white/80 p-5">
+      <p class="text-[11px] font-semibold uppercase tracking-[0.25em] text-slate-500">Active Now</p>
+      <p class="display-font mt-2 text-4xl font-bold text-emerald-700">{{.ActiveVehicles}}</p>
+      <p class="mt-2 text-xs text-slate-400">On route</p>
+    </div>
+    <div class="stat-card rounded-[20px] border border-white/80 p-5">
+      <p class="text-[11px] font-semibold uppercase tracking-[0.25em] text-slate-500">Drivers</p>
+      <p class="display-font mt-2 text-4xl font-bold text-slate-900">{{.TotalDrivers}}</p>
+      <p class="mt-2 text-xs text-slate-400">Registered</p>
+    </div>
+    <div class="stat-card rounded-[20px] border border-white/80 p-5">
+      <p class="text-[11px] font-semibold uppercase tracking-[0.25em] text-slate-500">Active Trips</p>
+      <p class="display-font mt-2 text-4xl font-bold text-sky-700">{{.ActiveTrips}}</p>
+      <p class="mt-2 text-xs text-slate-400">In progress</p>
+    </div>
+  </div>
+
+  <div class="table-card overflow-hidden rounded-[20px] border border-white/80">
+    <div class="flex items-center justify-between border-b border-slate-200/60 px-5 py-4">
+      <h3 class="display-font text-base font-bold text-slate-900">Recent Activity</h3>
+      <a href="/admin/vehicles" class="text-xs font-semibold text-sky-600 hover:text-sky-800">View all &rarr;</a>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead class="bg-slate-50/80">
+          <tr class="text-left">
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Vehicle</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Route</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Status</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Last Update</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          {{range .RecentVehicles}}
+          <tr class="transition-colors hover:bg-slate-50/60">
+            <td class="px-5 py-3.5 font-semibold text-slate-900">{{.Name}}</td>
+            <td class="px-5 py-3.5 text-slate-500">{{.Route}}</td>
+            <td class="px-5 py-3.5">
+              {{if eq .Status "active"}}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-semibold text-emerald-700"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>Active</span>
+              {{else}}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-700"><span class="h-1.5 w-1.5 rounded-full bg-amber-400"></span>Idle</span>
+              {{end}}
+            </td>
+            <td class="px-5 py-3.5 text-slate-400">{{.LastSeen}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+</div>
+{{end}}

--- a/web/templates/views/login.html
+++ b/web/templates/views/login.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Transit Tracker - {{.Title}}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            ink: "#10233f",
+            mist: "#edf4fb",
+            line: "#d7e3f1",
+            ocean: "#0f766e",
+            sky: "#0369a1",
+            sand: "#f59e0b"
+          },
+          boxShadow: {
+            soft: "0 24px 70px rgba(15, 23, 42, 0.16)"
+          },
+          fontFamily: {
+            sans: ["Inter", "sans-serif"],
+            display: ["Space Grotesk", "sans-serif"]
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body
+  class="min-h-screen bg-[#e9f2fb] font-sans text-slate-900"
+  data-mode="{{.Mode}}"
+  data-login-endpoint="{{.LoginEndpoint}}"
+  data-signup-endpoint="{{.SignupEndpoint}}">
+  <div class="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.95),_transparent_28rem),linear-gradient(180deg,#eef6ff_0%,#dceaf6_100%)] px-4 py-8 sm:px-6 lg:px-8">
+    <div class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[1.05fr_0.95fr]">
+
+      <section class="rounded-[32px] border border-white/70 bg-white/90 p-6 shadow-soft backdrop-blur-xl sm:p-8">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.28em] text-sky-700">Access</p>
+            <h2 class="mt-2 font-display text-3xl font-bold tracking-tight text-ink">Login or create a demo account</h2>
+          </div>
+          <a href="/admin/dashboard" class="rounded-full border border-line px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-900">Skip to dashboard</a>
+        </div>
+
+        <div class="mt-6 flex rounded-2xl bg-mist p-1.5">
+          <button type="button" data-auth-tab="login" class="auth-tab flex-1 rounded-xl px-4 py-3 text-sm font-semibold transition">Login</button>
+          <button type="button" data-auth-tab="signup" class="auth-tab flex-1 rounded-xl px-4 py-3 text-sm font-semibold transition">Sign up</button>
+        </div>
+
+        <div id="auth-status" class="mt-4 hidden rounded-2xl border px-4 py-3 text-sm"></div>
+
+        <form id="login-form" class="auth-panel mt-6 space-y-4" data-mode="login" novalidate>
+          <div>
+            <label for="login-email" class="mb-1.5 block text-sm font-semibold text-slate-700">Email</label>
+            <input id="login-email" name="email" type="email" autocomplete="email" required value="demo@transit.local" class="w-full rounded-2xl border border-line bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+          </div>
+          <div>
+            <label for="login-password" class="mb-1.5 block text-sm font-semibold text-slate-700">Password</label>
+            <input id="login-password" name="password" type="password" autocomplete="current-password" required value="password123" class="w-full rounded-2xl border border-line bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+          </div>
+          <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-ink px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-800">Sign in</button>
+        </form>
+
+        <form id="signup-form" class="auth-panel mt-6 hidden space-y-4" data-mode="signup" novalidate>
+          <div>
+            <label for="signup-name" class="mb-1.5 block text-sm font-semibold text-slate-700">Full name</label>
+            <input id="signup-name" name="name" type="text" autocomplete="name" required placeholder="Jane Doe" class="w-full rounded-2xl border border-line bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+          </div>
+          <div>
+            <label for="signup-email" class="mb-1.5 block text-sm font-semibold text-slate-700">Email</label>
+            <input id="signup-email" name="email" type="email" autocomplete="email" required placeholder="jane@transit.local" class="w-full rounded-2xl border border-line bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+          </div>
+          <div class="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label for="signup-password" class="mb-1.5 block text-sm font-semibold text-slate-700">Password</label>
+              <input id="signup-password" name="password" type="password" autocomplete="new-password" required placeholder="Minimum 8 characters" class="w-full rounded-2xl border border-line bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+            </div>
+            <div>
+              <label for="signup-confirm" class="mb-1.5 block text-sm font-semibold text-slate-700">Confirm password</label>
+              <input id="signup-confirm" name="confirmPassword" type="password" autocomplete="new-password" required placeholder="Repeat password" class="w-full rounded-2xl border border-line bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+            </div>
+          </div>
+          <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-sky px-4 py-3 text-sm font-semibold text-white transition hover:bg-sky-700">Create account</button>
+        </form>
+        
+      </section>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      const initialMode = document.body.dataset.mode || "login";
+      const loginEndpoint = document.body.dataset.loginEndpoint || "/api/v1/auth/login";
+      const signupEndpoint = document.body.dataset.signupEndpoint || "/api/v1/auth/signup";
+      const authTabs = document.querySelectorAll("[data-auth-tab]");
+      const panels = {
+        login: document.getElementById("login-form"),
+        signup: document.getElementById("signup-form")
+      };
+      const statusEl = document.getElementById("auth-status");
+      const loginForm = document.getElementById("login-form");
+      const signupForm = document.getElementById("signup-form");
+      const demoStorageKey = "transit-poc-users";
+      const tokenStorageKey = "transit-poc-token";
+
+      function seedDemoUsers() {
+        const existing = window.localStorage.getItem(demoStorageKey);
+        if (existing) {
+          return;
+        }
+
+        const demoUsers = [
+          {
+            name: "Transit Demo",
+            email: "demo@transit.local",
+            password: "password123"
+          }
+        ];
+        window.localStorage.setItem(demoStorageKey, JSON.stringify(demoUsers));
+      }
+
+      function readUsers() {
+        try {
+          return JSON.parse(window.localStorage.getItem(demoStorageKey) || "[]");
+        } catch (error) {
+          return [];
+        }
+      }
+
+      function writeUsers(users) {
+        window.localStorage.setItem(demoStorageKey, JSON.stringify(users));
+      }
+
+      function setStatus(kind, message) {
+        statusEl.className = "mt-4 rounded-2xl border px-4 py-3 text-sm";
+        if (kind === "success") {
+          statusEl.classList.add("border-emerald-200", "bg-emerald-50", "text-emerald-800");
+        } else {
+          statusEl.classList.add("border-rose-200", "bg-rose-50", "text-rose-700");
+        }
+        statusEl.textContent = message;
+        statusEl.classList.remove("hidden");
+      }
+
+      function setActiveMode(mode) {
+        authTabs.forEach(function (tab) {
+          const active = tab.dataset.authTab === mode;
+          tab.classList.toggle("bg-white", active);
+          tab.classList.toggle("text-slate-900", active);
+          tab.classList.toggle("shadow-sm", active);
+          tab.classList.toggle("text-slate-500", !active);
+        });
+
+        Object.keys(panels).forEach(function (key) {
+          panels[key].classList.toggle("hidden", key !== mode);
+        });
+      }
+
+      authTabs.forEach(function (tab) {
+        tab.addEventListener("click", function () {
+          setActiveMode(tab.dataset.authTab);
+          statusEl.classList.add("hidden");
+        });
+      });
+
+      loginForm.addEventListener("submit", function (event) {
+        event.preventDefault();
+        const formData = new FormData(loginForm);
+        const email = String(formData.get("email") || "").trim().toLowerCase();
+        const password = String(formData.get("password") || "");
+        const users = readUsers();
+        const match = users.find(function (user) {
+          return user.email.toLowerCase() === email && user.password === password;
+        });
+
+        if (!email || !password) {
+          setStatus("error", "Enter both email and password.");
+          return;
+        }
+
+        if (!match) {
+          setStatus("error", "Dummy login failed. Try demo@transit.local / password123 or create a new fake account first.");
+          return;
+        }
+
+        window.localStorage.setItem(tokenStorageKey, JSON.stringify({
+          endpoint: loginEndpoint,
+          token: "demo-token",
+          email: match.email,
+          createdAt: new Date().toISOString()
+        }));
+        setStatus("success", "Dummy login successful. Redirecting to the dashboard...");
+        window.setTimeout(function () {
+          window.location.href = "/admin/dashboard";
+        }, 700);
+      });
+
+      signupForm.addEventListener("submit", function (event) {
+        event.preventDefault();
+        const formData = new FormData(signupForm);
+        const name = String(formData.get("name") || "").trim();
+        const email = String(formData.get("email") || "").trim().toLowerCase();
+        const password = String(formData.get("password") || "");
+        const confirmPassword = String(formData.get("confirmPassword") || "");
+        const users = readUsers();
+
+        if (!name || !email || !password || !confirmPassword) {
+          setStatus("error", "Fill in all signup fields.");
+          return;
+        }
+
+        if (password.length < 8) {
+          setStatus("error", "Use at least 8 characters for the dummy password.");
+          return;
+        }
+
+        if (password !== confirmPassword) {
+          setStatus("error", "Passwords do not match.");
+          return;
+        }
+
+        if (users.some(function (user) { return user.email.toLowerCase() === email; })) {
+          setStatus("error", "That dummy email already exists. Sign in instead.");
+          return;
+        }
+
+        users.push({
+          name: name,
+          email: email,
+          password: password,
+          endpoint: signupEndpoint
+        });
+        writeUsers(users);
+
+        loginForm.querySelector("[name=email]").value = email;
+        loginForm.querySelector("[name=password]").value = password;
+        signupForm.reset();
+        setActiveMode("login");
+        setStatus("success", "Dummy account created locally. You can sign in now.");
+      });
+
+      seedDemoUsers();
+      setActiveMode(initialMode === "signup" ? "signup" : "login");
+    }());
+  </script>
+</body>
+</html>

--- a/web/templates/views/map.html
+++ b/web/templates/views/map.html
@@ -1,0 +1,137 @@
+{{define "content"}}
+<div class="p-4 lg:p-5">
+  <div class="grid gap-4 lg:grid-cols-[1fr_280px]">
+
+    <!-- Map -->
+    <div class="relative overflow-hidden rounded-[24px] border border-white/70 shadow-xl" style="height:calc(100vh - 9rem); min-height:480px">
+      <div id="main-map" class="absolute inset-0"></div>
+
+      <!-- Stats overlay top-left -->
+      <div class="pointer-events-none absolute left-4 top-4 z-[500]">
+        <div class="glass-panel pointer-events-auto inline-flex items-center gap-5 rounded-2xl border border-white/70 px-5 py-3 shadow-lg">
+          <div class="text-center">
+            <p class="display-font text-2xl font-bold text-slate-900">4</p>
+            <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-700">Active</p>
+          </div>
+          <div class="h-7 w-px bg-slate-200"></div>
+          <div class="text-center">
+            <p class="display-font text-2xl font-bold text-slate-900">2</p>
+            <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-600">Idle</p>
+          </div>
+          <div class="h-7 w-px bg-slate-200"></div>
+          <div class="text-center">
+            <p class="display-font text-2xl font-bold text-slate-900">6</p>
+            <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-500">Buses</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Legend bottom-left -->
+      <div class="pointer-events-none absolute bottom-4 left-4 z-[500]">
+        <div class="glass-panel pointer-events-auto inline-flex items-center gap-4 rounded-xl border border-white/70 px-4 py-2.5 text-xs font-medium text-slate-700 shadow-md">
+          <span class="flex items-center gap-1.5"><span class="h-2.5 w-2.5 rounded-full bg-teal-600"></span>Active</span>
+          <span class="flex items-center gap-1.5"><span class="h-2.5 w-2.5 rounded-full bg-amber-500"></span>Idle</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Fleet sidebar -->
+    <div class="space-y-4">
+      <!-- Vehicle list -->
+      <div class="table-card rounded-[20px] border border-white/80 p-4">
+        <div class="mb-3 flex items-center justify-between">
+          <h3 class="display-font text-sm font-bold text-slate-900">Fleet Status</h3>
+          <span class="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-600">6 buses</span>
+        </div>
+        <div class="space-y-2">
+          <div class="flex items-center gap-3 rounded-xl bg-slate-50/80 p-2.5">
+            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-teal-600 text-sm text-white">&#128652;</span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm font-semibold text-slate-900">Bus 001</p>
+              <p class="truncate text-xs text-slate-400">Route A &middot; James Mwangi</p>
+            </div>
+            <span class="h-2 w-2 shrink-0 rounded-full bg-emerald-500"></span>
+          </div>
+          <div class="flex items-center gap-3 rounded-xl bg-slate-50/80 p-2.5">
+            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-teal-600 text-sm text-white">&#128652;</span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm font-semibold text-slate-900">Bus 002</p>
+              <p class="truncate text-xs text-slate-400">Route B &middot; Brad Pitt</p>
+            </div>
+            <span class="h-2 w-2 shrink-0 rounded-full bg-emerald-500"></span>
+          </div>
+          <div class="flex items-center gap-3 rounded-xl bg-slate-50/80 p-2.5">
+            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-teal-600 text-sm text-white">&#128652;</span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm font-semibold text-slate-900">Bus 003</p>
+              <p class="truncate text-xs text-slate-400">Route C &middot; Bruce Wayne</p>
+            </div>
+            <span class="h-2 w-2 shrink-0 rounded-full bg-emerald-500"></span>
+          </div>
+          <div class="flex items-center gap-3 rounded-xl bg-slate-50/80 p-2.5">
+            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-500 text-sm text-white">&#128652;</span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm font-semibold text-slate-900">Bus 004</p>
+              <p class="truncate text-xs text-slate-400">Route A &middot; Michael Phelps</p>
+            </div>
+            <span class="h-2 w-2 shrink-0 rounded-full bg-amber-400"></span>
+          </div>
+          <div class="flex items-center gap-3 rounded-xl bg-slate-50/80 p-2.5">
+            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-teal-600 text-sm text-white">&#128652;</span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm font-semibold text-slate-900">Bus 005</p>
+              <p class="truncate text-xs text-slate-400">Route D &middot; Michael Jordan</p>
+            </div>
+            <span class="h-2 w-2 shrink-0 rounded-full bg-emerald-500"></span>
+          </div>
+          <div class="flex items-center gap-3 rounded-xl bg-slate-50/80 p-2.5">
+            <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-500 text-sm text-white">&#128652;</span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-sm font-semibold text-slate-900">Bus 006</p>
+              <p class="truncate text-xs text-slate-400">Route B &middot; Unassigned</p>
+            </div>
+            <span class="h-2 w-2 shrink-0 rounded-full bg-amber-400"></span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Route summary -->
+      <div class="table-card rounded-[20px] border border-white/80 p-4">
+        <h3 class="display-font mb-3 text-sm font-bold text-slate-900">Active Routes</h3>
+        <div class="space-y-2">
+          <div class="flex items-center justify-between rounded-xl bg-slate-50/80 px-3 py-2.5">
+            <div>
+              <p class="text-sm font-semibold text-slate-900">Route A</p>
+              <p class="text-xs text-slate-400">CBD &rarr; Westlands</p>
+            </div>
+            <span class="rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">2 buses</span>
+          </div>
+          <div class="flex items-center justify-between rounded-xl bg-slate-50/80 px-3 py-2.5">
+            <div>
+              <p class="text-sm font-semibold text-slate-900">Route B</p>
+              <p class="text-xs text-slate-400">Ngong Rd &rarr; City</p>
+            </div>
+            <span class="rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-semibold text-amber-700">2 buses</span>
+          </div>
+          <div class="flex items-center justify-between rounded-xl bg-slate-50/80 px-3 py-2.5">
+            <div>
+              <p class="text-sm font-semibold text-slate-900">Route C</p>
+              <p class="text-xs text-slate-400">Thika Rd &rarr; CBD</p>
+            </div>
+            <span class="rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">1 bus</span>
+          </div>
+          <div class="flex items-center justify-between rounded-xl bg-slate-50/80 px-3 py-2.5">
+            <div>
+              <p class="text-sm font-semibold text-slate-900">Route D</p>
+              <p class="text-xs text-slate-400">Eastlands &rarr; City</p>
+            </div>
+            <span class="rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">1 bus</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+{{end}}
+

--- a/web/templates/views/trips.html
+++ b/web/templates/views/trips.html
@@ -1,0 +1,48 @@
+{{define "content"}}
+<div class="p-4 lg:p-5">
+  <div class="table-card overflow-hidden rounded-[20px] border border-white/80">
+    <div class="flex items-center justify-between border-b border-slate-200/60 px-5 py-4">
+      <div>
+        <h3 class="display-font text-lg font-bold text-slate-900">Trip History</h3>
+        <p class="mt-0.5 text-xs text-slate-400">{{len .Trips}} trips today</p>
+      </div>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead class="bg-slate-50/80">
+          <tr class="text-left">
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Trip</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Vehicle</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Driver</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Route</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Start</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">End</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Status</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          {{range .Trips}}
+          <tr class="transition-colors hover:bg-slate-50/60">
+            <td class="px-5 py-4 font-mono text-xs font-medium text-slate-400">{{.ID}}</td>
+            <td class="px-5 py-4 font-semibold text-slate-900">{{.Vehicle}}</td>
+            <td class="px-5 py-4 text-slate-500">{{.Driver}}</td>
+            <td class="px-5 py-4 text-slate-500">{{.Route}}</td>
+            <td class="px-5 py-4 text-slate-500">{{.Start}}</td>
+            <td class="px-5 py-4 text-slate-400">{{.End}}</td>
+            <td class="px-5 py-4">
+              {{if eq .Status "active"}}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-semibold text-emerald-700"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>Active</span>
+              {{else if eq .Status "completed"}}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600"><span class="h-1.5 w-1.5 rounded-full bg-slate-400"></span>Completed</span>
+              {{else}}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-700"><span class="h-1.5 w-1.5 rounded-full bg-amber-400"></span>{{.Status}}</span>
+              {{end}}
+            </td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{{end}}

--- a/web/templates/views/users.html
+++ b/web/templates/views/users.html
@@ -1,0 +1,45 @@
+{{define "content"}}
+<div class="p-4 lg:p-5">
+  <div class="table-card overflow-hidden rounded-[20px] border border-white/80">
+    <div class="flex items-center justify-between border-b border-slate-200/60 px-5 py-4">
+      <div>
+        <h3 class="display-font text-lg font-bold text-slate-900">All Users</h3>
+        <p class="mt-0.5 text-xs text-slate-400">{{len .Users}} accounts</p>
+      </div>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead class="bg-slate-50/80">
+          <tr class="text-left">
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Name</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Email</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Role</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Last Seen</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          {{range .Users}}
+          <tr class="transition-colors hover:bg-slate-50/60">
+            <td class="px-5 py-4">
+              <div class="flex items-center gap-3">
+                <span class="flex h-8 w-8 items-center justify-center rounded-xl bg-slate-100 text-xs font-bold text-slate-600">{{slice .Name 0 1}}</span>
+                <p class="font-semibold text-slate-900">{{.Name}}</p>
+              </div>
+            </td>
+            <td class="px-5 py-4 text-slate-500">{{.Email}}</td>
+            <td class="px-5 py-4">
+              {{if eq .Role "admin"}}
+              <span class="inline-flex items-center rounded-full bg-violet-50 px-2.5 py-1 text-xs font-semibold text-violet-700">Admin</span>
+              {{else}}
+              <span class="inline-flex items-center rounded-full bg-sky-50 px-2.5 py-1 text-xs font-semibold text-sky-700">Driver</span>
+              {{end}}
+            </td>
+            <td class="px-5 py-4 text-slate-400">{{.LastSeen}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{{end}}

--- a/web/templates/views/vehicles.html
+++ b/web/templates/views/vehicles.html
@@ -1,0 +1,51 @@
+{{define "content"}}
+<div class="p-4 lg:p-5">
+  <div class="table-card overflow-hidden rounded-[20px] border border-white/80">
+    <div class="flex items-center justify-between border-b border-slate-200/60 px-5 py-4">
+      <div>
+        <h3 class="display-font text-lg font-bold text-slate-900">All Vehicles</h3>
+        <p class="mt-0.5 text-xs text-slate-400">{{len .Vehicles}} registered in fleet</p>
+      </div>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead class="bg-slate-50/80">
+          <tr class="text-left">
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">ID</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Vehicle</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Route</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Driver</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Status</th>
+            <th class="px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">Last Seen</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          {{range .Vehicles}}
+          <tr class="transition-colors hover:bg-slate-50/60">
+            <td class="px-5 py-4 font-mono text-xs font-medium text-slate-400">{{.ID}}</td>
+            <td class="px-5 py-4">
+              <div class="flex items-center gap-3">
+                <span class="flex h-9 w-9 items-center justify-center rounded-xl bg-sky-50 text-lg">&#128652;</span>
+                <p class="font-semibold text-slate-900">{{.Name}}</p>
+              </div>
+            </td>
+            <td class="px-5 py-4 text-slate-500">{{.Route}}</td>
+            <td class="px-5 py-4 text-slate-500">{{.Driver}}</td>
+            <td class="px-5 py-4">
+              {{if eq .Status "active"}}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-semibold text-emerald-700"><span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>Active</span>
+              {{else if eq .Status "idle"}}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-700"><span class="h-1.5 w-1.5 rounded-full bg-amber-400"></span>Idle</span>
+              {{else}}
+              <span class="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-500"><span class="h-1.5 w-1.5 rounded-full bg-slate-400"></span>Offline</span>
+              {{end}}
+            </td>
+            <td class="px-5 py-4 text-slate-400">{{.LastSeen}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{{end}}


### PR DESCRIPTION
This PR adds a proof-of-concept admin interface for managing the system as discussed in the issue #65.

The goal is to explore a lightweight UI that can be served directly from the Go server using templates.

The POC includes:
- dashboard
- vehicle management
- users page
- trips monitoring
- map view (Leaflet + OpenStreetMap)

The UI is built using: Go templates, Bootstrap, minimal JavaScript

Currently this uses dummy data for UI exploration. Further will be improved as per the progress in the backend Apis.

Opening this PR mainly to get early feedback on the approach and confirm that this direction aligns with the intended project architecture before continuing further development.

Closes #65