### PR TITLE
 add admin location history endpoint with JSON and CSV export

### DIFF
--- a/location_history_handlers.go
+++ b/location_history_handlers.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	defaultHistoryLimit = 100
+	maxHistoryLimit     = 1000
+)
+
+type locationHistoryResponse struct {
+	VehicleID string          `json:"vehicle_id"`
+	Count     int             `json:"count"`
+	Locations []locationEntry `json:"locations"`
+}
+
+type locationEntry struct {
+	Latitude   float64  `json:"latitude"`
+	Longitude  float64  `json:"longitude"`
+	Bearing    *float64 `json:"bearing"`
+	Speed      *float64 `json:"speed"`
+	Accuracy   *float64 `json:"accuracy"`
+	Timestamp  int64    `json:"timestamp"`
+	TripID     string   `json:"trip_id"`
+	ReceivedAt string   `json:"recorded_at"`
+}
+
+func handleGetLocationHistory(lister LocationHistoryLister, checker VehicleChecker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vehicleID := r.PathValue("vehicleID")
+		if vehicleID == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "vehicle_id is required"})
+			return
+		}
+		if len(vehicleID) > maxVehicleIDLength {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("vehicle_id must be at most %d characters", maxVehicleIDLength)})
+			return
+		}
+		if !vehicleIDPattern.MatchString(vehicleID) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "vehicle_id must contain only alphanumeric characters, dots, hyphens, and underscores"})
+			return
+		}
+
+		q := r.URL.Query()
+
+		from, err := parseOptionalInt64(q.Get("from"), 0)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "from must be a valid unix timestamp"})
+			return
+		}
+		to, err := parseOptionalInt64(q.Get("to"), time.Now().Unix())
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "to must be a valid unix timestamp"})
+			return
+		}
+		if from > to {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "from must be less than or equal to to"})
+			return
+		}
+
+		limit, err := parseOptionalInt(q.Get("limit"), defaultHistoryLimit)
+		if err != nil || limit < 1 || limit > maxHistoryLimit {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("limit must be between 1 and %d", maxHistoryLimit)})
+			return
+		}
+
+		format := q.Get("format")
+		if format == "" {
+			format = "json"
+		}
+		if format != "json" && format != "csv" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "format must be json or csv"})
+			return
+		}
+
+		exists, err := checker.VehicleExists(r.Context(), vehicleID)
+		if err != nil {
+			slog.Error("failed to check vehicle existence", "vehicle_id", vehicleID, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+		if !exists {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "vehicle not found"})
+			return
+		}
+
+		points, err := lister.GetLocationHistory(r.Context(), vehicleID, from, to, limit)
+		if err != nil {
+			slog.Error("failed to get location history", "vehicle_id", vehicleID, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		if format == "csv" {
+			writeCSV(w, vehicleID, points)
+			return
+		}
+
+		entries := make([]locationEntry, 0, len(points))
+		for _, p := range points {
+			entries = append(entries, locationEntry{
+				Latitude:   p.Latitude,
+				Longitude:  p.Longitude,
+				Bearing:    p.Bearing,
+				Speed:      p.Speed,
+				Accuracy:   p.Accuracy,
+				Timestamp:  p.Timestamp,
+				TripID:     p.TripID,
+				ReceivedAt: p.ReceivedAt.UTC().Format(time.RFC3339),
+			})
+		}
+
+		writeJSON(w, http.StatusOK, locationHistoryResponse{
+			VehicleID: vehicleID,
+			Count:     len(entries),
+			Locations: entries,
+		})
+	}
+}
+
+func writeCSV(w http.ResponseWriter, vehicleID string, points []LocationPoint) {
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s_locations.csv"`, vehicleID))
+	w.WriteHeader(http.StatusOK)
+
+	writer := csv.NewWriter(w)
+	defer writer.Flush()
+
+	header := []string{"timestamp", "latitude", "longitude", "bearing", "speed", "accuracy", "trip_id", "recorded_at"}
+	if err := writer.Write(header); err != nil {
+		slog.Error("failed to write CSV header", "error", err)
+		return
+	}
+
+	for _, p := range points {
+		record := []string{
+			strconv.FormatInt(p.Timestamp, 10),
+			strconv.FormatFloat(p.Latitude, 'f', -1, 64),
+			strconv.FormatFloat(p.Longitude, 'f', -1, 64),
+			formatOptionalFloat(p.Bearing),
+			formatOptionalFloat(p.Speed),
+			formatOptionalFloat(p.Accuracy),
+			p.TripID,
+			p.ReceivedAt.UTC().Format(time.RFC3339),
+		}
+		if err := writer.Write(record); err != nil {
+			slog.Error("failed to write CSV record", "error", err)
+			return
+		}
+	}
+}
+
+func formatOptionalFloat(v *float64) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*v, 'f', -1, 64)
+}
+
+func parseOptionalInt64(s string, defaultVal int64) (int64, error) {
+	if s == "" {
+		return defaultVal, nil
+	}
+	return strconv.ParseInt(s, 10, 64)
+}
+
+func parseOptionalInt(s string, defaultVal int) (int, error) {
+	if s == "" {
+		return defaultVal, nil
+	}
+	return strconv.Atoi(s)
+}

--- a/location_history_handlers_test.go
+++ b/location_history_handlers_test.go
@@ -1,0 +1,402 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockLocationHistoryLister struct {
+	points []LocationPoint
+	err    error
+}
+
+func (m *mockLocationHistoryLister) GetLocationHistory(_ context.Context, _ string, _, _ int64, _ int) ([]LocationPoint, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.points, nil
+}
+
+type mockVehicleChecker struct {
+	exists bool
+	err    error
+}
+
+func (m *mockVehicleChecker) VehicleExists(_ context.Context, _ string) (bool, error) {
+	return m.exists, m.err
+}
+
+func newHistoryRequest(vehicleID string, query string) *http.Request {
+	path := "/api/v1/admin/vehicles/placeholder/locations"
+	if query != "" {
+		path += "?" + query
+	}
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	r.SetPathValue("vehicleID", vehicleID)
+	return r
+}
+
+func float64Ptr(v float64) *float64 {
+	return &v
+}
+
+func TestHandleGetLocationHistory_Success(t *testing.T) {
+	now := time.Now().UTC()
+	lister := &mockLocationHistoryLister{
+		points: []LocationPoint{
+			{
+				Latitude: -1.29, Longitude: 36.82,
+				Bearing: float64Ptr(180.0), Speed: float64Ptr(8.5), Accuracy: float64Ptr(12.0),
+				Timestamp: now.Unix(), TripID: "trip-1", ReceivedAt: now,
+			},
+		},
+	}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("vehicle-042", ""))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp locationHistoryResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "vehicle-042", resp.VehicleID)
+	assert.Equal(t, 1, resp.Count)
+	require.Len(t, resp.Locations, 1)
+	assert.Equal(t, -1.29, resp.Locations[0].Latitude)
+	assert.Equal(t, 36.82, resp.Locations[0].Longitude)
+	require.NotNil(t, resp.Locations[0].Bearing)
+	assert.Equal(t, 180.0, *resp.Locations[0].Bearing)
+	require.NotNil(t, resp.Locations[0].Speed)
+	assert.Equal(t, 8.5, *resp.Locations[0].Speed)
+	assert.Equal(t, "trip-1", resp.Locations[0].TripID)
+}
+
+func TestHandleGetLocationHistory_CSV(t *testing.T) {
+	now := time.Now().UTC()
+	lister := &mockLocationHistoryLister{
+		points: []LocationPoint{
+			{
+				Latitude: -1.29, Longitude: 36.82,
+				Bearing: float64Ptr(180.0), Speed: float64Ptr(8.5), Accuracy: float64Ptr(12.0),
+				Timestamp: 1752566400, TripID: "trip-1", ReceivedAt: now,
+			},
+		},
+	}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("vehicle-042", "format=csv"))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "vehicle-042_locations.csv")
+
+	reader := csv.NewReader(w.Body)
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2, "header + 1 data row")
+
+	assert.Equal(t, []string{"timestamp", "latitude", "longitude", "bearing", "speed", "accuracy", "trip_id", "recorded_at"}, records[0])
+	assert.Equal(t, "1752566400", records[1][0])
+	assert.Equal(t, "-1.29", records[1][1])
+	assert.Equal(t, "36.82", records[1][2])
+	assert.Equal(t, "180", records[1][3])
+	assert.Equal(t, "8.5", records[1][4])
+	assert.Equal(t, "12", records[1][5])
+	assert.Equal(t, "trip-1", records[1][6])
+}
+
+func TestHandleGetLocationHistory_DefaultParams(t *testing.T) {
+	lister := &mockLocationHistoryLister{points: make([]LocationPoint, 0)}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("bus-1", ""))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp locationHistoryResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, 0, resp.Count)
+	assert.NotNil(t, resp.Locations, "locations should be empty array, not null")
+	assert.Len(t, resp.Locations, 0)
+}
+
+func TestHandleGetLocationHistory_EmptyHistory(t *testing.T) {
+	lister := &mockLocationHistoryLister{points: make([]LocationPoint, 0)}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("bus-empty", ""))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify JSON contains [] not null
+	body := w.Body.String()
+	assert.Contains(t, body, `"locations":[]`)
+}
+
+func TestHandleGetLocationHistory_VehicleNotFound(t *testing.T) {
+	lister := &mockLocationHistoryLister{}
+	checker := &mockVehicleChecker{exists: false}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("ghost-bus", ""))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp["error"], "vehicle not found")
+}
+
+func TestHandleGetLocationHistory_InvalidVehicleID(t *testing.T) {
+	lister := &mockLocationHistoryLister{}
+	checker := &mockVehicleChecker{}
+	handler := handleGetLocationHistory(lister, checker)
+
+	tests := []struct {
+		name      string
+		vehicleID string
+		wantErr   string
+	}{
+		{"special characters", "bus@#$", "alphanumeric"},
+		{"spaces", "bus 1", "alphanumeric"},
+		{"empty", "", "vehicle_id is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, newHistoryRequest(tt.vehicleID, ""))
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			var resp map[string]string
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+			assert.Contains(t, resp["error"], tt.wantErr)
+		})
+	}
+}
+
+func TestHandleGetLocationHistory_VehicleIDTooLong(t *testing.T) {
+	lister := &mockLocationHistoryLister{}
+	checker := &mockVehicleChecker{}
+	handler := handleGetLocationHistory(lister, checker)
+
+	// Exactly 50 chars should pass validation (will hit vehicle check)
+	w50 := httptest.NewRecorder()
+	checker.exists = true
+	lister.points = make([]LocationPoint, 0)
+	handler.ServeHTTP(w50, newHistoryRequest(strings.Repeat("a", 50), ""))
+	assert.Equal(t, http.StatusOK, w50.Code, "50-char vehicle_id should be accepted")
+
+	// 51 chars should be rejected
+	w51 := httptest.NewRecorder()
+	handler.ServeHTTP(w51, newHistoryRequest(strings.Repeat("a", 51), ""))
+	assert.Equal(t, http.StatusBadRequest, w51.Code, "51-char vehicle_id should be rejected")
+
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(w51.Body).Decode(&resp))
+	assert.Contains(t, resp["error"], "at most 50")
+}
+
+func TestHandleGetLocationHistory_InvalidLimit(t *testing.T) {
+	lister := &mockLocationHistoryLister{}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"zero", "limit=0"},
+		{"negative", "limit=-1"},
+		{"over max", "limit=1001"},
+		{"non-numeric", "limit=abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, newHistoryRequest("bus-1", tt.query))
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			var resp map[string]string
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+			assert.Contains(t, resp["error"], "limit")
+		})
+	}
+}
+
+func TestHandleGetLocationHistory_InvalidTimestamp(t *testing.T) {
+	lister := &mockLocationHistoryLister{}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	tests := []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{"non-numeric from", "from=abc", "from"},
+		{"non-numeric to", "to=xyz", "to"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, newHistoryRequest("bus-1", tt.query))
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			var resp map[string]string
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+			assert.Contains(t, resp["error"], tt.wantErr)
+		})
+	}
+}
+
+func TestHandleGetLocationHistory_FromGreaterThanTo(t *testing.T) {
+	lister := &mockLocationHistoryLister{}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("bus-1", "from=2000&to=1000"))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp["error"], "from must be less than or equal to to")
+}
+
+func TestHandleGetLocationHistory_StoreError(t *testing.T) {
+	lister := &mockLocationHistoryLister{err: fmt.Errorf("database connection lost")}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("bus-1", ""))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp["error"], "internal server error")
+}
+
+func TestHandleGetLocationHistory_CheckerError(t *testing.T) {
+	lister := &mockLocationHistoryLister{}
+	checker := &mockVehicleChecker{err: fmt.Errorf("database connection lost")}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("bus-1", ""))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp["error"], "internal server error")
+}
+
+func TestHandleGetLocationHistory_NullableFieldsJSON(t *testing.T) {
+	lister := &mockLocationHistoryLister{
+		points: []LocationPoint{
+			{Latitude: 1.0, Longitude: 2.0, Bearing: nil, Speed: nil, Accuracy: nil, Timestamp: time.Now().Unix(), ReceivedAt: time.Now()},
+			{Latitude: 3.0, Longitude: 4.0, Bearing: float64Ptr(0), Speed: float64Ptr(0), Accuracy: float64Ptr(0), Timestamp: time.Now().Unix() - 60, ReceivedAt: time.Now()},
+		},
+	}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("bus-1", ""))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp locationHistoryResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Locations, 2)
+
+	// First: nil fields
+	assert.Nil(t, resp.Locations[0].Bearing, "nil bearing should serialize as null")
+	assert.Nil(t, resp.Locations[0].Speed)
+	assert.Nil(t, resp.Locations[0].Accuracy)
+
+	// Second: zero-valued fields (not nil)
+	require.NotNil(t, resp.Locations[1].Bearing, "zero bearing should not be nil")
+	assert.Equal(t, 0.0, *resp.Locations[1].Bearing)
+	require.NotNil(t, resp.Locations[1].Speed)
+	assert.Equal(t, 0.0, *resp.Locations[1].Speed)
+}
+
+func TestHandleGetLocationHistory_CSVNullableFields(t *testing.T) {
+	lister := &mockLocationHistoryLister{
+		points: []LocationPoint{
+			{Latitude: 1.0, Longitude: 2.0, Bearing: nil, Speed: nil, Accuracy: nil, Timestamp: 1752566400, ReceivedAt: time.Now()},
+		},
+	}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("bus-1", "format=csv"))
+
+	reader := csv.NewReader(w.Body)
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+
+	// bearing, speed, accuracy columns should be empty for nil
+	assert.Equal(t, "", records[1][3], "nil bearing should be empty in CSV")
+	assert.Equal(t, "", records[1][4], "nil speed should be empty in CSV")
+	assert.Equal(t, "", records[1][5], "nil accuracy should be empty in CSV")
+}
+
+func TestHandleGetLocationHistory_BoundaryLimit(t *testing.T) {
+	lister := &mockLocationHistoryLister{points: make([]LocationPoint, 0)}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	// limit=1 should be accepted
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, newHistoryRequest("bus-1", "limit=1"))
+	assert.Equal(t, http.StatusOK, w1.Code, "limit=1 should be accepted")
+
+	// limit=1000 should be accepted
+	w1000 := httptest.NewRecorder()
+	handler.ServeHTTP(w1000, newHistoryRequest("bus-1", "limit=1000"))
+	assert.Equal(t, http.StatusOK, w1000.Code, "limit=1000 should be accepted")
+
+	// limit=1001 should be rejected
+	w1001 := httptest.NewRecorder()
+	handler.ServeHTTP(w1001, newHistoryRequest("bus-1", "limit=1001"))
+	assert.Equal(t, http.StatusBadRequest, w1001.Code, "limit=1001 should be rejected")
+}
+
+func TestHandleGetLocationHistory_InvalidFormat(t *testing.T) {
+	lister := &mockLocationHistoryLister{}
+	checker := &mockVehicleChecker{exists: true}
+	handler := handleGetLocationHistory(lister, checker)
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newHistoryRequest("bus-1", "format=xml"))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp["error"], "format must be json or csv")
+}

--- a/location_history_store.go
+++ b/location_history_store.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// LocationPoint represents a single persisted location point for history queries.
+type LocationPoint struct {
+	Latitude   float64
+	Longitude  float64
+	Bearing    *float64
+	Speed      *float64
+	Accuracy   *float64
+	Timestamp  int64
+	TripID     string
+	ReceivedAt time.Time
+}
+
+// LocationHistoryLister retrieves historical location points for a vehicle.
+type LocationHistoryLister interface {
+	GetLocationHistory(ctx context.Context, vehicleID string, from, to int64, limit int) ([]LocationPoint, error)
+}
+
+// VehicleChecker checks whether a vehicle exists.
+type VehicleChecker interface {
+	VehicleExists(ctx context.Context, vehicleID string) (bool, error)
+}
+
+// GetLocationHistory returns location points for a vehicle within the given
+// timestamp range, ordered by most recent first.
+func (s *Store) GetLocationHistory(ctx context.Context, vehicleID string, from, to int64, limit int) ([]LocationPoint, error) {
+	query := `
+		SELECT latitude, longitude, bearing, speed, accuracy, timestamp, trip_id, received_at
+		FROM location_points
+		WHERE vehicle_id = $1
+		  AND timestamp >= $2
+		  AND timestamp <= $3
+		ORDER BY timestamp DESC
+		LIMIT $4
+	`
+
+	rows, err := s.pool.Query(ctx, query, vehicleID, from, to, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query location history: %w", err)
+	}
+	defer rows.Close()
+
+	points := make([]LocationPoint, 0)
+	for rows.Next() {
+		var p LocationPoint
+		var bearing, speed, accuracy *float64
+		if err := rows.Scan(&p.Latitude, &p.Longitude, &bearing, &speed, &accuracy, &p.Timestamp, &p.TripID, &p.ReceivedAt); err != nil {
+			return nil, fmt.Errorf("scan location point: %w", err)
+		}
+		p.Bearing = bearing
+		p.Speed = speed
+		p.Accuracy = accuracy
+		points = append(points, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate location points: %w", err)
+	}
+
+	return points, nil
+}
+
+// VehicleExists returns true if a vehicle with the given ID exists.
+func (s *Store) VehicleExists(ctx context.Context, vehicleID string) (bool, error) {
+	var exists bool
+	err := s.pool.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM vehicles WHERE id = $1)", vehicleID).Scan(&exists)
+	if err != nil && err != pgx.ErrNoRows {
+		return false, fmt.Errorf("check vehicle exists: %w", err)
+	}
+	return exists, nil
+}

--- a/location_history_store_test.go
+++ b/location_history_store_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_GetLocationHistory_Success(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx, "DELETE FROM location_points")
+	require.NoError(t, err)
+	_, err = store.pool.Exec(ctx, "DELETE FROM vehicles")
+	require.NoError(t, err)
+
+	_, err = store.pool.Exec(ctx, "INSERT INTO vehicles (id) VALUES ('hist-bus-1')")
+	require.NoError(t, err)
+
+	now := time.Now().Unix()
+	_, err = store.pool.Exec(ctx,
+		"INSERT INTO location_points (vehicle_id, trip_id, latitude, longitude, bearing, speed, accuracy, timestamp) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+		"hist-bus-1", "trip-1", -1.29, 36.82, 180.0, 8.5, 12.0, now)
+	require.NoError(t, err)
+	_, err = store.pool.Exec(ctx,
+		"INSERT INTO location_points (vehicle_id, trip_id, latitude, longitude, bearing, speed, accuracy, timestamp) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+		"hist-bus-1", "trip-1", -1.30, 36.83, 90.0, 10.0, 5.0, now-60)
+	require.NoError(t, err)
+
+	points, err := store.GetLocationHistory(ctx, "hist-bus-1", 0, now, 100)
+	require.NoError(t, err)
+	require.Len(t, points, 2)
+
+	// Most recent first
+	assert.Equal(t, now, points[0].Timestamp)
+	assert.Equal(t, now-60, points[1].Timestamp)
+	assert.Equal(t, -1.29, points[0].Latitude)
+	assert.Equal(t, 36.82, points[0].Longitude)
+	assert.Equal(t, "trip-1", points[0].TripID)
+
+	require.NotNil(t, points[0].Bearing)
+	assert.Equal(t, 180.0, *points[0].Bearing)
+	require.NotNil(t, points[0].Speed)
+	assert.Equal(t, 8.5, *points[0].Speed)
+	require.NotNil(t, points[0].Accuracy)
+	assert.Equal(t, 12.0, *points[0].Accuracy)
+}
+
+func TestStore_GetLocationHistory_TimeRange(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx, "DELETE FROM location_points")
+	require.NoError(t, err)
+	_, err = store.pool.Exec(ctx, "DELETE FROM vehicles")
+	require.NoError(t, err)
+
+	_, err = store.pool.Exec(ctx, "INSERT INTO vehicles (id) VALUES ('hist-bus-range')")
+	require.NoError(t, err)
+
+	now := time.Now().Unix()
+	// Insert 3 points at different timestamps
+	for _, ts := range []int64{now - 300, now - 100, now} {
+		_, err = store.pool.Exec(ctx,
+			"INSERT INTO location_points (vehicle_id, trip_id, latitude, longitude, timestamp) VALUES ($1, '', $2, $3, $4)",
+			"hist-bus-range", 1.0, 2.0, ts)
+		require.NoError(t, err)
+	}
+
+	// Query only the middle range
+	points, err := store.GetLocationHistory(ctx, "hist-bus-range", now-200, now-50, 100)
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.Equal(t, now-100, points[0].Timestamp)
+}
+
+func TestStore_GetLocationHistory_Limit(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx, "DELETE FROM location_points")
+	require.NoError(t, err)
+	_, err = store.pool.Exec(ctx, "DELETE FROM vehicles")
+	require.NoError(t, err)
+
+	_, err = store.pool.Exec(ctx, "INSERT INTO vehicles (id) VALUES ('hist-bus-limit')")
+	require.NoError(t, err)
+
+	now := time.Now().Unix()
+	for i := range 5 {
+		_, err = store.pool.Exec(ctx,
+			"INSERT INTO location_points (vehicle_id, trip_id, latitude, longitude, timestamp) VALUES ($1, '', $2, $3, $4)",
+			"hist-bus-limit", 1.0, 2.0, now-int64(i))
+		require.NoError(t, err)
+	}
+
+	points, err := store.GetLocationHistory(ctx, "hist-bus-limit", 0, now, 2)
+	require.NoError(t, err)
+	assert.Len(t, points, 2, "should respect limit")
+}
+
+func TestStore_GetLocationHistory_EmptyResult(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx, "DELETE FROM location_points")
+	require.NoError(t, err)
+	_, err = store.pool.Exec(ctx, "DELETE FROM vehicles")
+	require.NoError(t, err)
+
+	_, err = store.pool.Exec(ctx, "INSERT INTO vehicles (id) VALUES ('hist-bus-empty')")
+	require.NoError(t, err)
+
+	points, err := store.GetLocationHistory(ctx, "hist-bus-empty", 0, time.Now().Unix(), 100)
+	require.NoError(t, err)
+	require.NotNil(t, points, "should return empty slice, not nil")
+	assert.Len(t, points, 0)
+}
+
+func TestStore_GetLocationHistory_NullableFields(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx, "DELETE FROM location_points")
+	require.NoError(t, err)
+	_, err = store.pool.Exec(ctx, "DELETE FROM vehicles")
+	require.NoError(t, err)
+
+	_, err = store.pool.Exec(ctx, "INSERT INTO vehicles (id) VALUES ('hist-bus-null')")
+	require.NoError(t, err)
+
+	now := time.Now().Unix()
+	// Insert with NULL bearing/speed/accuracy
+	_, err = store.pool.Exec(ctx,
+		"INSERT INTO location_points (vehicle_id, trip_id, latitude, longitude, timestamp) VALUES ($1, '', $2, $3, $4)",
+		"hist-bus-null", 1.0, 2.0, now)
+	require.NoError(t, err)
+
+	// Insert with zero bearing (should be distinct from nil)
+	_, err = store.pool.Exec(ctx,
+		"INSERT INTO location_points (vehicle_id, trip_id, latitude, longitude, bearing, speed, accuracy, timestamp) VALUES ($1, '', $2, $3, $4, $5, $6, $7)",
+		"hist-bus-null", 3.0, 4.0, 0.0, 0.0, 0.0, now-60)
+	require.NoError(t, err)
+
+	points, err := store.GetLocationHistory(ctx, "hist-bus-null", 0, now, 100)
+	require.NoError(t, err)
+	require.Len(t, points, 2)
+
+	// Most recent: NULL fields
+	assert.Nil(t, points[0].Bearing, "NULL bearing should be nil")
+	assert.Nil(t, points[0].Speed, "NULL speed should be nil")
+	assert.Nil(t, points[0].Accuracy, "NULL accuracy should be nil")
+
+	// Older: zero-valued fields (not nil)
+	require.NotNil(t, points[1].Bearing, "zero bearing should not be nil")
+	assert.Equal(t, 0.0, *points[1].Bearing)
+	require.NotNil(t, points[1].Speed, "zero speed should not be nil")
+	assert.Equal(t, 0.0, *points[1].Speed)
+	require.NotNil(t, points[1].Accuracy, "zero accuracy should not be nil")
+	assert.Equal(t, 0.0, *points[1].Accuracy)
+}
+
+func TestStore_VehicleExists_Found(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx, "DELETE FROM location_points")
+	require.NoError(t, err)
+	_, err = store.pool.Exec(ctx, "DELETE FROM vehicles")
+	require.NoError(t, err)
+
+	_, err = store.pool.Exec(ctx, "INSERT INTO vehicles (id) VALUES ('exists-bus')")
+	require.NoError(t, err)
+
+	exists, err := store.VehicleExists(ctx, "exists-bus")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestStore_VehicleExists_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	exists, err := store.VehicleExists(ctx, "nonexistent-bus-999")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}

--- a/main.go
+++ b/main.go
@@ -71,8 +71,9 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("POST /api/v1/auth/login", handleLogin(store, jwtSecret))
 	mux.HandleFunc("GET /gtfs-rt/vehicle-positions", handleGetFeed(tracker))
-	// TODO: protect with requireAuth once auth lands
+	// TODO: protect with requireAdmin once admin middleware lands
 	mux.HandleFunc("GET /api/v1/admin/status", handleAdminStatus(tracker, startTime))
+	mux.HandleFunc("GET /api/v1/admin/vehicles/{vehicleID}/locations", handleGetLocationHistory(store, store))
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	})


### PR DESCRIPTION
## Summary                                                                                                                                                                                              
                                                                                                                                                                                                          
  Implements location history and CSV export for admin vehicle analytics, as specified in README Section 3.3 Admin Capabilities:                                                                          
  - "View trip history and location trails"                                                                                                                                                               
  - "Download location data as CSV for analysis"                                                                                                                                                          
                                                                                                                                                                                                          
  ## Why                                                                                                                                                                                                  
                                                                                                                                                                                                          
  The server persists every location report to `location_points` but provides no way to retrieve historical data. Transit agencies need this for route debugging, driver trail review, and operational    
  analytics.      
                                                                                                                                                                                                          
  ## What Changed                                                                                                                                                                                         
  
  **New endpoint:** `GET /api/v1/admin/vehicles/{vehicleID}/locations`                                                                                                                                    
  - Query params: `from`, `to` (unix timestamps), `limit` (1-1000, default 100), `format` (json/csv)
  - JSON response with paginated locations array (default)                                                                                                                                                
  - CSV download with `Content-Disposition` header (`?format=csv`)                                                                                                                                        
  - 404 for unknown vehicles, 400 for invalid params, proper nullable field handling (`*float64`)                                                                                                         
                                                                                                                                                                                                          
  **New files:**                                                                                                                                                                                          
  - `location_history_store.go` — raw pool queries (matches `store_users.go` pattern)                                                                                                                     
  - `location_history_handlers.go` — closure-based handler with JSON + CSV output                                                                                                                         
  - `location_history_store_test.go` — integration tests                                                                                                                                                
  - `location_history_handlers_test.go` —  unit tests                                                                                                                                                   
                                                                                                                                                                                                          
  **Modified:** `main.go` — 1 route registration line  