### PR TITLE
Refactor: Rename DeactivateUser to DeleteUser to reflect hard delete behavior

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 	mux.Handle("GET /api/v1/admin/users/{id}", authMiddleware(handleGetUser(store)))
 	mux.Handle("POST /api/v1/admin/users", authMiddleware(handleCreateUser(store)))
 	mux.Handle("PUT /api/v1/admin/users/{id}", authMiddleware(handleUpdateUser(store)))
-	mux.Handle("DELETE /api/v1/admin/users/{id}", authMiddleware(handleDeactivateUser(store)))
+	mux.Handle("DELETE /api/v1/admin/users/{id}", authMiddleware(handleDeleteUser(store)))
 
 	srv := &http.Server{
 		Addr:         ":" + port,

--- a/store_users_test.go
+++ b/store_users_test.go
@@ -194,16 +194,16 @@ func TestStore_GetUser_NotFound(t *testing.T) {
 	assert.Nil(t, user)
 }
 
-func TestStore_DeactivateUser(t *testing.T) {
+func TestStore_DeleteUser(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
-	cleanupTestUsers(t, store, "crud-deactivate@example.com")
-	t.Cleanup(func() { cleanupTestUsers(t, store, "crud-deactivate@example.com") })
+	cleanupTestUsers(t, store, "crud-delete@example.com")
+	t.Cleanup(func() { cleanupTestUsers(t, store, "crud-delete@example.com") })
 
-	created, err := store.CreateUser(ctx, "To Delete", "crud-deactivate@example.com", "securepass", "driver")
+	created, err := store.CreateUser(ctx, "To Delete", "crud-delete@example.com", "securepass", "driver")
 	require.NoError(t, err)
 
-	err = store.DeactivateUser(ctx, created.ID)
+	err = store.DeleteUser(ctx, created.ID)
 	require.NoError(t, err)
 
 	// Verify user is gone
@@ -211,10 +211,10 @@ func TestStore_DeactivateUser(t *testing.T) {
 	assert.ErrorIs(t, err, ErrUserNotFound)
 }
 
-func TestStore_DeactivateUser_NotFound(t *testing.T) {
+func TestStore_DeleteUser_NotFound(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 
-	err := store.DeactivateUser(ctx, 999999)
+	err := store.DeleteUser(ctx, 999999)
 	assert.ErrorIs(t, err, ErrUserNotFound)
 }

--- a/user_handlers.go
+++ b/user_handlers.go
@@ -182,7 +182,7 @@ func handleUpdateUser(store UserUpdater) http.HandlerFunc {
 	}
 }
 
-func handleDeactivateUser(store UserDeactivator) http.HandlerFunc {
+func handleDeleteUser(store UserDeleter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id, err := parseUserID(r)
 		if err != nil {
@@ -190,12 +190,12 @@ func handleDeactivateUser(store UserDeactivator) http.HandlerFunc {
 			return
 		}
 
-		if err := store.DeactivateUser(r.Context(), id); err != nil {
+		if err := store.DeleteUser(r.Context(), id); err != nil {
 			if errors.Is(err, ErrUserNotFound) {
 				writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
 				return
 			}
-			slog.Error("failed to deactivate user", "id", id, "error", err)
+			slog.Error("failed to delete user", "id", id, "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 			return
 		}

--- a/user_handlers_test.go
+++ b/user_handlers_test.go
@@ -54,11 +54,11 @@ func (m *mockUserUpdater) UpdateUser(ctx context.Context, id int64, name, email,
 	return m.user, m.err
 }
 
-type mockUserDeactivator struct {
+type mockUserDeleter struct {
 	err error
 }
 
-func (m *mockUserDeactivator) DeactivateUser(ctx context.Context, id int64) error {
+func (m *mockUserDeleter) DeleteUser(ctx context.Context, id int64) error {
 	return m.err
 }
 
@@ -596,10 +596,10 @@ func TestHandleUpdateUser_BodyTooLarge(t *testing.T) {
 	assert.Contains(t, decodeErrorResponse(t, w), "invalid JSON")
 }
 
-// --- Deactivate User ---
+// --- Delete User ---
 
-func TestHandleDeactivateUser_HappyPath(t *testing.T) {
-	handler := handleDeactivateUser(&mockUserDeactivator{})
+func TestHandleDeleteUser_HappyPath(t *testing.T) {
+	handler := handleDeleteUser(&mockUserDeleter{})
 	req := httptest.NewRequest("DELETE", "/api/v1/admin/users/1", nil)
 	req.SetPathValue("id", "1")
 	w := httptest.NewRecorder()
@@ -609,8 +609,8 @@ func TestHandleDeactivateUser_HappyPath(t *testing.T) {
 	assert.Empty(t, w.Body.String(), "204 No Content must have no response body")
 }
 
-func TestHandleDeactivateUser_NotFound(t *testing.T) {
-	handler := handleDeactivateUser(&mockUserDeactivator{err: ErrUserNotFound})
+func TestHandleDeleteUser_NotFound(t *testing.T) {
+	handler := handleDeleteUser(&mockUserDeleter{err: ErrUserNotFound})
 	req := httptest.NewRequest("DELETE", "/api/v1/admin/users/999", nil)
 	req.SetPathValue("id", "999")
 	w := httptest.NewRecorder()
@@ -620,8 +620,8 @@ func TestHandleDeactivateUser_NotFound(t *testing.T) {
 	assert.Equal(t, "user not found", decodeErrorResponse(t, w))
 }
 
-func TestHandleDeactivateUser_InvalidID(t *testing.T) {
-	handler := handleDeactivateUser(&mockUserDeactivator{})
+func TestHandleDeleteUser_InvalidID(t *testing.T) {
+	handler := handleDeleteUser(&mockUserDeleter{})
 	req := httptest.NewRequest("DELETE", "/api/v1/admin/users/abc", nil)
 	req.SetPathValue("id", "abc")
 	w := httptest.NewRecorder()
@@ -631,8 +631,8 @@ func TestHandleDeactivateUser_InvalidID(t *testing.T) {
 	assert.Equal(t, "invalid user id", decodeErrorResponse(t, w))
 }
 
-func TestHandleDeactivateUser_DBError(t *testing.T) {
-	handler := handleDeactivateUser(&mockUserDeactivator{err: fmt.Errorf("database down")})
+func TestHandleDeleteUser_DBError(t *testing.T) {
+	handler := handleDeleteUser(&mockUserDeleter{err: fmt.Errorf("database down")})
 	req := httptest.NewRequest("DELETE", "/api/v1/admin/users/1", nil)
 	req.SetPathValue("id", "1")
 	w := httptest.NewRecorder()

--- a/user_store.go
+++ b/user_store.go
@@ -42,8 +42,8 @@ type UserUpdater interface {
 	UpdateUser(ctx context.Context, id int64, name, email, role string) (*UserResponse, error)
 }
 
-type UserDeactivator interface {
-	DeactivateUser(ctx context.Context, id int64) error
+type UserDeleter interface {
+	DeleteUser(ctx context.Context, id int64) error
 }
 
 func (s *Store) ListUsers(ctx context.Context) ([]UserResponse, error) {
@@ -143,10 +143,12 @@ func (s *Store) UpdateUser(ctx context.Context, id int64, name, email, role stri
 	}, nil
 }
 
-func (s *Store) DeactivateUser(ctx context.Context, id int64) error {
+// DeleteUser removes a user from the database by ID.
+func (s *Store) DeleteUser(ctx context.Context, id int64) error {
+
 	rowsAffected, err := s.queries.DeleteUser(ctx, id)
 	if err != nil {
-		return fmt.Errorf("deactivate user: %w", err)
+		return fmt.Errorf("delete user: %w", err)
 	}
 	if rowsAffected == 0 {
 		return ErrUserNotFound


### PR DESCRIPTION
## Description
Fixes #76 

This PR resolves an inconsistency between the naming of the user removal functions and their actual database behavior. Previously, the handler and store methods were named `DeactivateUser`, implying a soft-delete mechanism. However, the underlying SQL query (`DELETE FROM users WHERE id = $1;`) actually performs a permanent hard delete. To prevent confusion and align the Go code with the actual database behavior and the `DELETE` HTTP method, these have been properly renamed to `Delete` variants.

## Changes
* **`user_handlers.go`**: Renamed `handleDeactivateUser` to `handleDeleteUser` and updated the expected interface argument to `UserDeleter`.
* **`user_store.go`**: Renamed the `UserDeactivator` interface to `UserDeleter` and the `DeactivateUser` store method to `DeleteUser`.
* **`main.go`**: Updated the route registration for `DELETE /api/v1/admin/users/{id}` to use the new `handleDeleteUser` function.
* **`user_handlers_test.go`**: Updated mock structs (`mockUserDeleter`) and unit tests to reflect the new `DeleteUser` and `handleDeleteUser` naming.
* **`store_users_test.go`**: Updated test function names and variables to call the new `DeleteUser` method.

## Local Testing
- [x] Formatted code with `go fmt`
- [x] Passed linter checks with `go vet`
- [x] All tests pass locally (`go test ./...`)