### PR TITLE
fix: apply requireAdmin middleware to admin user management routes

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,11 +88,11 @@ func main() {
 	mux.Handle("POST /api/v1/locations", authMiddleware(handlePostLocation(store, tracker, rateLimiter)))
 
 	// Admin user management
-	mux.Handle("GET /api/v1/admin/users", authMiddleware(handleListUsers(store)))
-	mux.Handle("GET /api/v1/admin/users/{id}", authMiddleware(handleGetUser(store)))
-	mux.Handle("POST /api/v1/admin/users", authMiddleware(handleCreateUser(store)))
-	mux.Handle("PUT /api/v1/admin/users/{id}", authMiddleware(handleUpdateUser(store)))
-	mux.Handle("DELETE /api/v1/admin/users/{id}", authMiddleware(handleDeactivateUser(store)))
+	mux.Handle("GET /api/v1/admin/users", authMiddleware(adminMiddleware(handleListUsers(store))))
+	mux.Handle("GET /api/v1/admin/users/{id}", authMiddleware(adminMiddleware(handleGetUser(store))))
+	mux.Handle("POST /api/v1/admin/users", authMiddleware(adminMiddleware(handleCreateUser(store))))
+	mux.Handle("PUT /api/v1/admin/users/{id}", authMiddleware(adminMiddleware(handleUpdateUser(store))))
+	mux.Handle("DELETE /api/v1/admin/users/{id}", authMiddleware(adminMiddleware(handleDeactivateUser(store))))
 
 	srv := &http.Server{
 		Addr:         ":" + port,


### PR DESCRIPTION
## Problem
The `/api/v1/admin/users/*` routes only validated JWT signature and expiry via `requireAuth`, 
but did not check the caller's role. Any authenticated driver could create, delete, and modify 
all user accounts—including promoting themselves to admin or deleting other admins.

## Solution
Applied the existing `requireAdmin` middleware to all five admin user management routes:
- `GET /api/v1/admin/users`
- `GET /api/v1/admin/users/{id}`
- `POST /api/v1/admin/users`
- `PUT /api/v1/admin/users/{id}`
- `DELETE /api/v1/admin/users/{id}`

Routes now use `authMiddleware(adminMiddleware(...))` to verify both JWT validity and admin role.

## Changes
- **main.go**: Wrapped all admin user routes with `adminMiddleware`

## Security Impact
- Non-admin users now receive `403 Forbidden` instead of succeeding
- Prevents privilege escalation and unauthorized data modification
- Aligns with existing admin route protection pattern (`/api/v1/admin/status`, `/api/v1/admin/vehicles/*`)

Closes #75 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization controls for admin user management endpoints to require enhanced permission validation, ensuring only properly authenticated administrators can access user management functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->