### PR TITLE
 add OpenAPI 3.1 spec with drift-guard tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ This timeline follows the GSoC 2026 standard coding period (May 25 – August 24
   - Operator manual: how to onboard drivers, manage vehicles, monitor feed health
 - Write architecture documentation:
   - System architecture diagram
-  - API reference (OpenAPI/Swagger spec)
+  - API reference ([OpenAPI 3.1 spec](openapi.yaml))
   - Data retention and privacy considerations
 - Comprehensive testing:
   - Server: unit tests, integration tests, GTFS-RT feed validation

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ This timeline follows the GSoC 2026 standard coding period (May 25 – August 24
   - Operator manual: how to onboard drivers, manage vehicles, monitor feed health
 - Write architecture documentation:
   - System architecture diagram
-  - API reference (OpenAPI/Swagger spec)
+  - API reference ([OpenAPI 3.1 spec](openapi.yaml))
   - Data retention and privacy considerations
 - Comprehensive testing:
   - Server: unit tests, integration tests, GTFS-RT feed validation

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	golang.org/x/crypto v0.48.0
 	golang.org/x/time v0.15.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -24,5 +25,4 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	golang.org/x/crypto v0.48.0
 	golang.org/x/time v0.15.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -25,5 +26,4 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,869 @@
+openapi: 3.1.0
+info:
+  title: Vehicle Positions API
+  version: 0.1.0
+  summary: Realtime vehicle position tracking for transit agencies without AVL hardware.
+  description: |
+    The Vehicle Positions server ingests GPS reports from driver Android apps
+    and serves a standards-compliant GTFS-RT Vehicle Positions feed. It is
+    built for transit agencies in developing countries that have a GTFS static
+    feed and a fleet of Android phones but no AVL infrastructure.
+
+    This document describes every HTTP endpoint currently registered in
+    `main.go`. Schemas, validation rules, and status codes are derived
+    directly from the handler source — see `openapi_test.go`, which asserts
+    that the spec and the code cannot drift apart.
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: http://localhost:8080
+    description: Local development
+
+tags:
+  - name: auth
+    description: Driver authentication.
+  - name: locations
+    description: GPS location ingest.
+  - name: feed
+    description: GTFS-RT feed consumption.
+  - name: health
+    description: Liveness and readiness probes.
+  - name: admin
+    description: Administrative management endpoints.
+  - name: trips
+    description: Driver trip lifecycle.
+
+# All endpoints require a bearer JWT unless they explicitly opt out with `security: []`.
+security:
+  - bearerAuth: []
+
+paths:
+  /api/v1/auth/login:
+    post:
+      tags: [auth]
+      summary: Log in with email and password
+      description: |
+        Exchanges an email and password for a JWT bearer token valid for 24
+        hours. The returned token must be supplied as
+        `Authorization: Bearer <token>` on protected endpoints.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Login successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '400':
+          description: Missing or invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Invalid email or password.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/locations:
+    post:
+      tags: [locations]
+      summary: Submit a single location report
+      description: |
+        Records a GPS fix from a driver's device. The driver identity comes
+        from the JWT `sub` claim, not the request body. Requests are
+        rate-limited to one report per driver per 5 seconds; additional
+        reports receive HTTP 429. Request bodies are capped at 1 MiB.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LocationReport'
+      responses:
+        '201':
+          description: Location accepted and persisted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          description: Invalid JSON or payload validation failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '429':
+          description: Rate limit exceeded for this driver.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /gtfs-rt/vehicle-positions:
+    get:
+      tags: [feed]
+      summary: GTFS-RT Vehicle Positions feed
+      description: |
+        Returns a standards-compliant GTFS-RT `FeedMessage` containing every
+        vehicle that has reported within the staleness threshold (default 5
+        minutes). Defaults to protobuf; pass `?format=json` to receive the
+        protojson-encoded form for debugging.
+      security: []
+      parameters:
+        - in: query
+          name: format
+          required: false
+          schema:
+            type: string
+            enum: [json]
+          description: When set to `json`, returns the protojson-encoded feed.
+      responses:
+        '200':
+          description: GTFS-RT FeedMessage.
+          content:
+            application/x-protobuf:
+              schema:
+                type: string
+                format: binary
+                description: Serialized GTFS-RT `FeedMessage` protobuf.
+            application/json:
+              schema:
+                type: object
+                description: protojson-encoded GTFS-RT `FeedMessage`.
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /health:
+    get:
+      tags: [health]
+      summary: Liveness probe
+      description: Returns 200 if the process is serving requests.
+      security: []
+      responses:
+        '200':
+          description: Server is alive.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+
+  /ready:
+    get:
+      tags: [health]
+      summary: Readiness probe
+      description: |
+        Returns 200 if the server can reach the database within 2 seconds,
+        or 503 if the database ping fails.
+      security: []
+      responses:
+        '200':
+          description: Server is ready.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '503':
+          description: Server is degraded (database unreachable).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+
+  /api/v1/admin/status:
+    get:
+      tags: [admin]
+      summary: System status and vehicle counts
+      description: Requires the `admin` role.
+      responses:
+        '200':
+          description: Current status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminStatus'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/admin/vehicles:
+    get:
+      tags: [admin]
+      summary: List all vehicles
+      description: Requires the `admin` role.
+      responses:
+        '200':
+          description: Vehicles.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vehicle'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    post:
+      tags: [admin]
+      summary: Create or update a vehicle
+      description: |
+        Upserts by `id`. Requires the `admin` role. Request bodies are capped
+        at 1 KiB.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertVehicleRequest'
+      responses:
+        '200':
+          description: Vehicle created or updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vehicle'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/vehicles/{id}:
+    parameters:
+      - $ref: '#/components/parameters/VehicleIDPath'
+    get:
+      tags: [admin]
+      summary: Get a vehicle by id
+      description: Requires the `admin` role.
+      responses:
+        '200':
+          description: Vehicle.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vehicle'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    delete:
+      tags: [admin]
+      summary: Deactivate a vehicle
+      description: |
+        Sets `active = false`. The row is preserved so historical trips keep
+        referencing it. Requires the `admin` role.
+      responses:
+        '204':
+          description: Vehicle deactivated.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/users:
+    get:
+      tags: [admin]
+      summary: List all users
+      description: |
+        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
+        only requires a valid bearer token — the admin-role check is
+        missing from the handler. Tracked by PR #79, which adds
+        `requireAdmin` to this route; when that merges, a `403` response
+        will be added here.
+      responses:
+        '200':
+          description: Users.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    post:
+      tags: [admin]
+      summary: Create a user
+      description: |
+        Request bodies are capped at 1 KiB.
+
+        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
+        only requires a valid bearer token — the admin-role check is
+        missing from the handler. Tracked by PR #79, which adds
+        `requireAdmin` to this route; when that merges, a `403` response
+        will be added here.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+      responses:
+        '201':
+          description: User created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Email already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/users/{id}:
+    parameters:
+      - $ref: '#/components/parameters/UserIDPath'
+    get:
+      tags: [admin]
+      summary: Get a user by id
+      description: |
+        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
+        only requires a valid bearer token — the admin-role check is
+        missing from the handler. Tracked by PR #79, which adds
+        `requireAdmin` to this route; when that merges, a `403` response
+        will be added here.
+      responses:
+        '200':
+          description: User.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    put:
+      tags: [admin]
+      summary: Update a user
+      description: |
+        Updates name, email, and role. Request bodies are capped at 1 KiB.
+
+        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
+        only requires a valid bearer token — the admin-role check is
+        missing from the handler. Tracked by PR #79, which adds
+        `requireAdmin` to this route; when that merges, a `403` response
+        will be added here.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequest'
+      responses:
+        '200':
+          description: User updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Email already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    delete:
+      tags: [admin]
+      summary: Delete a user
+      description: |
+        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
+        only requires a valid bearer token — the admin-role check is
+        missing from the handler. Tracked by PR #79, which adds
+        `requireAdmin` to this route; when that merges, a `403` response
+        will be added here.
+      responses:
+        '204':
+          description: User deleted.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/trips/start:
+    post:
+      tags: [trips]
+      summary: Start a trip
+      description: |
+        Creates a new active trip for the authenticated driver. The driver
+        must be assigned to the vehicle and must not already have an active
+        trip. Request bodies are capped at 1 KiB.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartTripRequest'
+      responses:
+        '201':
+          description: Trip started.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Trip'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Driver is not assigned to this vehicle.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Driver already has an active trip.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/trips/end:
+    post:
+      tags: [trips]
+      summary: End an active trip
+      description: Request bodies are capped at 1 KiB.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EndTripRequest'
+      responses:
+        '200':
+          description: Trip ended.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: No active trip matched the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        JWT bearer token issued by `POST /api/v1/auth/login`. Signed HS256,
+        24-hour TTL, `iss: vehicle-positions-api`.
+
+  parameters:
+    VehicleIDPath:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 50
+        pattern: '^[a-zA-Z0-9._-]+$'
+      description: Vehicle identifier.
+    UserIDPath:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+      description: User identifier.
+
+  responses:
+    BadRequest:
+      description: Invalid request.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Unauthorized:
+      description: Missing or invalid bearer token.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Forbidden:
+      description: Caller lacks the required role.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    PayloadTooLarge:
+      description: Request body exceeded the handler's size limit.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    UnsupportedMediaType:
+      description: Content-Type must be `application/json`.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    InternalError:
+      description: Internal server error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  schemas:
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          description: Human-readable error message (matches the `writeJSON` helper).
+
+    StatusResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password
+
+    LoginResponse:
+      type: object
+      required: [token]
+      properties:
+        token:
+          type: string
+          description: JWT bearer token (HS256, 24-hour TTL).
+
+    LocationReport:
+      type: object
+      additionalProperties: false
+      required: [vehicle_id, latitude, longitude, timestamp]
+      properties:
+        vehicle_id:
+          type: string
+          minLength: 1
+          maxLength: 50
+          pattern: '^[a-zA-Z0-9._-]+$'
+        trip_id:
+          type: string
+          description: Optional GTFS trip identifier the driver is currently operating.
+        latitude:
+          type: number
+          format: double
+          minimum: -90
+          maximum: 90
+        longitude:
+          type: number
+          format: double
+          minimum: -180
+          maximum: 180
+        bearing:
+          type: [number, 'null']
+          format: double
+          minimum: 0
+          maximum: 360
+          description: Compass heading in degrees. May be null or omitted if unknown.
+        speed:
+          type: [number, 'null']
+          format: double
+          minimum: 0
+          description: Ground speed in metres per second. May be null or omitted if unknown.
+        accuracy:
+          type: [number, 'null']
+          format: double
+          minimum: 0
+          description: GPS horizontal accuracy in metres. May be null or omitted if unknown.
+        timestamp:
+          type: integer
+          format: int64
+          description: |
+            Unix seconds. Must be within 5 minutes of the server clock;
+            reports outside that window are rejected with 400.
+
+    UpsertVehicleRequest:
+      type: object
+      additionalProperties: false
+      required: [id]
+      properties:
+        id:
+          type: string
+          minLength: 1
+          maxLength: 50
+          pattern: '^[a-zA-Z0-9._-]+$'
+        label:
+          type: string
+          maxLength: 255
+        agency_tag:
+          type: string
+          maxLength: 255
+
+    Vehicle:
+      type: object
+      required: [id, label, agency_tag, active, created_at, updated_at]
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        agency_tag:
+          type: string
+        active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CreateUserRequest:
+      type: object
+      additionalProperties: false
+      required: [name, email, password, role]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password
+          minLength: 8
+        role:
+          type: string
+          enum: [driver, admin]
+
+    UpdateUserRequest:
+      type: object
+      additionalProperties: false
+      required: [name, email, role]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          enum: [driver, admin]
+
+    User:
+      type: object
+      required: [id, name, email, role, created_at, updated_at]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          enum: [driver, admin]
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    StartTripRequest:
+      type: object
+      additionalProperties: false
+      required: [vehicle_id]
+      properties:
+        vehicle_id:
+          type: string
+          minLength: 1
+          maxLength: 50
+          pattern: '^[a-zA-Z0-9._-]+$'
+        route_id:
+          type: string
+          maxLength: 100
+        gtfs_trip_id:
+          type: string
+          maxLength: 100
+
+    EndTripRequest:
+      type: object
+      additionalProperties: false
+      required: [trip_id]
+      properties:
+        trip_id:
+          type: integer
+          format: int64
+          minimum: 1
+
+    Trip:
+      type: object
+      required:
+        - id
+        - user_id
+        - vehicle_id
+        - route_id
+        - gtfs_trip_id
+        - start_time
+        - status
+      properties:
+        id:
+          type: integer
+          format: int64
+        user_id:
+          type: integer
+          format: int64
+        vehicle_id:
+          type: string
+        route_id:
+          type: string
+        gtfs_trip_id:
+          type: string
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+          description: |
+            Present only on completed trips. The server omits this field
+            while the trip is active (Go `*time.Time` with `omitempty`).
+        status:
+          type: string
+          enum: [active, completed]
+
+    AdminStatus:
+      type: object
+      required:
+        - status
+        - uptime_seconds
+        - active_vehicles
+        - total_vehicles_tracked
+      properties:
+        status:
+          type: string
+        uptime_seconds:
+          type: integer
+          format: int64
+          minimum: 0
+        active_vehicles:
+          type: integer
+          minimum: 0
+        total_vehicles_tracked:
+          type: integer
+          minimum: 0
+        last_update:
+          type: string
+          format: date-time
+          description: |
+            Timestamp of the most recent location report. Omitted when no
+            vehicle has reported yet (Go `*time.Time` with `omitempty`).

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,10 +9,22 @@ info:
     built for transit agencies in developing countries that have a GTFS static
     feed and a fleet of Android phones but no AVL infrastructure.
 
-    This document describes every HTTP endpoint currently registered in
-    `main.go`. Schemas, validation rules, and status codes are derived
-    directly from the handler source — see `openapi_test.go`, which asserts
-    that the spec and the code cannot drift apart.
+    This document describes every JSON API endpoint the server registers.
+    Schemas, validation rules, and status codes are derived directly from the
+    handler source.
+
+    `openapi_test.go` parses the server's Go source and holds this file to
+    it: routes must match the mux registrations in both directions, every
+    route behind `requireAuth` / `requireAdmin` must declare the matching
+    `401` / `403`, and the validation keywords that mirror a Go constant
+    must equal it. What none of that reaches is prose — descriptions still
+    have to be read against the handlers by hand.
+
+    Out of scope: the server-rendered admin UI (`/admin/*`, `/static/*`),
+    which is HTML rather than JSON and is registered only when
+    `ADMIN_UI_ENABLED` is set. Those routes are listed explicitly in
+    `openapi_test.go` so that adding one is a deliberate decision rather
+    than an invisible gap.
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
@@ -305,12 +317,7 @@ paths:
     get:
       tags: [admin]
       summary: List all users
-      description: |
-        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
-        only requires a valid bearer token — the admin-role check is
-        missing from the handler. Tracked by PR #79, which adds
-        `requireAdmin` to this route; when that merges, a `403` response
-        will be added here.
+      description: Requires the `admin` role.
       responses:
         '200':
           description: Users.
@@ -322,19 +329,15 @@ paths:
                   $ref: '#/components/schemas/User'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
     post:
       tags: [admin]
       summary: Create a user
       description: |
-        Request bodies are capped at 1 KiB.
-
-        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
-        only requires a valid bearer token — the admin-role check is
-        missing from the handler. Tracked by PR #79, which adds
-        `requireAdmin` to this route; when that merges, a `403` response
-        will be added here.
+        Requires the `admin` role. Request bodies are capped at 1 KiB.
       requestBody:
         required: true
         content:
@@ -352,6 +355,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '409':
           description: Email already exists.
           content:
@@ -369,12 +374,7 @@ paths:
     get:
       tags: [admin]
       summary: Get a user by id
-      description: |
-        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
-        only requires a valid bearer token — the admin-role check is
-        missing from the handler. Tracked by PR #79, which adds
-        `requireAdmin` to this route; when that merges, a `403` response
-        will be added here.
+      description: Requires the `admin` role.
       responses:
         '200':
           description: User.
@@ -386,6 +386,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -394,13 +396,8 @@ paths:
       tags: [admin]
       summary: Update a user
       description: |
-        Updates name, email, and role. Request bodies are capped at 1 KiB.
-
-        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
-        only requires a valid bearer token — the admin-role check is
-        missing from the handler. Tracked by PR #79, which adds
-        `requireAdmin` to this route; when that merges, a `403` response
-        will be added here.
+        Updates name, email, and role. Requires the `admin` role. Request
+        bodies are capped at 1 KiB.
       requestBody:
         required: true
         content:
@@ -418,6 +415,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
@@ -433,12 +432,7 @@ paths:
     delete:
       tags: [admin]
       summary: Delete a user
-      description: |
-        **Note:** unlike other `/api/v1/admin/*` endpoints, this currently
-        only requires a valid bearer token — the admin-role check is
-        missing from the handler. Tracked by PR #79, which adds
-        `requireAdmin` to this route; when that merges, a `403` response
-        will be added here.
+      description: Requires the `admin` role.
       responses:
         '204':
           description: User deleted.
@@ -446,8 +440,151 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/assignments:
+    post:
+      tags: [admin]
+      summary: Assign a driver to a vehicle
+      description: |
+        Links a driver to a vehicle. A driver must hold an assignment for a
+        vehicle before `POST /api/v1/trips/start` will accept a trip on it.
+        Requires the `admin` role. Request bodies are capped at 1 KiB.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAssignmentRequest'
+      responses:
+        '201':
+          description: Assignment created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Assignment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: |
+            The referenced user or vehicle does not exist. Surfaced from the
+            foreign-key violation, so the message is either `user not found`
+            or `vehicle not found`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: This driver is already assigned to this vehicle.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/users/{id}/vehicles:
+    parameters:
+      - $ref: '#/components/parameters/UserIDPath'
+    get:
+      tags: [admin]
+      summary: List the vehicles assigned to a driver
+      description: |
+        Requires the `admin` role. The handler validates the id but does not
+        check that the user exists, so an unknown id returns `200` with an
+        empty array rather than `404`.
+      responses:
+        '200':
+          description: Assignments held by this driver.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Assignment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/users/{userID}/vehicles/{vehicleID}:
+    parameters:
+      - $ref: '#/components/parameters/AssignmentUserIDPath'
+      - $ref: '#/components/parameters/AssignmentVehicleIDPath'
+    delete:
+      tags: [admin]
+      summary: Remove a driver's vehicle assignment
+      description: |
+        Deletes the assignment linking a driver to a vehicle. Requires the
+        `admin` role. Unlike the other delete endpoints in this API, this one
+        answers `200` with a status body rather than `204`.
+      responses:
+        '200':
+          description: Assignment removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: No assignment links this driver to this vehicle.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/vehicles/{id}/users:
+    parameters:
+      - $ref: '#/components/parameters/VehicleIDPath'
+    get:
+      tags: [admin]
+      summary: List the drivers assigned to a vehicle
+      description: |
+        Requires the `admin` role. The handler validates the id but does not
+        check that the vehicle exists, so an unknown id returns `200` with an
+        empty array rather than `404`.
+      responses:
+        '200':
+          description: |
+            Assignments on this vehicle. Each item is the same `Assignment`
+            object returned by the user-scoped listing, so `vehicle_id` is
+            constant across the array.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Assignment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
 
@@ -546,10 +683,7 @@ components:
       in: path
       required: true
       schema:
-        type: string
-        minLength: 1
-        maxLength: 50
-        pattern: '^[a-zA-Z0-9._-]+$'
+        $ref: '#/components/schemas/VehicleID'
       description: Vehicle identifier.
     UserIDPath:
       name: id
@@ -560,6 +694,22 @@ components:
         format: int64
         minimum: 1
       description: User identifier.
+    AssignmentUserIDPath:
+      name: userID
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+      description: User identifier.
+    AssignmentVehicleIDPath:
+      name: vehicleID
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/VehicleID'
+      description: Vehicle identifier.
 
   responses:
     BadRequest:
@@ -606,6 +756,18 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
 
   schemas:
+    # Every vehicle-id-shaped field references this schema instead of
+    # restating the constraints, so the drift guard has a single place to
+    # compare against vehicleIDPattern / maxVehicleIDLength in handlers.go.
+    VehicleID:
+      type: string
+      minLength: 1
+      maxLength: 50
+      pattern: '^[a-zA-Z0-9._-]+$'
+      description: |
+        Agency-assigned vehicle identifier. Constraints mirror
+        `maxVehicleIDLength` and `vehicleIDPattern` in `handlers.go`.
+
     ErrorResponse:
       type: object
       required: [error]
@@ -644,15 +806,20 @@ components:
       type: object
       additionalProperties: false
       required: [vehicle_id, latitude, longitude, timestamp]
+      description: |
+        A single GPS fix. Beyond the per-field constraints below, the handler
+        rejects reports where `latitude` and `longitude` are *both* zero —
+        null island is far likelier to be a failed fix than a real position.
+        That is a cross-field rule no JSON Schema keyword can express, so it
+        is stated here rather than encoded.
       properties:
         vehicle_id:
-          type: string
-          minLength: 1
-          maxLength: 50
-          pattern: '^[a-zA-Z0-9._-]+$'
+          $ref: '#/components/schemas/VehicleID'
         trip_id:
           type: string
-          description: Optional GTFS trip identifier the driver is currently operating.
+          description: |
+            Optional GTFS trip identifier the driver is currently operating.
+            Not validated — any string is accepted and stored verbatim.
         latitude:
           type: number
           format: double
@@ -673,18 +840,24 @@ components:
           type: [number, 'null']
           format: double
           minimum: 0
-          description: Ground speed in metres per second. May be null or omitted if unknown.
+          description: |
+            Ground speed in metres per second. Rejected if negative; there is
+            no upper bound. May be null or omitted if unknown.
         accuracy:
           type: [number, 'null']
           format: double
-          minimum: 0
-          description: GPS horizontal accuracy in metres. May be null or omitted if unknown.
+          description: |
+            GPS horizontal accuracy in metres. May be null or omitted if
+            unknown. Unlike `bearing` and `speed`, this field is not
+            validated — any value the JSON decoder accepts is stored.
         timestamp:
           type: integer
           format: int64
+          minimum: 1
           description: |
-            Unix seconds. Must be within 5 minutes of the server clock;
-            reports outside that window are rejected with 400.
+            Unix seconds. Must be positive and within 5 minutes of the server
+            clock in either direction; reports outside that window are
+            rejected with 400.
 
     UpsertVehicleRequest:
       type: object
@@ -692,10 +865,7 @@ components:
       required: [id]
       properties:
         id:
-          type: string
-          minLength: 1
-          maxLength: 50
-          pattern: '^[a-zA-Z0-9._-]+$'
+          $ref: '#/components/schemas/VehicleID'
         label:
           type: string
           maxLength: 255
@@ -708,7 +878,7 @@ components:
       required: [id, label, agency_tag, active, created_at, updated_at]
       properties:
         id:
-          type: string
+          $ref: '#/components/schemas/VehicleID'
         label:
           type: string
         agency_tag:
@@ -778,16 +948,38 @@ components:
           type: string
           format: date-time
 
+    CreateAssignmentRequest:
+      type: object
+      additionalProperties: false
+      required: [user_id, vehicle_id]
+      properties:
+        user_id:
+          type: integer
+          format: int64
+          minimum: 1
+        vehicle_id:
+          $ref: '#/components/schemas/VehicleID'
+
+    Assignment:
+      type: object
+      required: [user_id, vehicle_id, created_at]
+      properties:
+        user_id:
+          type: integer
+          format: int64
+        vehicle_id:
+          $ref: '#/components/schemas/VehicleID'
+        created_at:
+          type: string
+          format: date-time
+
     StartTripRequest:
       type: object
       additionalProperties: false
       required: [vehicle_id]
       properties:
         vehicle_id:
-          type: string
-          minLength: 1
-          maxLength: 50
-          pattern: '^[a-zA-Z0-9._-]+$'
+          $ref: '#/components/schemas/VehicleID'
         route_id:
           type: string
           maxLength: 100
@@ -823,7 +1015,7 @@ components:
           type: integer
           format: int64
         vehicle_id:
-          type: string
+          $ref: '#/components/schemas/VehicleID'
         route_id:
           type: string
         gtfs_trip_id:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -48,6 +48,8 @@ tags:
     description: Driver trip lifecycle.
   - name: vehicles
     description: Driver-facing vehicle access.
+  - name: rider
+    description: Crowd-sourced positioning from rider devices.
 
 # All endpoints require a bearer JWT unless they explicitly opt out with `security: []`.
 security:
@@ -166,6 +168,266 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/v1/rider/register:
+    post:
+      tags: [rider]
+      summary: Register a rider device
+      description: |
+        Exchanges a device installation for a rider token. This is the only
+        rider endpoint open to an unauthenticated caller.
+
+        Registration is idempotent per installation: a known `installation_id`
+        answers `200`, a new one `201`. The response carries the cadence the
+        server wants, so clients take their batch size and interval from here
+        rather than hard-coding them.
+
+        Bodies are capped at 64 KiB and rate-limited per client.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RiderRegisterRequest'
+      responses:
+        '200':
+          description: Existing installation; the token is reissued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiderRegisterResponse'
+        '201':
+          description: New installation registered.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiderRegisterResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '429':
+          description: Too many registrations from this client.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/rider/rides:
+    post:
+      tags: [rider]
+      summary: Start a ride
+      description: |
+        Declares that the rider has boarded a trip, so their positions can be
+        matched against its shape.
+
+        `422` means the request was well-formed but the trip could not be
+        matched against the loaded schedule; `503` means no schedule is
+        loaded at all.
+      security:
+        - riderAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartRideRequest'
+      responses:
+        '201':
+          description: Ride started.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StartRideResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: No such trip in the loaded schedule.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: This rider already has a ride in progress.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '422':
+          description: The trip could not be matched against the schedule.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Rides are being started too quickly for this rider.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ScheduleUnavailable'
+
+  /api/v1/rider/rides/{id}/positions:
+    parameters:
+      - $ref: '#/components/parameters/RideIDPath'
+    post:
+      tags: [rider]
+      summary: Upload a batch of positions
+      description: |
+        Submits a batch of fixes for a ride. The response reports what was
+        accepted, whether the ride is now publishable, and whether the server
+        ended it — a rider who has drifted off the route for long enough is
+        ended server-side, reported through `ended` and `end_reason` rather
+        than an error status.
+
+        Batches are capped at 12 positions and 64 KiB, and rate-limited to
+        the advertised reporting interval.
+      security:
+        - riderAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PositionsRequest'
+      responses:
+        '200':
+          description: Batch processed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PositionsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: The ride is not in a state that accepts positions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '429':
+          description: Batches are arriving faster than the reporting interval allows.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/rider/rides/{id}/end:
+    parameters:
+      - $ref: '#/components/parameters/RideIDPath'
+    post:
+      tags: [rider]
+      summary: End a ride
+      description: Closes a ride and reports what it contributed.
+      security:
+        - riderAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EndRideRequest'
+      responses:
+        '200':
+          description: Ride ended.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EndRideResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: The ride has already ended.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          $ref: '#/components/responses/PayloadTooLarge'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '429':
+          description: Too many requests from this rider.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/rider/trips/{trip_id}/status:
+    parameters:
+      - $ref: '#/components/parameters/TripGTFSIDPath'
+    get:
+      tags: [rider]
+      summary: Whether a trip is already covered
+      description: |
+        Tells a client whether a trip already has a trusted AVL feed or other
+        riders reporting, so it can decide not to spend battery duplicating
+        coverage.
+      security:
+        - riderAuth: []
+      parameters:
+        - in: query
+          name: start_date
+          required: false
+          schema:
+            type: string
+            pattern: '^[0-9]{8}$'
+          description: |
+            GTFS service date as `YYYYMMDD`. Defaults to the service date the
+            loaded schedule considers current.
+      responses:
+        '200':
+          description: Coverage for this trip.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TripCoverage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: No such trip in the loaded schedule.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ScheduleUnavailable'
+
   /gtfs-rt/vehicle-positions:
     get:
       tags: [feed]
@@ -235,6 +497,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusResponse'
+
+  /api/v1/admin/rider/status:
+    get:
+      tags: [admin]
+      summary: Rider subsystem health
+      description: |
+        Reports the rider engine's state: the schedule snapshot it is matching
+        against, the trusted feeds it corroborates with, and current rider and
+        ride counts. Requires the `admin` role.
+
+        Rider mode being off is a fact about the server, not an error — a
+        disabled server answers `200` with `enabled: false` and omits the
+        detail sections rather than returning `404`.
+      responses:
+        '200':
+          description: Rider subsystem status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RiderStatus'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/rider/rides:
+    get:
+      tags: [admin]
+      summary: List rider rides
+      description: |
+        Lists rides newest-first, filtered by status. Requires the `admin`
+        role. Like the other admin lists, one row beyond `limit` is read to
+        set `has_more`.
+      parameters:
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+            enum: [active, ended]
+            default: active
+          description: Which rides to return. Defaults to `active`.
+        - in: query
+          name: limit
+          required: false
+          schema:
+            $ref: '#/components/schemas/RiderRideListLimit'
+          description: Maximum number of rides to return.
+        - in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+          description: Number of rides to skip.
+      responses:
+        '200':
+          description: Matching rides.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminRides'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
 
   /api/v1/admin/status:
     get:
@@ -977,6 +1312,16 @@ components:
         JWT bearer token issued by `POST /api/v1/auth/login`. Signed HS256,
         24-hour TTL, `iss: vehicle-positions-api`.
 
+    riderAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        JWT issued by `POST /api/v1/rider/register`, carrying the `rider`
+        role. It is not interchangeable with the driver/admin token from
+        `POST /api/v1/auth/login`: `requireRider` accepts only the rider
+        role, and the rest of the API rejects it.
+
   parameters:
     VehicleIDPath:
       name: id
@@ -1021,6 +1366,20 @@ components:
       schema:
         $ref: '#/components/schemas/ListOffset'
       description: Number of rows to skip.
+    RideIDPath:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Ride identifier returned by `POST /api/v1/rider/rides`.
+    TripGTFSIDPath:
+      name: trip_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: GTFS trip identifier from the loaded schedule.
     TripIDPath:
       name: id
       in: path
@@ -1071,6 +1430,13 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
     UnsupportedMediaType:
       description: Content-Type must be `application/json`.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    ScheduleUnavailable:
+      description: |
+        No GTFS schedule is loaded, so the rider engine cannot match trips.
       content:
         application/json:
           schema:
@@ -1353,6 +1719,375 @@ components:
           type: string
           format: date-time
           description: RFC 3339 UTC time the tracker last recorded this vehicle.
+
+    # Named so the drift guard has a stable address to pin against
+    # defaultRiderRideListLimit / maxRiderRideListLimit in
+    # rider_admin_handlers.go.
+    RiderRideListLimit:
+      type: integer
+      minimum: 1
+      maximum: 200
+      default: 50
+
+    RiderRegisterRequest:
+      type: object
+      additionalProperties: false
+      required: [installation_id, platform, app_id, app_version, attestation]
+      properties:
+        installation_id:
+          type: string
+          maxLength: 100
+          description: Stable per-install identifier. Re-registering with the same value reissues the token.
+        platform:
+          type: string
+          maxLength: 100
+        app_id:
+          type: string
+          maxLength: 100
+        app_version:
+          type: string
+          maxLength: 100
+        attestation:
+          type: ['object', 'null']
+          description: |
+            Opaque platform attestation, passed through to the configured
+            verifier. Null when the client has none to offer.
+
+    RiderRegisterResponse:
+      type: object
+      required: [rider_id, token, report_interval_seconds, max_batch_size]
+      properties:
+        rider_id:
+          type: string
+        token:
+          type: string
+          description: Rider JWT for the `riderAuth` scheme.
+        report_interval_seconds:
+          type: integer
+          description: How often the server wants position batches.
+        max_batch_size:
+          type: integer
+          description: Largest batch the positions endpoint will accept.
+
+    StartRideRequest:
+      type: object
+      additionalProperties: false
+      required: [trip_id, start_date, route_id, vehicle_id, boarding_stop_id, destination_stop_id]
+      properties:
+        trip_id:
+          type: string
+          maxLength: 100
+        start_date:
+          type: string
+          pattern: '^[0-9]{8}$'
+          description: GTFS service date as `YYYYMMDD`.
+        route_id:
+          type: string
+          maxLength: 100
+        vehicle_id:
+          type: string
+          maxLength: 100
+          description: |
+            Free text as the rider's app knows it. Unlike the driver API this
+            is not held to `VehicleID` — it is a hint, not a key.
+        boarding_stop_id:
+          type: string
+          maxLength: 100
+        destination_stop_id:
+          type: string
+          maxLength: 100
+
+    StartRideResponse:
+      type: object
+      required: [ride_id, state, report_interval_seconds, max_batch_size]
+      properties:
+        ride_id:
+          type: string
+        state:
+          type: string
+          description: The ride's initial matching state.
+        report_interval_seconds:
+          type: integer
+        max_batch_size:
+          type: integer
+        destination:
+          $ref: '#/components/schemas/RideDestination'
+
+    RideDestination:
+      type: object
+      description: |
+        Where the rider said they are getting off, resolved to a position.
+        Omitted when the destination stop could not be placed.
+      required: [stop_id, latitude, longitude]
+      properties:
+        stop_id:
+          type: string
+        latitude:
+          type: number
+          format: double
+        longitude:
+          type: number
+          format: double
+
+    PositionsRequest:
+      type: object
+      additionalProperties: false
+      required: [positions]
+      properties:
+        positions:
+          type: array
+          maxItems: 12
+          items:
+            $ref: '#/components/schemas/PositionUpload'
+
+    PositionUpload:
+      type: object
+      additionalProperties: false
+      description: |
+        One fix from the device. `accuracy`, `speed`, and `bearing` are
+        required and nullable: a device with no reading must be able to say so
+        rather than claim a zero.
+      required: [latitude, longitude, accuracy, speed, bearing, timestamp]
+      properties:
+        latitude:
+          type: number
+          format: double
+        longitude:
+          type: number
+          format: double
+        accuracy:
+          type: [number, 'null']
+          format: double
+        speed:
+          type: [number, 'null']
+          format: double
+        bearing:
+          type: [number, 'null']
+          format: double
+        timestamp:
+          type: integer
+          format: int64
+          description: Unix seconds.
+
+    PositionsResponse:
+      type: object
+      required:
+        - state
+        - published
+        - corroboration
+        - accepted
+        - ignored
+        - off_route_streak
+        - ended
+        - end_reason
+      properties:
+        state:
+          type: string
+          description: The ride's matching state after this batch.
+        published:
+          type: boolean
+          description: Whether the ride is now contributing to the public feed.
+        corroboration:
+          type: string
+        accepted:
+          type: integer
+        ignored:
+          type: integer
+          description: Fixes discarded as off-route, stale, or duplicated.
+        off_route_streak:
+          type: integer
+        ended:
+          type: boolean
+          description: |
+            True when the server ended the ride itself, typically after a long
+            off-route streak. The batch still returns 200.
+        end_reason:
+          type: string
+          description: Empty unless `ended` is true.
+
+    EndRideRequest:
+      type: object
+      additionalProperties: false
+      required: [reason]
+      properties:
+        reason:
+          type: string
+          maxLength: 100
+
+    EndRideResponse:
+      type: object
+      required: [status, summary]
+      properties:
+        status:
+          type: string
+        summary:
+          $ref: '#/components/schemas/RideSummary'
+
+    RideSummary:
+      type: object
+      required: [points, matched, corroborated, duration_seconds]
+      properties:
+        points:
+          type: integer
+        matched:
+          type: integer
+        corroborated:
+          type: integer
+        duration_seconds:
+          type: integer
+
+    TripCoverage:
+      type: object
+      required: [trip_id, start_date, trusted, rider_reported, riders]
+      properties:
+        trip_id:
+          type: string
+        start_date:
+          type: string
+          pattern: '^[0-9]{8}$'
+        trusted:
+          type: boolean
+          description: A trusted AVL feed already covers this trip.
+        rider_reported:
+          type: boolean
+          description: At least one rider is currently positioning this trip.
+        riders:
+          type: integer
+          description: How many riders are reporting it.
+
+    RiderStatus:
+      type: object
+      description: |
+        The detail sections are omitted when rider mode is off, so a disabled
+        server answers `{"enabled": false}`.
+      required: [enabled]
+      properties:
+        enabled:
+          type: boolean
+        gtfs:
+          $ref: '#/components/schemas/RiderGTFSStatus'
+        trusted_feeds:
+          type: array
+          items:
+            $ref: '#/components/schemas/RiderFeedStatus'
+        riders:
+          $ref: '#/components/schemas/RiderTierCounts'
+        rides:
+          $ref: '#/components/schemas/RiderRideCounts'
+
+    RiderGTFSStatus:
+      type: object
+      required: [source, loaded_at, trips, shapes, timezone]
+      properties:
+        source:
+          type: string
+        loaded_at:
+          type: string
+          format: date-time
+        trips:
+          type: integer
+        shapes:
+          type: integer
+        timezone:
+          type: string
+
+    RiderFeedStatus:
+      type: object
+      required: [url, last_success, last_error, entities]
+      properties:
+        url:
+          type: string
+        last_success:
+          type: string
+          description: RFC 3339 UTC, or an empty string if the feed has never succeeded.
+        last_error:
+          type: string
+        entities:
+          type: integer
+
+    RiderTierCounts:
+      type: object
+      required: [total, trusted, blocked]
+      properties:
+        total:
+          type: integer
+        trusted:
+          type: integer
+        blocked:
+          type: integer
+
+    RiderRideCounts:
+      type: object
+      required: [active, publishable]
+      properties:
+        active:
+          type: integer
+        publishable:
+          type: integer
+
+    AdminRides:
+      type: object
+      required: [count, has_more, rides]
+      properties:
+        count:
+          type: integer
+        has_more:
+          type: boolean
+        rides:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminRide'
+
+    AdminRide:
+      type: object
+      required:
+        - id
+        - rider_id
+        - trip_id
+        - start_date
+        - route_id
+        - state
+        - corroborated
+        - status
+        - end_reason
+        - points_total
+        - points_matched
+        - points_corroborated
+        - started_at
+        - ended_at
+      properties:
+        id:
+          type: string
+        rider_id:
+          type: string
+        trip_id:
+          type: string
+        start_date:
+          type: string
+        route_id:
+          type: string
+        state:
+          type: string
+        corroborated:
+          type: boolean
+        status:
+          type: string
+          enum: [active, ended]
+        end_reason:
+          type: string
+        points_total:
+          type: integer
+        points_matched:
+          type: integer
+        points_corroborated:
+          type: integer
+        started_at:
+          type: string
+          format: date-time
+        ended_at:
+          type: [string, 'null']
+          format: date-time
+          description: Null while the ride is still active.
 
     # Named so the drift guard has a stable address to pin against
     # defaultListLimit / maxListLimit in handlers.go.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,10 +21,10 @@ info:
     have to be read against the handlers by hand.
 
     Out of scope: the server-rendered admin UI (`/admin/*`, `/static/*`),
-    which is HTML rather than JSON and is registered only when
-    `ADMIN_UI_ENABLED` is set. Those routes are listed explicitly in
-    `openapi_test.go` so that adding one is a deliberate decision rather
-    than an invisible gap.
+    which serves HTML pages and form posts rather than JSON and is disabled
+    by setting `ADMIN_UI_ENABLED` to a false value (it is on by default).
+    Those routes are listed explicitly in `openapi_test.go` so that adding
+    one is a deliberate decision rather than an invisible gap.
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
@@ -84,6 +84,14 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           description: Invalid email or password.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: |
+            Too many login attempts. The limiter keys on client IP and the
+            submitted email; a successful login clears the email's counter.
           content:
             application/json:
               schema:
@@ -297,6 +305,34 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/v1/admin/vehicles/live:
+    get:
+      tags: [admin]
+      summary: Snapshot of currently reporting vehicles
+      description: |
+        Returns every vehicle the tracker considers active — those that have
+        reported within `STALENESS_THRESHOLD` — joined with the vehicle's
+        label and, where a trip is running, that trip's route and driver.
+        Ordered by `vehicle_id`. Requires the `admin` role.
+
+        This reads the in-memory tracker rather than the locations table, so
+        it reflects live state, not history. Use
+        `GET /api/v1/admin/vehicles/{vehicleID}/locations` for the recorded
+        trail.
+      responses:
+        '200':
+          description: Active vehicles.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LiveVehicles'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /api/v1/admin/vehicles/{id}:
     parameters:
       - $ref: '#/components/parameters/VehicleIDPath'
@@ -418,6 +454,100 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           description: No vehicle exists with this id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/trips:
+    get:
+      tags: [admin]
+      summary: List trips
+      description: |
+        Returns trips newest-first with the vehicle label and driver name
+        resolved. Requires the `admin` role.
+
+        Paging is offset-based. The handler reads one row past `limit` to set
+        `has_more`, so a truncated page is distinguishable from an exact fit.
+      parameters:
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+            enum: ['', active, completed]
+          description: Filter by trip status. Omit or pass an empty string for all trips.
+        - in: query
+          name: vehicle_id
+          required: false
+          schema:
+            type: string
+          description: Restrict to one vehicle. Omit for all vehicles.
+        - in: query
+          name: q
+          required: false
+          schema:
+            type: string
+          description: Free-text search across the trip's vehicle, driver, and route fields.
+        - in: query
+          name: limit
+          required: false
+          schema:
+            $ref: '#/components/schemas/TripListLimit'
+          description: Maximum number of trips to return.
+        - in: query
+          name: offset
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+          description: Number of trips to skip.
+      responses:
+        '200':
+          description: Matching trips.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TripList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/trips/{id}/locations:
+    parameters:
+      - $ref: '#/components/parameters/TripIDPath'
+    get:
+      tags: [admin]
+      summary: Get a trip with its recorded trail
+      description: |
+        Returns the trip summary together with every location fix recorded
+        against it, oldest first. Requires the `admin` role.
+
+        A non-numeric `id` returns `404` rather than `400` — the handler
+        treats an unparseable id as a trip that does not exist.
+      responses:
+        '200':
+          description: |
+            Trip and its trail. `points` is an empty array for a trip with no
+            recorded fixes; the `trip` object is still returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TripTrail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: No trip exists with this id, or the id is not a number.
           content:
             application/json:
               schema:
@@ -819,6 +949,15 @@ components:
     # path variable differently: most use {id}, while the assignment-delete and
     # location-history routes use {vehicleID}. OpenAPI requires `name` to match
     # the template variable, so the pair cannot be collapsed.
+    TripIDPath:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+        minimum: 1
+      description: Trip identifier.
     VehicleIDPathNamed:
       name: vehicleID
       in: path
@@ -1063,6 +1202,199 @@ components:
         updated_at:
           type: string
           format: date-time
+
+    LiveVehicles:
+      type: object
+      required: [count, vehicles]
+      properties:
+        count:
+          type: integer
+          minimum: 0
+        vehicles:
+          type: array
+          items:
+            $ref: '#/components/schemas/LiveVehicleEntry'
+
+    LiveVehicleEntry:
+      type: object
+      description: |
+        A vehicle's current tracker state. `trip_db_id`, `route_id`, and
+        `driver_name` are populated only while a trip is running on the
+        vehicle and are explicitly `null` otherwise — none carry `omitempty`,
+        so the key is always present. Likewise `bearing` and `speed` are
+        `null` when the device did not report them, keeping "unknown"
+        distinct from a real zero.
+      required:
+        - vehicle_id
+        - label
+        - latitude
+        - longitude
+        - bearing
+        - speed
+        - gtfs_trip_id
+        - trip_db_id
+        - route_id
+        - driver_name
+        - reported_at
+        - updated_at
+      properties:
+        vehicle_id:
+          $ref: '#/components/schemas/VehicleID'
+        label:
+          type: string
+          description: |
+            The vehicle's label, or the vehicle id when the vehicle has no
+            row in the vehicles table.
+        latitude:
+          type: number
+          format: double
+        longitude:
+          type: number
+          format: double
+        bearing:
+          type: [number, 'null']
+          format: double
+        speed:
+          type: [number, 'null']
+          format: double
+        gtfs_trip_id:
+          type: string
+          description: The GTFS trip id from the last location report. Empty when none was sent.
+        trip_db_id:
+          type: [integer, 'null']
+          format: int64
+          description: Database id of the active trip, or null when no trip is running.
+        route_id:
+          type: [string, 'null']
+        driver_name:
+          type: [string, 'null']
+        reported_at:
+          type: integer
+          format: int64
+          description: Device timestamp of the last fix, Unix seconds.
+        updated_at:
+          type: string
+          format: date-time
+          description: RFC 3339 UTC time the tracker last recorded this vehicle.
+
+    # Named so the drift guard has a stable address to pin against
+    # defaultTripListLimit / maxTripListLimit in admin_live_handlers.go.
+    TripListLimit:
+      type: integer
+      minimum: 1
+      maximum: 200
+      default: 50
+
+    TripList:
+      type: object
+      required: [count, has_more, trips]
+      properties:
+        count:
+          type: integer
+          minimum: 0
+          description: Number of trips in `trips`, after the `limit` cap is applied.
+        has_more:
+          type: boolean
+          description: True when more trips match the filter than this page returned.
+        trips:
+          type: array
+          items:
+            $ref: '#/components/schemas/TripSummary'
+
+    TripSummary:
+      type: object
+      description: |
+        A trip with its vehicle label and driver name resolved. Distinct from
+        `Trip`, which is what the driver-facing trip endpoints return.
+      required:
+        - id
+        - vehicle_id
+        - vehicle_label
+        - user_id
+        - driver_name
+        - route_id
+        - gtfs_trip_id
+        - start_time
+        - status
+      properties:
+        id:
+          type: integer
+          format: int64
+        vehicle_id:
+          $ref: '#/components/schemas/VehicleID'
+        vehicle_label:
+          type: string
+        user_id:
+          type: integer
+          format: int64
+        driver_name:
+          type: string
+        route_id:
+          type: string
+        gtfs_trip_id:
+          type: string
+        start_time:
+          type: string
+          format: date-time
+        end_time:
+          type: string
+          format: date-time
+          description: |
+            Present only on completed trips. The server omits this field while
+            the trip is active (Go `*time.Time` with `omitempty`).
+        status:
+          type: string
+          enum: [active, completed]
+
+    TripTrail:
+      type: object
+      required: [trip, points]
+      properties:
+        trip:
+          $ref: '#/components/schemas/TripSummary'
+        points:
+          type: array
+          items:
+            $ref: '#/components/schemas/TripTrailPoint'
+
+    TripTrailPoint:
+      type: object
+      description: |
+        `bearing`, `speed`, and `accuracy` are required and nullable for the
+        same reason as elsewhere: the Go fields are pointers without
+        `omitempty`, so an absent reading is `null` rather than missing.
+      required:
+        - latitude
+        - longitude
+        - bearing
+        - speed
+        - accuracy
+        - reported_at
+        - received_at
+      properties:
+        latitude:
+          type: number
+          format: double
+        longitude:
+          type: number
+          format: double
+        bearing:
+          type: [number, 'null']
+          format: double
+        speed:
+          type: [number, 'null']
+          format: double
+        accuracy:
+          type: [number, 'null']
+          format: double
+        reported_at:
+          type: integer
+          format: int64
+          description: Device timestamp, Unix seconds.
+        received_at:
+          type: string
+          format: date-time
+          description: RFC 3339 UTC timestamp of when the server stored the fix.
 
     # Named so the drift guard has a stable address to pin against
     # defaultHistoryLimit / maxHistoryLimit in location_history_handlers.go.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -256,17 +256,23 @@ paths:
   /api/v1/admin/vehicles:
     get:
       tags: [admin]
-      summary: List all vehicles
-      description: Requires the `admin` role.
+      summary: List vehicles
+      description: |
+        Returns one page of active vehicles. Requires the `admin` role.
+      parameters:
+        - $ref: '#/components/parameters/ListLimitQuery'
+        - $ref: '#/components/parameters/ListOffsetQuery'
       responses:
         '200':
-          description: Vehicles.
+          description: Vehicles. A bare array — there is no paging envelope.
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Vehicle'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -486,11 +492,24 @@ paths:
             type: string
           description: Restrict to one vehicle. Omit for all vehicles.
         - in: query
+          name: user_id
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+          description: |
+            Restrict to one driver. Omit for all drivers; a present value must
+            be a positive integer.
+        - in: query
           name: q
           required: false
           schema:
             type: string
-          description: Free-text search across the trip's vehicle, driver, and route fields.
+          description: |
+            Case-insensitive substring search over driver name, route id, and
+            GTFS trip id. It does not search vehicle fields — use `vehicle_id`
+            for that.
         - in: query
           name: limit
           required: false
@@ -518,6 +537,39 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/trips/{id}:
+    parameters:
+      - $ref: '#/components/parameters/TripIDPath'
+    get:
+      tags: [admin]
+      summary: Get a trip by id
+      description: |
+        Returns one trip with its vehicle label and driver name resolved.
+        Requires the `admin` role.
+
+        As with the trail endpoint, a non-numeric `id` returns `404` rather
+        than `400` — an unparseable id is treated as a trip that does not
+        exist.
+      responses:
+        '200':
+          description: Trip.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TripSummary'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: No trip exists with this id, or the id is not a number.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           $ref: '#/components/responses/InternalError'
 
@@ -558,17 +610,23 @@ paths:
   /api/v1/admin/users:
     get:
       tags: [admin]
-      summary: List all users
-      description: Requires the `admin` role.
+      summary: List users
+      description: |
+        Returns one page of users. Requires the `admin` role.
+      parameters:
+        - $ref: '#/components/parameters/ListLimitQuery'
+        - $ref: '#/components/parameters/ListOffsetQuery'
       responses:
         '200':
-          description: Users.
+          description: Users. A bare array — there is no paging envelope.
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -949,6 +1007,20 @@ components:
     # path variable differently: most use {id}, while the assignment-delete and
     # location-history routes use {vehicleID}. OpenAPI requires `name` to match
     # the template variable, so the pair cannot be collapsed.
+    ListLimitQuery:
+      name: limit
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/ListLimit'
+      description: Maximum number of rows to return.
+    ListOffsetQuery:
+      name: offset
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/ListOffset'
+      description: Number of rows to skip.
     TripIDPath:
       name: id
       in: path
@@ -1183,7 +1255,7 @@ components:
 
     User:
       type: object
-      required: [id, name, email, role, created_at, updated_at]
+      required: [id, name, email, role, active, created_at, updated_at]
       properties:
         id:
           type: integer
@@ -1196,6 +1268,11 @@ components:
         role:
           type: string
           enum: [driver, admin]
+        active:
+          type: boolean
+          description: |
+            False once the account has been deactivated. Deactivated users
+            keep their rows so historical trips still resolve a driver.
         created_at:
           type: string
           format: date-time
@@ -1276,6 +1353,23 @@ components:
           type: string
           format: date-time
           description: RFC 3339 UTC time the tracker last recorded this vehicle.
+
+    # Named so the drift guard has a stable address to pin against
+    # defaultListLimit / maxListLimit in handlers.go.
+    ListLimit:
+      type: integer
+      minimum: 1
+      maximum: 200
+      default: 50
+
+    # maxListOffset is math.MaxInt32: the paged queries take an int32 offset,
+    # and a larger value would wrap negative and surface as a 500 rather than
+    # a 400.
+    ListOffset:
+      type: integer
+      minimum: 0
+      maximum: 2147483647
+      default: 0
 
     # Named so the drift guard has a stable address to pin against
     # defaultTripListLimit / maxTripListLimit in admin_live_handlers.go.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -46,6 +46,8 @@ tags:
     description: Administrative management endpoints.
   - name: trips
     description: Driver trip lifecycle.
+  - name: vehicles
+    description: Driver-facing vehicle access.
 
 # All endpoints require a bearer JWT unless they explicitly opt out with `security: []`.
 security:
@@ -127,6 +129,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/vehicles:
+    get:
+      tags: [vehicles]
+      summary: List the vehicles assigned to the authenticated driver
+      description: |
+        Returns the active vehicles the calling driver is assigned to. The
+        driver identity comes from the JWT `sub` claim, so there is no path
+        or query parameter. Requires a valid bearer token but not the
+        `admin` role — this is the driver-facing counterpart to
+        `GET /api/v1/admin/vehicles`.
+      responses:
+        '200':
+          description: |
+            Vehicles assigned to this driver. Empty array when the driver has
+            no active assignments.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vehicle'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalError'
 
@@ -310,6 +338,90 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/admin/vehicles/{vehicleID}/locations:
+    parameters:
+      - $ref: '#/components/parameters/VehicleIDPathNamed'
+    get:
+      tags: [admin]
+      summary: Export a vehicle's location history
+      description: |
+        Returns the GPS fixes recorded for a vehicle within a time window,
+        as JSON or as a CSV download. Requires the `admin` role.
+
+        The window defaults to the 24 hours ending at `to` rather than to
+        all of history, so an unbounded request cannot trigger a full-table
+        scan. Note that `from` defaults relative to `to`, not to the current
+        time: a `to` in the past selects the 24 hours ending there instead
+        of failing the `from <= to` check.
+
+        Results are capped by `limit`. The handler reads one row beyond the
+        cap to set `has_more`, so a truncated response is distinguishable
+        from an exact fit.
+      parameters:
+        - in: query
+          name: from
+          required: false
+          schema:
+            type: integer
+            format: int64
+          description: |
+            Start of the window, Unix seconds, inclusive. Defaults to
+            `to - 86400`. Must be less than or equal to `to`.
+        - in: query
+          name: to
+          required: false
+          schema:
+            type: integer
+            format: int64
+          description: End of the window, Unix seconds, inclusive. Defaults to the current server time.
+        - in: query
+          name: limit
+          required: false
+          schema:
+            $ref: '#/components/schemas/HistoryLimit'
+          description: Maximum number of fixes to return.
+        - in: query
+          name: format
+          required: false
+          schema:
+            type: string
+            enum: [json, csv]
+            default: json
+          description: |
+            Response encoding. `csv` returns `text/csv` with a
+            `Content-Disposition: attachment` header naming the file
+            `<vehicle_id>_locations.csv`.
+      responses:
+        '200':
+          description: |
+            Location history. The CSV variant carries the same rows with the
+            header `timestamp,latitude,longitude,bearing,speed,accuracy,trip_id,received_at`;
+            absent `bearing` / `speed` / `accuracy` render as empty cells, and
+            `trip_id` is prefixed with `'` when it starts with a character a
+            spreadsheet would treat as a formula.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationHistory'
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: No vehicle exists with this id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           $ref: '#/components/responses/InternalError'
 
@@ -527,7 +639,7 @@ paths:
   /api/v1/admin/users/{userID}/vehicles/{vehicleID}:
     parameters:
       - $ref: '#/components/parameters/AssignmentUserIDPath'
-      - $ref: '#/components/parameters/AssignmentVehicleIDPath'
+      - $ref: '#/components/parameters/VehicleIDPathNamed'
     delete:
       tags: [admin]
       summary: Remove a driver's vehicle assignment
@@ -703,7 +815,11 @@ components:
         format: int64
         minimum: 1
       description: User identifier.
-    AssignmentVehicleIDPath:
+    # Two components describe the same vehicle id because the routes spell the
+    # path variable differently: most use {id}, while the assignment-delete and
+    # location-history routes use {vehicleID}. OpenAPI requires `name` to match
+    # the template variable, so the pair cannot be collapsed.
+    VehicleIDPathNamed:
       name: vehicleID
       in: path
       required: true
@@ -947,6 +1063,78 @@ components:
         updated_at:
           type: string
           format: date-time
+
+    # Named so the drift guard has a stable address to pin against
+    # defaultHistoryLimit / maxHistoryLimit in location_history_handlers.go.
+    HistoryLimit:
+      type: integer
+      minimum: 1
+      maximum: 1000
+      default: 100
+
+    LocationHistory:
+      type: object
+      required: [vehicle_id, count, has_more, locations]
+      properties:
+        vehicle_id:
+          $ref: '#/components/schemas/VehicleID'
+        count:
+          type: integer
+          minimum: 0
+          description: Number of fixes in `locations`, after the `limit` cap is applied.
+        has_more:
+          type: boolean
+          description: |
+            True when more fixes exist in the window than `limit` allowed.
+            Narrow the window or raise `limit` to see them.
+        locations:
+          type: array
+          items:
+            $ref: '#/components/schemas/LocationHistoryEntry'
+
+    LocationHistoryEntry:
+      type: object
+      required:
+        - latitude
+        - longitude
+        - bearing
+        - speed
+        - accuracy
+        - timestamp
+        - trip_id
+        - received_at
+      description: |
+        `bearing`, `speed`, and `accuracy` carry no `omitempty`, so they are
+        always present and are explicitly `null` when the device did not
+        report them. That distinguishes "unknown" from a real zero — a
+        bearing of 0 is due north, not a missing value.
+      properties:
+        latitude:
+          type: number
+          format: double
+        longitude:
+          type: number
+          format: double
+        bearing:
+          type: [number, 'null']
+          format: double
+        speed:
+          type: [number, 'null']
+          format: double
+        accuracy:
+          type: [number, 'null']
+          format: double
+        timestamp:
+          type: integer
+          format: int64
+          description: Unix seconds, as reported by the device.
+        trip_id:
+          type: string
+          description: Empty string when the fix was not associated with a trip.
+        received_at:
+          type: string
+          format: date-time
+          description: RFC 3339 UTC timestamp of when the server stored the fix.
 
     CreateAssignmentRequest:
       type: object

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// These tests enforce that openapi.yaml stays in lock-step with the HTTP
+// routes and validation constants declared in main.go / handlers.go. They do
+// not pull in a full OpenAPI library; a minimal structural view of the spec
+// is enough to guard the invariants that catch drift.
+
+const openAPIPath = "openapi.yaml"
+
+type openAPISpec struct {
+	OpenAPI string `yaml:"openapi"`
+	Info    struct {
+		Title   string `yaml:"title"`
+		Version string `yaml:"version"`
+	} `yaml:"info"`
+	Paths      map[string]map[string]any `yaml:"paths"`
+	Components struct {
+		Schemas         map[string]any `yaml:"schemas"`
+		SecuritySchemes map[string]any `yaml:"securitySchemes"`
+	} `yaml:"components"`
+}
+
+func loadOpenAPISpec(t *testing.T) *openAPISpec {
+	t.Helper()
+	data, err := os.ReadFile(openAPIPath)
+	require.NoError(t, err, "openapi.yaml must exist at repo root")
+	require.NotEmpty(t, data, "openapi.yaml must not be empty")
+
+	var spec openAPISpec
+	require.NoError(t, yaml.Unmarshal(data, &spec), "openapi.yaml must parse as valid YAML")
+	return &spec
+}
+
+// muxRoutePattern captures (METHOD, PATH) from every mux registration in
+// main.go. main.go consistently writes routes as:
+//
+//	mux.Handle("METHOD /path", ...)
+//	mux.HandleFunc("METHOD /path", ...)
+var muxRoutePattern = regexp.MustCompile(`mux\.(?:Handle|HandleFunc)\("([A-Z]+)\s+([^"]+)"`)
+
+// muxRegistrationPattern matches every mux.Handle/HandleFunc call regardless of
+// how the pattern argument is spelled (string literal, constant, expression).
+// It is used to cross-check muxRoutePattern so a refactor that moves routes
+// into constants (e.g. mux.Handle(routeFoo, ...)) fails loudly instead of
+// silently hiding the route from the drift guard.
+var muxRegistrationPattern = regexp.MustCompile(`mux\.(?:Handle|HandleFunc)\(`)
+
+type registeredRoute struct{ method, path string }
+
+func extractRoutesFromMainGo(t *testing.T) []registeredRoute {
+	t.Helper()
+	data, err := os.ReadFile("main.go")
+	require.NoError(t, err, "main.go must exist at repo root")
+	src := string(data)
+
+	matches := muxRoutePattern.FindAllStringSubmatch(src, -1)
+	require.NotEmpty(t, matches, "expected mux route registrations in main.go")
+
+	// Fail loudly if any mux registration slipped past muxRoutePattern (e.g. a
+	// route whose method+path argument isn't a literal string). Otherwise the
+	// drift guard would silently skip it.
+	totalRegistrations := len(muxRegistrationPattern.FindAllString(src, -1))
+	require.Equal(t, totalRegistrations, len(matches),
+		"muxRoutePattern missed %d mux registration(s) in main.go — a route argument is probably not a literal string",
+		totalRegistrations-len(matches))
+
+	routes := make([]registeredRoute, 0, len(matches))
+	for _, m := range matches {
+		routes = append(routes, registeredRoute{method: m[1], path: m[2]})
+	}
+	return routes
+}
+
+func TestOpenAPI_Version(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+	assert.Equal(t, "3.1.0", spec.OpenAPI, "spec must target OpenAPI 3.1.0")
+}
+
+func TestOpenAPI_InfoComplete(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+	assert.NotEmpty(t, spec.Info.Title, "info.title must be set")
+	assert.NotEmpty(t, spec.Info.Version, "info.version must be set")
+}
+
+func TestOpenAPI_SecurityScheme(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+	raw, ok := spec.Components.SecuritySchemes["bearerAuth"]
+	require.True(t, ok, "bearerAuth security scheme must be defined")
+
+	scheme, ok := raw.(map[string]any)
+	require.True(t, ok, "bearerAuth must be a YAML mapping")
+	assert.Equal(t, "http", scheme["type"])
+	assert.Equal(t, "bearer", scheme["scheme"])
+	assert.Equal(t, "JWT", scheme["bearerFormat"])
+}
+
+func TestOpenAPI_ErrorResponseSchema(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+	raw, ok := spec.Components.Schemas["ErrorResponse"]
+	require.True(t, ok, "ErrorResponse schema must exist (matches writeJSON error shape)")
+
+	schema, ok := raw.(map[string]any)
+	require.True(t, ok)
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "ErrorResponse must declare properties")
+	_, ok = props["error"]
+	assert.True(t, ok, "ErrorResponse.properties.error must exist")
+}
+
+// TestOpenAPI_AllRoutesDocumented is the critical drift guard: every route
+// registered in main.go must have a matching path+method entry in the spec.
+// Adding a new endpoint without documenting it will fail CI here.
+func TestOpenAPI_AllRoutesDocumented(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+	routes := extractRoutesFromMainGo(t)
+
+	for _, r := range routes {
+		pathItem, ok := spec.Paths[r.path]
+		if !ok {
+			t.Errorf("main.go registers %s %s but openapi.yaml has no entry for this path", r.method, r.path)
+			continue
+		}
+		method := strings.ToLower(r.method)
+		if _, ok := pathItem[method]; !ok {
+			t.Errorf("main.go registers %s %s but openapi.yaml does not document this method", r.method, r.path)
+		}
+	}
+}
+
+// TestOpenAPI_NoExtraRoutes is the inverse drift guard: the spec must not
+// document endpoints that no longer exist in main.go.
+func TestOpenAPI_NoExtraRoutes(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+	routes := extractRoutesFromMainGo(t)
+
+	type key struct{ path, method string }
+	registered := make(map[key]struct{}, len(routes))
+	for _, r := range routes {
+		registered[key{path: r.path, method: strings.ToLower(r.method)}] = struct{}{}
+	}
+
+	// Only these fields under a path item are operations — other keys like
+	// "parameters", "summary", "description" must be ignored.
+	operationMethods := map[string]struct{}{
+		"get": {}, "post": {}, "put": {}, "delete": {},
+		"patch": {}, "head": {}, "options": {}, "trace": {},
+	}
+
+	for path, pathItem := range spec.Paths {
+		for field := range pathItem {
+			if _, isOp := operationMethods[field]; !isOp {
+				continue
+			}
+			if _, ok := registered[key{path: path, method: field}]; !ok {
+				t.Errorf("openapi.yaml documents %s %s but main.go does not register this route", strings.ToUpper(field), path)
+			}
+		}
+	}
+}
+
+// TestOpenAPI_LocationReportConstantsMatchCode cross-references the spec's
+// LocationReport.vehicle_id validation against the constants in handlers.go,
+// so changing the regex or length limit in Go forces a spec update.
+func TestOpenAPI_LocationReportConstantsMatchCode(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+
+	schema, ok := spec.Components.Schemas["LocationReport"].(map[string]any)
+	require.True(t, ok, "LocationReport schema must be a mapping")
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "LocationReport.properties must exist")
+
+	vehicleID, ok := props["vehicle_id"].(map[string]any)
+	require.True(t, ok, "LocationReport.properties.vehicle_id must exist")
+
+	assert.Equal(t, vehicleIDPattern.String(), vehicleID["pattern"],
+		"LocationReport.vehicle_id.pattern must match vehicleIDPattern in handlers.go")
+
+	// yaml.v3 decodes small integers into int when the target is interface{};
+	// accept int64 too in case the platform differs.
+	var maxLen int
+	switch v := vehicleID["maxLength"].(type) {
+	case int:
+		maxLen = v
+	case int64:
+		maxLen = int(v)
+	default:
+		t.Fatalf("LocationReport.vehicle_id.maxLength must be an integer, got %T", vehicleID["maxLength"])
+	}
+	assert.Equal(t, maxVehicleIDLength, maxLen,
+		"LocationReport.vehicle_id.maxLength must match maxVehicleIDLength in handlers.go")
+}

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -347,7 +347,10 @@ func TestOpenAPI_ConstraintsMatchCode(t *testing.T) {
 	spec := loadOpenAPISpec(t)
 	mappings := spec.mappings()
 
-	const upsertVehicle = "#/components/schemas/UpsertVehicleRequest/properties"
+	const (
+		upsertVehicle = "#/components/schemas/UpsertVehicleRequest/properties"
+		historyLimit  = "#/components/schemas/HistoryLimit"
+	)
 
 	constraints := []struct {
 		location string
@@ -359,6 +362,8 @@ func TestOpenAPI_ConstraintsMatchCode(t *testing.T) {
 		{vehicleIDSchemaRef, "maxLength", maxVehicleIDLength, "maxVehicleIDLength"},
 		{upsertVehicle + "/label", "maxLength", maxFieldLength, "maxFieldLength"},
 		{upsertVehicle + "/agency_tag", "maxLength", maxFieldLength, "maxFieldLength"},
+		{historyLimit, "maximum", maxHistoryLimit, "maxHistoryLimit"},
+		{historyLimit, "default", defaultHistoryLimit, "defaultHistoryLimit"},
 	}
 
 	for _, constraint := range constraints {

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -7,6 +7,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -67,6 +69,28 @@ var htmlUIRoutes = map[string]struct{}{
 	"POST /admin/users/{id}/deactivate":                  {},
 	"POST /admin/users/{id}/vehicles":                    {},
 	"POST /admin/users/{id}/vehicles/{vehicleID}/remove": {},
+}
+
+// schemaStructs pairs a response schema with the Go struct whose JSON encoding
+// it describes. TestOpenAPI_SchemaPropertiesMatchStructs holds each pair to its
+// struct's tags — the check that would have caught `User.active` when #92 added
+// the field and this spec did not follow.
+//
+// Only response schemas belong here. Request schemas describe what a client may
+// send, which is not always the same shape the server decodes into.
+var schemaStructs = map[string]string{
+	"User":                 "UserResponse",
+	"Vehicle":              "VehicleResponse",
+	"Trip":                 "TripResponse",
+	"TripSummary":          "TripSummary",
+	"Assignment":           "AssignmentResponse",
+	"LiveVehicles":         "liveVehiclesResponse",
+	"LiveVehicleEntry":     "liveVehicleEntry",
+	"TripList":             "tripListResponse",
+	"TripTrail":            "tripTrailResponse",
+	"TripTrailPoint":       "tripTrailPoint",
+	"LocationHistory":      "locationHistoryResponse",
+	"LocationHistoryEntry": "locationEntry",
 }
 
 // operationMethods are the path-item fields that describe an operation. Every
@@ -154,26 +178,37 @@ func (r registeredRoute) String() string { return r.method + " " + r.path }
 // means routes registered elsewhere — registerAdminUI in
 // admin_page_handlers.go, today — are visible too, and a future move into a
 // subpackage would not blind the guard.
-func extractRegisteredRoutes(t *testing.T) []registeredRoute {
+// walkModuleSources parses every non-test Go file in this module and hands each
+// syntax tree to visit, along with the FileSet for position reporting.
+func walkModuleSources(t *testing.T, visit func(fileSet *token.FileSet, file *ast.File)) {
 	t.Helper()
 
 	fileSet := token.NewFileSet()
-	routes := make([]registeredRoute, 0, len(htmlUIRoutes))
-
-	walkErr := filepath.WalkDir(".", func(file string, entry fs.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if entry.IsDir() {
-			return skipNonModuleDir(file, entry)
+			return skipNonModuleDir(path, entry)
 		}
-		if !strings.HasSuffix(file, ".go") || strings.HasSuffix(file, "_test.go") {
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
 
-		parsed, err := parser.ParseFile(fileSet, file, nil, parser.SkipObjectResolution)
-		require.NoErrorf(t, err, "parsing %s", file)
+		parsed, err := parser.ParseFile(fileSet, path, nil, parser.SkipObjectResolution)
+		require.NoErrorf(t, err, "parsing %s", path)
+		visit(fileSet, parsed)
+		return nil
+	})
+	require.NoError(t, walkErr)
+}
 
+func extractRegisteredRoutes(t *testing.T) []registeredRoute {
+	t.Helper()
+
+	routes := make([]registeredRoute, 0, len(htmlUIRoutes))
+
+	walkModuleSources(t, func(fileSet *token.FileSet, parsed *ast.File) {
 		ast.Inspect(parsed, func(node ast.Node) bool {
 			call, ok := node.(*ast.CallExpr)
 			if !ok || len(call.Args) != 2 {
@@ -201,9 +236,7 @@ func extractRegisteredRoutes(t *testing.T) []registeredRoute {
 			})
 			return true
 		})
-		return nil
 	})
-	require.NoError(t, walkErr)
 
 	require.NotEmpty(t, routes, "expected mux route registrations in the server source")
 	return routes
@@ -394,6 +427,8 @@ func TestOpenAPI_ConstraintsMatchCode(t *testing.T) {
 		upsertVehicle = "#/components/schemas/UpsertVehicleRequest/properties"
 		historyLimit  = "#/components/schemas/HistoryLimit"
 		tripListLimit = "#/components/schemas/TripListLimit"
+		listLimit     = "#/components/schemas/ListLimit"
+		listOffset    = "#/components/schemas/ListOffset"
 	)
 
 	constraints := []struct {
@@ -410,6 +445,9 @@ func TestOpenAPI_ConstraintsMatchCode(t *testing.T) {
 		{historyLimit, "default", defaultHistoryLimit, "defaultHistoryLimit"},
 		{tripListLimit, "maximum", maxTripListLimit, "maxTripListLimit"},
 		{tripListLimit, "default", defaultTripListLimit, "defaultTripListLimit"},
+		{listLimit, "maximum", maxListLimit, "maxListLimit"},
+		{listLimit, "default", defaultListLimit, "defaultListLimit"},
+		{listOffset, "maximum", maxListOffset, "maxListOffset"},
 	}
 
 	for _, constraint := range constraints {
@@ -479,5 +517,136 @@ func TestOpenAPI_HTMLUIExclusionsAreCurrent(t *testing.T) {
 	for route := range htmlUIRoutes {
 		assert.Containsf(t, registered, route,
 			"htmlUIRoutes withholds %q from the spec, but no Go source registers it any more", route)
+	}
+}
+
+// structJSONField is one marshalled field of a Go struct.
+type structJSONField struct {
+	name      string
+	omitEmpty bool
+}
+
+// structJSONFields returns, for every named struct in the module, the JSON
+// fields it marshals to. Fields tagged `json:"-"` are skipped, and an untagged
+// exported field marshals under its Go name.
+func structJSONFields(t *testing.T) map[string][]structJSONField {
+	t.Helper()
+
+	structs := make(map[string][]structJSONField)
+	walkModuleSources(t, func(_ *token.FileSet, parsed *ast.File) {
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			spec, ok := node.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+			definition, ok := spec.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+
+			fields := make([]structJSONField, 0, len(definition.Fields.List))
+			for _, field := range definition.Fields.List {
+				if len(field.Names) == 0 {
+					continue // Embedded field; none of the mapped structs use one.
+				}
+				name, omitEmpty, marshalled := jsonTag(field)
+				if !marshalled {
+					continue
+				}
+				fields = append(fields, structJSONField{name: name, omitEmpty: omitEmpty})
+			}
+			structs[spec.Name.Name] = fields
+			return true
+		})
+	})
+
+	return structs
+}
+
+// jsonTag reads a struct field's encoding/json tag. It reports the wire name,
+// whether the field is omitted when empty, and whether it is marshalled at all.
+func jsonTag(field *ast.Field) (name string, omitEmpty, marshalled bool) {
+	name = field.Names[0].Name
+	if field.Tag == nil {
+		return name, false, field.Names[0].IsExported()
+	}
+
+	value, err := strconv.Unquote(field.Tag.Value)
+	if err != nil {
+		return name, false, field.Names[0].IsExported()
+	}
+	tag, ok := reflect.StructTag(value).Lookup("json")
+	if !ok {
+		return name, false, field.Names[0].IsExported()
+	}
+
+	parts := strings.Split(tag, ",")
+	if parts[0] == "-" && len(parts) == 1 {
+		return "", false, false
+	}
+	if parts[0] != "" {
+		name = parts[0]
+	}
+	return name, slices.Contains(parts[1:], "omitempty"), true
+}
+
+// TestOpenAPI_SchemaPropertiesMatchStructs holds every response schema to the
+// Go struct it describes: the property set must match the struct's JSON tags
+// exactly, and a field marshalled unconditionally must be listed in `required`.
+//
+// This is the guard the earlier rounds lacked. Routes and constraints were
+// pinned to Go, but schema bodies were not, so `User.active` could be added in
+// #92 and go undocumented without anything failing.
+func TestOpenAPI_SchemaPropertiesMatchStructs(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+	mappings := spec.mappings()
+	structs := structJSONFields(t)
+
+	for schemaName, structName := range schemaStructs {
+		t.Run(schemaName, func(t *testing.T) {
+			schema, ok := mappings["#/components/schemas/"+schemaName]
+			require.Truef(t, ok, "schema %s must exist", schemaName)
+
+			fields, ok := structs[structName]
+			require.Truef(t, ok, "Go struct %s must exist", structName)
+			require.NotEmptyf(t, fields, "Go struct %s must marshal at least one field", structName)
+
+			properties, ok := schema["properties"].(map[string]any)
+			require.Truef(t, ok, "%s must declare properties", schemaName)
+
+			required := make(map[string]struct{})
+			if listed, ok := schema["required"].([]any); ok {
+				for _, name := range listed {
+					required[name.(string)] = struct{}{}
+				}
+			}
+
+			documented := make([]string, 0, len(properties))
+			for name := range properties {
+				documented = append(documented, name)
+			}
+			marshalled := make([]string, 0, len(fields))
+			for _, field := range fields {
+				marshalled = append(marshalled, field.name)
+			}
+			slices.Sort(documented)
+			slices.Sort(marshalled)
+			assert.Equalf(t, marshalled, documented,
+				"%s properties must match the JSON fields %s marshals", schemaName, structName)
+
+			for _, field := range fields {
+				_, isRequired := required[field.name]
+				if field.omitEmpty {
+					assert.Falsef(t, isRequired,
+						"%s.%s is omitempty in %s, so it must not be listed as required",
+						schemaName, field.name, structName)
+					continue
+				}
+				assert.Truef(t, isRequired,
+					"%s.%s is always marshalled by %s, so it must be listed as required",
+					schemaName, field.name, structName)
+			}
+		})
 	}
 }

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -91,6 +91,22 @@ var schemaStructs = map[string]string{
 	"TripTrailPoint":       "tripTrailPoint",
 	"LocationHistory":      "locationHistoryResponse",
 	"LocationHistoryEntry": "locationEntry",
+
+	// Rider mode (#94).
+	"RiderRegisterResponse": "riderRegisterResponse",
+	"StartRideResponse":     "startRideResponse",
+	"RideDestination":       "rideDestination",
+	"PositionsResponse":     "positionsResponse",
+	"EndRideResponse":       "endRideResponse",
+	"RideSummary":           "rideSummaryJSON",
+	"TripCoverage":          "tripStatusResponse",
+	"RiderStatus":           "riderStatusResponse",
+	"RiderGTFSStatus":       "riderGTFSStatus",
+	"RiderFeedStatus":       "riderFeedStatus",
+	"RiderTierCounts":       "riderTierCounts",
+	"RiderRideCounts":       "riderRideCounts",
+	"AdminRides":            "adminRidesResponse",
+	"AdminRide":             "adminRideEntry",
 }
 
 // operationMethods are the path-item fields that describe an operation. Every
@@ -164,6 +180,7 @@ type registeredRoute struct {
 	source       string
 	auth         bool
 	admin        bool
+	rider        bool
 }
 
 func (r registeredRoute) String() string { return r.method + " " + r.path }
@@ -209,6 +226,7 @@ func extractRegisteredRoutes(t *testing.T) []registeredRoute {
 	routes := make([]registeredRoute, 0, len(htmlUIRoutes))
 
 	walkModuleSources(t, func(fileSet *token.FileSet, parsed *ast.File) {
+		aliases := middlewareAliases(parsed)
 		ast.Inspect(parsed, func(node ast.Node) bool {
 			call, ok := node.(*ast.CallExpr)
 			if !ok || len(call.Args) != 2 {
@@ -231,8 +249,9 @@ func extractRegisteredRoutes(t *testing.T) []registeredRoute {
 				method: method,
 				path:   path,
 				source: source,
-				auth:   wrappedBy(call.Args[1], "authMiddleware"),
-				admin:  wrappedBy(call.Args[1], "adminMiddleware"),
+				auth:   wrappedBy(call.Args[1], aliases, "requireAuth"),
+				admin:  wrappedBy(call.Args[1], aliases, "requireAdmin"),
+				rider:  wrappedBy(call.Args[1], aliases, "requireRider"),
 			})
 			return true
 		})
@@ -289,17 +308,62 @@ func stringLiteral(expr ast.Expr) (string, bool) {
 	return value, true
 }
 
+// middlewareConstructors are the functions that build an auth middleware. A
+// route is classified by which of these produced the wrapper around its
+// handler, not by what the local variable happens to be called.
+var middlewareConstructors = map[string]struct{}{
+	"requireAuth": {}, "requireAdmin": {}, "requireRider": {},
+}
+
+// middlewareAliases maps each local variable holding an auth middleware to the
+// constructor that produced it — `authMiddleware := requireAuth(secret)` in
+// newMux, `auth := requireRider(s.jwtSecret)` in registerRiderRoutes.
+//
+// Resolving the alias rather than matching the variable name is what lets the
+// guard see that the rider routes are authenticated: they spell their wrapper
+// `auth`, and a name-based check would read them as public.
+func middlewareAliases(file *ast.File) map[string]string {
+	aliases := make(map[string]string)
+	ast.Inspect(file, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return true
+		}
+		name, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		constructor, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if _, isMiddleware := middlewareConstructors[constructor.Name]; isMiddleware {
+			aliases[name.Name] = constructor.Name
+		}
+		return true
+	})
+	return aliases
+}
+
 // wrappedBy reports whether the handler argument of a mux registration is
-// wrapped in a call to the named middleware at any depth — newMux composes them
-// as authMiddleware(adminMiddleware(handler)).
-func wrappedBy(handler ast.Expr, middleware string) bool {
+// wrapped, at any depth, in a middleware built by the named constructor —
+// newMux composes them as authMiddleware(adminMiddleware(handler)).
+func wrappedBy(handler ast.Expr, aliases map[string]string, constructor string) bool {
 	wrapped := false
 	ast.Inspect(handler, func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-		if name, ok := call.Fun.(*ast.Ident); ok && name.Name == middleware {
+		name, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if name.Name == constructor || aliases[name.Name] == constructor {
 			wrapped = true
 			return false
 		}
@@ -311,6 +375,25 @@ func wrappedBy(handler ast.Expr, middleware string) bool {
 func isEmptyList(value any) bool {
 	list, ok := value.([]any)
 	return ok && len(list) == 0
+}
+
+// declaresScheme reports whether an operation's security block requires the
+// named scheme.
+func declaresScheme(value any, scheme string) bool {
+	requirements, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, requirement := range requirements {
+		entry, ok := requirement.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, named := entry[scheme]; named {
+			return true
+		}
+	}
+	return false
 }
 
 // TestOpenAPI_AllRoutesDocumented is the primary drift guard: every route the
@@ -369,18 +452,33 @@ func TestOpenAPI_AuthRequirementsMatchCode(t *testing.T) {
 		}
 
 		security, overridden := operation["security"]
-		if !route.auth {
-			assert.Truef(t, overridden && isEmptyList(security),
-				"%s registers %s without authMiddleware, so the spec must opt out with `security: []`",
-				route.source, route)
-			continue
-		}
 
-		assert.Falsef(t, overridden,
-			"%s wraps %s in authMiddleware, so the spec must inherit the global bearerAuth requirement rather than override security",
-			route.source, route)
-		assert.Containsf(t, operation["responses"], "401",
-			"%s wraps %s in authMiddleware, so the spec must document a 401 response", route.source, route)
+		switch {
+		case route.rider:
+			// The rider API carries its own token: requireRider accepts a JWT
+			// with the rider role, not the driver/admin one the global scheme
+			// describes, so these operations must name riderAuth explicitly.
+			assert.Truef(t, overridden && declaresScheme(security, "riderAuth"),
+				"%s wraps %s in requireRider, so the spec must declare `security: [{riderAuth: []}]`",
+				route.source, route)
+			assert.Containsf(t, operation["responses"], "401",
+				"%s wraps %s in requireRider, so the spec must document a 401 response", route.source, route)
+			assert.Containsf(t, operation["responses"], "403",
+				"%s wraps %s in requireRider, which rejects a non-rider role, so the spec must document a 403 response",
+				route.source, route)
+
+		case route.auth:
+			assert.Falsef(t, overridden,
+				"%s wraps %s in requireAuth, so the spec must inherit the global bearerAuth requirement rather than override security",
+				route.source, route)
+			assert.Containsf(t, operation["responses"], "401",
+				"%s wraps %s in requireAuth, so the spec must document a 401 response", route.source, route)
+
+		default:
+			assert.Truef(t, overridden && isEmptyList(security),
+				"%s registers %s behind no auth middleware, so the spec must opt out with `security: []`",
+				route.source, route)
+		}
 	}
 }
 
@@ -429,6 +527,9 @@ func TestOpenAPI_ConstraintsMatchCode(t *testing.T) {
 		tripListLimit = "#/components/schemas/TripListLimit"
 		listLimit     = "#/components/schemas/ListLimit"
 		listOffset    = "#/components/schemas/ListOffset"
+		riderLimit    = "#/components/schemas/RiderRideListLimit"
+		riderBatch    = "#/components/schemas/PositionsRequest/properties/positions"
+		riderRegister = "#/components/schemas/RiderRegisterResponse/properties"
 	)
 
 	constraints := []struct {
@@ -448,6 +549,9 @@ func TestOpenAPI_ConstraintsMatchCode(t *testing.T) {
 		{listLimit, "maximum", maxListLimit, "maxListLimit"},
 		{listLimit, "default", defaultListLimit, "defaultListLimit"},
 		{listOffset, "maximum", maxListOffset, "maxListOffset"},
+		{riderLimit, "maximum", maxRiderRideListLimit, "maxRiderRideListLimit"},
+		{riderLimit, "default", defaultRiderRideListLimit, "defaultRiderRideListLimit"},
+		{riderBatch, "maxItems", riderMaxBatchSize, "riderMaxBatchSize"},
 	}
 
 	for _, constraint := range constraints {

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
-	"regexp"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -11,201 +15,418 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// These tests enforce that openapi.yaml stays in lock-step with the HTTP
-// routes and validation constants declared in main.go / handlers.go. They do
-// not pull in a full OpenAPI library; a minimal structural view of the spec
-// is enough to guard the invariants that catch drift.
+// These tests keep openapi.yaml in lock-step with the server. Every assertion
+// compares the spec against something derived from Go source: the routes
+// registered on the mux, the middleware wrapping each handler, or the
+// validation constants in handlers.go. Assertions that would only restate what
+// the spec's author typed into the YAML are deliberately absent — they can
+// only fail when someone edits openapi.yaml, which is not drift.
+//
+// Prose is out of reach of all of this. Descriptions still have to be read
+// against the handlers by hand.
 
 const openAPIPath = "openapi.yaml"
 
+// vehicleIDSchemaRef is the one schema every vehicle-id-shaped field in the
+// spec must reference. It doubles as a location, because mappings() files that
+// schema under the same string — see TestOpenAPI_VehicleIDSchemaIsSingleSource.
+const vehicleIDSchemaRef = "#/components/schemas/VehicleID"
+
+// htmlUIRoutes are registered by registerAdminUI in admin_handlers.go, behind
+// the ADMIN_UI_ENABLED flag. They serve HTML pages and static assets rather
+// than the JSON API, so openapi.yaml does not describe them.
+//
+// They are excluded by name rather than by scanning main.go alone, so that
+// adding a server-rendered route fails TestOpenAPI_AllRoutesDocumented until
+// someone decides whether it belongs in the spec.
+var htmlUIRoutes = map[string]struct{}{
+	"GET /static/":         {},
+	"GET /admin/login":     {},
+	"GET /admin/signup":    {},
+	"GET /admin/map":       {},
+	"GET /admin/dashboard": {},
+	"GET /admin/vehicles":  {},
+	"GET /admin/users":     {},
+	"GET /admin/trips":     {},
+}
+
+// operationMethods are the path-item fields that describe an operation. Every
+// other key under a path ("parameters", "summary", …) must be ignored.
+var operationMethods = map[string]struct{}{
+	"get": {}, "put": {}, "post": {}, "delete": {},
+	"options": {}, "head": {}, "patch": {}, "trace": {},
+}
+
 type openAPISpec struct {
-	OpenAPI string `yaml:"openapi"`
-	Info    struct {
-		Title   string `yaml:"title"`
-		Version string `yaml:"version"`
-	} `yaml:"info"`
-	Paths      map[string]map[string]any `yaml:"paths"`
-	Components struct {
-		Schemas         map[string]any `yaml:"schemas"`
-		SecuritySchemes map[string]any `yaml:"securitySchemes"`
-	} `yaml:"components"`
+	Paths map[string]map[string]any `yaml:"paths"`
+
+	// document is the same file decoded without a schema. The typed view above
+	// reads better for the route checks; the untyped one lets the $ref and
+	// vehicle-id walks visit every node without knowing its shape.
+	document map[string]any
 }
 
 func loadOpenAPISpec(t *testing.T) *openAPISpec {
 	t.Helper()
+
 	data, err := os.ReadFile(openAPIPath)
-	require.NoError(t, err, "openapi.yaml must exist at repo root")
-	require.NotEmpty(t, data, "openapi.yaml must not be empty")
+	require.NoError(t, err, "openapi.yaml must exist at the repo root")
 
 	var spec openAPISpec
 	require.NoError(t, yaml.Unmarshal(data, &spec), "openapi.yaml must parse as valid YAML")
+	require.NoError(t, yaml.Unmarshal(data, &spec.document))
+	require.NotEmpty(t, spec.Paths, "openapi.yaml must document at least one path")
 	return &spec
 }
 
-// muxRoutePattern captures (METHOD, PATH) from every mux registration in
-// main.go. main.go consistently writes routes as:
-//
-//	mux.Handle("METHOD /path", ...)
-//	mux.HandleFunc("METHOD /path", ...)
-var muxRoutePattern = regexp.MustCompile(`mux\.(?:Handle|HandleFunc)\("([A-Z]+)\s+([^"]+)"`)
-
-// muxRegistrationPattern matches every mux.Handle/HandleFunc call regardless of
-// how the pattern argument is spelled (string literal, constant, expression).
-// It is used to cross-check muxRoutePattern so a refactor that moves routes
-// into constants (e.g. mux.Handle(routeFoo, ...)) fails loudly instead of
-// silently hiding the route from the drift guard.
-var muxRegistrationPattern = regexp.MustCompile(`mux\.(?:Handle|HandleFunc)\(`)
-
-type registeredRoute struct{ method, path string }
-
-func extractRoutesFromMainGo(t *testing.T) []registeredRoute {
-	t.Helper()
-	data, err := os.ReadFile("main.go")
-	require.NoError(t, err, "main.go must exist at repo root")
-	src := string(data)
-
-	matches := muxRoutePattern.FindAllStringSubmatch(src, -1)
-	require.NotEmpty(t, matches, "expected mux route registrations in main.go")
-
-	// Fail loudly if any mux registration slipped past muxRoutePattern (e.g. a
-	// route whose method+path argument isn't a literal string). Otherwise the
-	// drift guard would silently skip it.
-	totalRegistrations := len(muxRegistrationPattern.FindAllString(src, -1))
-	require.Equal(t, totalRegistrations, len(matches),
-		"muxRoutePattern missed %d mux registration(s) in main.go — a route argument is probably not a literal string",
-		totalRegistrations-len(matches))
-
-	routes := make([]registeredRoute, 0, len(matches))
-	for _, m := range matches {
-		routes = append(routes, registeredRoute{method: m[1], path: m[2]})
+func (s *openAPISpec) operation(path, method string) (map[string]any, bool) {
+	pathItem, ok := s.Paths[path]
+	if !ok {
+		return nil, false
 	}
+	operation, ok := pathItem[strings.ToLower(method)].(map[string]any)
+	return operation, ok
+}
+
+// mappings returns every mapping in the document keyed by its location, using
+// the same "#/components/schemas/Name" syntax that $ref uses. That shared
+// spelling is what lets TestOpenAPI_AllRefsResolve look a reference up
+// directly.
+func (s *openAPISpec) mappings() map[string]map[string]any {
+	found := make(map[string]map[string]any)
+
+	var walk func(location string, node any)
+	walk = func(location string, node any) {
+		switch typed := node.(type) {
+		case map[string]any:
+			found[location] = typed
+			for key, child := range typed {
+				walk(location+"/"+key, child)
+			}
+		case []any:
+			for i, child := range typed {
+				walk(location+"/"+strconv.Itoa(i), child)
+			}
+		}
+	}
+	walk("#", s.document)
+
+	return found
+}
+
+// registeredRoute is one mux registration found in the server's Go source,
+// together with the middleware wrapping its handler.
+type registeredRoute struct {
+	method, path string
+	source       string
+	auth         bool
+	admin        bool
+}
+
+func (r registeredRoute) String() string { return r.method + " " + r.path }
+
+// extractRegisteredRoutes parses every non-test Go file in the repo root and
+// returns the routes they register.
+//
+// It walks the AST rather than grepping the source, so a `mux.Handle(` inside a
+// comment or an unrelated string cannot invent a phantom route, and a
+// registration whose pattern is not a literal string is reported loudly instead
+// of slipping past unseen. Reading every file rather than just main.go means
+// routes registered elsewhere — registerAdminUI in admin_handlers.go, today —
+// are visible too.
+func extractRegisteredRoutes(t *testing.T) []registeredRoute {
+	t.Helper()
+
+	files, err := filepath.Glob("*.go")
+	require.NoError(t, err)
+
+	fileSet := token.NewFileSet()
+	routes := make([]registeredRoute, 0, len(files))
+
+	for _, file := range files {
+		if strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+
+		parsed, err := parser.ParseFile(fileSet, file, nil, parser.SkipObjectResolution)
+		require.NoErrorf(t, err, "parsing %s", file)
+
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || len(call.Args) != 2 {
+				return true
+			}
+			registrar, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || (registrar.Sel.Name != "Handle" && registrar.Sel.Name != "HandleFunc") {
+				return true
+			}
+
+			source := fileSet.Position(call.Pos()).String()
+			pattern, ok := stringLiteral(call.Args[0])
+			require.Truef(t, ok,
+				"%s: mux route pattern is not a literal string, so the drift guard cannot read the route", source)
+
+			method, path, ok := strings.Cut(pattern, " ")
+			require.Truef(t, ok, "%s: route pattern %q has no HTTP method prefix", source, pattern)
+
+			routes = append(routes, registeredRoute{
+				method: method,
+				path:   path,
+				source: source,
+				auth:   wrappedBy(call.Args[1], "authMiddleware"),
+				admin:  wrappedBy(call.Args[1], "adminMiddleware"),
+			})
+			return true
+		})
+	}
+
+	require.NotEmpty(t, routes, "expected mux route registrations in the server source")
 	return routes
 }
 
-func TestOpenAPI_Version(t *testing.T) {
-	t.Parallel()
-	spec := loadOpenAPISpec(t)
-	assert.Equal(t, "3.1.0", spec.OpenAPI, "spec must target OpenAPI 3.1.0")
+// apiRoutes returns the registered routes openapi.yaml is expected to document,
+// i.e. everything but the server-rendered admin UI.
+func apiRoutes(t *testing.T) []registeredRoute {
+	t.Helper()
+
+	all := extractRegisteredRoutes(t)
+	api := make([]registeredRoute, 0, len(all))
+	for _, route := range all {
+		if _, isUI := htmlUIRoutes[route.String()]; !isUI {
+			api = append(api, route)
+		}
+	}
+
+	require.NotEmpty(t, api, "expected JSON API routes outside the admin UI")
+	return api
 }
 
-func TestOpenAPI_InfoComplete(t *testing.T) {
-	t.Parallel()
-	spec := loadOpenAPISpec(t)
-	assert.NotEmpty(t, spec.Info.Title, "info.title must be set")
-	assert.NotEmpty(t, spec.Info.Version, "info.version must be set")
+func stringLiteral(expr ast.Expr) (string, bool) {
+	literal, ok := expr.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
 }
 
-func TestOpenAPI_SecurityScheme(t *testing.T) {
-	t.Parallel()
-	spec := loadOpenAPISpec(t)
-	raw, ok := spec.Components.SecuritySchemes["bearerAuth"]
-	require.True(t, ok, "bearerAuth security scheme must be defined")
-
-	scheme, ok := raw.(map[string]any)
-	require.True(t, ok, "bearerAuth must be a YAML mapping")
-	assert.Equal(t, "http", scheme["type"])
-	assert.Equal(t, "bearer", scheme["scheme"])
-	assert.Equal(t, "JWT", scheme["bearerFormat"])
+// wrappedBy reports whether the handler argument of a mux registration is
+// wrapped in a call to the named middleware at any depth — newMux composes them
+// as authMiddleware(adminMiddleware(handler)).
+func wrappedBy(handler ast.Expr, middleware string) bool {
+	wrapped := false
+	ast.Inspect(handler, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if name, ok := call.Fun.(*ast.Ident); ok && name.Name == middleware {
+			wrapped = true
+			return false
+		}
+		return true
+	})
+	return wrapped
 }
 
-func TestOpenAPI_ErrorResponseSchema(t *testing.T) {
-	t.Parallel()
-	spec := loadOpenAPISpec(t)
-	raw, ok := spec.Components.Schemas["ErrorResponse"]
-	require.True(t, ok, "ErrorResponse schema must exist (matches writeJSON error shape)")
-
-	schema, ok := raw.(map[string]any)
-	require.True(t, ok)
-
-	props, ok := schema["properties"].(map[string]any)
-	require.True(t, ok, "ErrorResponse must declare properties")
-	_, ok = props["error"]
-	assert.True(t, ok, "ErrorResponse.properties.error must exist")
+func isEmptyList(value any) bool {
+	list, ok := value.([]any)
+	return ok && len(list) == 0
 }
 
-// TestOpenAPI_AllRoutesDocumented is the critical drift guard: every route
-// registered in main.go must have a matching path+method entry in the spec.
-// Adding a new endpoint without documenting it will fail CI here.
+// TestOpenAPI_AllRoutesDocumented is the primary drift guard: every route the
+// server registers must have a matching path and method in the spec. Adding an
+// endpoint without documenting it fails here.
 func TestOpenAPI_AllRoutesDocumented(t *testing.T) {
 	t.Parallel()
 	spec := loadOpenAPISpec(t)
-	routes := extractRoutesFromMainGo(t)
 
-	for _, r := range routes {
-		pathItem, ok := spec.Paths[r.path]
-		if !ok {
-			t.Errorf("main.go registers %s %s but openapi.yaml has no entry for this path", r.method, r.path)
+	for _, route := range apiRoutes(t) {
+		if _, ok := spec.Paths[route.path]; !ok {
+			t.Errorf("%s registers %s but openapi.yaml has no entry for this path", route.source, route)
 			continue
 		}
-		method := strings.ToLower(r.method)
-		if _, ok := pathItem[method]; !ok {
-			t.Errorf("main.go registers %s %s but openapi.yaml does not document this method", r.method, r.path)
+		if _, ok := spec.operation(route.path, route.method); !ok {
+			t.Errorf("%s registers %s but openapi.yaml does not document this method", route.source, route)
 		}
 	}
 }
 
-// TestOpenAPI_NoExtraRoutes is the inverse drift guard: the spec must not
-// document endpoints that no longer exist in main.go.
+// TestOpenAPI_NoExtraRoutes is the inverse guard: the spec must not describe
+// endpoints the server no longer serves.
 func TestOpenAPI_NoExtraRoutes(t *testing.T) {
 	t.Parallel()
 	spec := loadOpenAPISpec(t)
-	routes := extractRoutesFromMainGo(t)
 
-	type key struct{ path, method string }
-	registered := make(map[key]struct{}, len(routes))
-	for _, r := range routes {
-		registered[key{path: r.path, method: strings.ToLower(r.method)}] = struct{}{}
-	}
-
-	// Only these fields under a path item are operations — other keys like
-	// "parameters", "summary", "description" must be ignored.
-	operationMethods := map[string]struct{}{
-		"get": {}, "post": {}, "put": {}, "delete": {},
-		"patch": {}, "head": {}, "options": {}, "trace": {},
+	registered := make(map[string]struct{})
+	for _, route := range apiRoutes(t) {
+		registered[strings.ToLower(route.method)+" "+route.path] = struct{}{}
 	}
 
 	for path, pathItem := range spec.Paths {
 		for field := range pathItem {
-			if _, isOp := operationMethods[field]; !isOp {
+			if _, isOperation := operationMethods[field]; !isOperation {
 				continue
 			}
-			if _, ok := registered[key{path: path, method: field}]; !ok {
-				t.Errorf("openapi.yaml documents %s %s but main.go does not register this route", strings.ToUpper(field), path)
+			if _, ok := registered[field+" "+path]; !ok {
+				t.Errorf("openapi.yaml documents %s %s but no Go source registers this route",
+					strings.ToUpper(field), path)
 			}
 		}
 	}
 }
 
-// TestOpenAPI_LocationReportConstantsMatchCode cross-references the spec's
-// LocationReport.vehicle_id validation against the constants in handlers.go,
-// so changing the regex or length limit in Go forces a spec update.
-func TestOpenAPI_LocationReportConstantsMatchCode(t *testing.T) {
+// TestOpenAPI_AuthRequirementsMatchCode ties each operation's security block to
+// the middleware actually wrapping its handler, so moving a route behind
+// requireAuth — or out from behind it — without touching the spec fails here.
+func TestOpenAPI_AuthRequirementsMatchCode(t *testing.T) {
 	t.Parallel()
 	spec := loadOpenAPISpec(t)
 
-	schema, ok := spec.Components.Schemas["LocationReport"].(map[string]any)
-	require.True(t, ok, "LocationReport schema must be a mapping")
+	for _, route := range apiRoutes(t) {
+		operation, ok := spec.operation(route.path, route.method)
+		if !ok {
+			continue // Reported by TestOpenAPI_AllRoutesDocumented.
+		}
 
-	props, ok := schema["properties"].(map[string]any)
-	require.True(t, ok, "LocationReport.properties must exist")
+		security, overridden := operation["security"]
+		if !route.auth {
+			assert.Truef(t, overridden && isEmptyList(security),
+				"%s registers %s without authMiddleware, so the spec must opt out with `security: []`",
+				route.source, route)
+			continue
+		}
 
-	vehicleID, ok := props["vehicle_id"].(map[string]any)
-	require.True(t, ok, "LocationReport.properties.vehicle_id must exist")
-
-	assert.Equal(t, vehicleIDPattern.String(), vehicleID["pattern"],
-		"LocationReport.vehicle_id.pattern must match vehicleIDPattern in handlers.go")
-
-	// yaml.v3 decodes small integers into int when the target is interface{};
-	// accept int64 too in case the platform differs.
-	var maxLen int
-	switch v := vehicleID["maxLength"].(type) {
-	case int:
-		maxLen = v
-	case int64:
-		maxLen = int(v)
-	default:
-		t.Fatalf("LocationReport.vehicle_id.maxLength must be an integer, got %T", vehicleID["maxLength"])
+		assert.Falsef(t, overridden,
+			"%s wraps %s in authMiddleware, so the spec must inherit the global bearerAuth requirement rather than override security",
+			route.source, route)
+		assert.Containsf(t, operation["responses"], "401",
+			"%s wraps %s in authMiddleware, so the spec must document a 401 response", route.source, route)
 	}
-	assert.Equal(t, maxVehicleIDLength, maxLen,
-		"LocationReport.vehicle_id.maxLength must match maxVehicleIDLength in handlers.go")
+}
+
+// TestOpenAPI_AdminRoutesDocumentForbidden asserts that every route behind
+// requireAdmin documents the 403 it can return. This is the check that would
+// have caught the spec's stale "the admin-role check is missing from the
+// handler" notes: the moment adminMiddleware was applied to the user routes,
+// the spec owed a 403.
+//
+// Only the positive direction is asserted. A handler may return 403 for its own
+// reasons — POST /api/v1/trips/start does, when the driver is not assigned to
+// the vehicle — so documenting 403 without adminMiddleware is not an error.
+func TestOpenAPI_AdminRoutesDocumentForbidden(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+
+	for _, route := range apiRoutes(t) {
+		if !route.admin {
+			continue
+		}
+		operation, ok := spec.operation(route.path, route.method)
+		if !ok {
+			continue // Reported by TestOpenAPI_AllRoutesDocumented.
+		}
+		assert.Containsf(t, operation["responses"], "403",
+			"%s wraps %s in adminMiddleware, so the spec must document a 403 response", route.source, route)
+	}
+}
+
+// TestOpenAPI_ConstraintsMatchCode pins the spec's validation keywords to the
+// Go constants they mirror, so changing a limit in Go forces a spec update.
+//
+// Only constraints backed by a named constant are listed. The rest — the
+// latitude and longitude bounds, the 100-character trip and route ids, the
+// 8-character password minimum — are bare literals in the handlers, so
+// checking them here would compare a literal against a literal and prove
+// nothing. They stay a manual read.
+func TestOpenAPI_ConstraintsMatchCode(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+	mappings := spec.mappings()
+
+	const upsertVehicle = "#/components/schemas/UpsertVehicleRequest/properties"
+
+	constraints := []struct {
+		location string
+		keyword  string
+		want     any
+		constant string
+	}{
+		{vehicleIDSchemaRef, "pattern", vehicleIDPattern.String(), "vehicleIDPattern"},
+		{vehicleIDSchemaRef, "maxLength", maxVehicleIDLength, "maxVehicleIDLength"},
+		{upsertVehicle + "/label", "maxLength", maxFieldLength, "maxFieldLength"},
+		{upsertVehicle + "/agency_tag", "maxLength", maxFieldLength, "maxFieldLength"},
+	}
+
+	for _, constraint := range constraints {
+		t.Run(constraint.location+"/"+constraint.keyword, func(t *testing.T) {
+			node, ok := mappings[constraint.location]
+			require.Truef(t, ok, "%s must exist in the spec", constraint.location)
+			assert.Equalf(t, constraint.want, node[constraint.keyword],
+				"%s %s must match %s in Go", constraint.location, constraint.keyword, constraint.constant)
+		})
+	}
+}
+
+// TestOpenAPI_VehicleIDSchemaIsSingleSource fails if any node other than the
+// VehicleID schema itself carries the vehicle-id pattern. Without it a new
+// endpoint could inline the constraints again and drift independently of
+// handlers.go, which is the whole reason the shared schema exists — the check
+// above only looks at the locations it is told about.
+func TestOpenAPI_VehicleIDSchemaIsSingleSource(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+
+	pattern := vehicleIDPattern.String()
+	for location, node := range spec.mappings() {
+		if location == vehicleIDSchemaRef {
+			continue
+		}
+		assert.NotEqualf(t, pattern, node["pattern"],
+			"%s inlines the vehicle-id pattern; reference %s instead so the constraints live in one place",
+			location, vehicleIDSchemaRef)
+	}
+}
+
+// TestOpenAPI_AllRefsResolve follows every $ref in the document. The spec leans
+// hard on shared components, and a mistyped pointer is still valid YAML.
+func TestOpenAPI_AllRefsResolve(t *testing.T) {
+	t.Parallel()
+	spec := loadOpenAPISpec(t)
+
+	mappings := spec.mappings()
+	references := 0
+	for location, node := range mappings {
+		reference, ok := node["$ref"].(string)
+		if !ok {
+			continue
+		}
+		references++
+		_, resolved := mappings[reference]
+		assert.Truef(t, resolved, "%s references %s, which does not exist", location, reference)
+	}
+
+	require.NotZero(t, references, "expected the spec to use $ref")
+}
+
+// TestOpenAPI_HTMLUIExclusionsAreCurrent keeps the exclusion list honest in the
+// direction the other tests cannot see. A newly added server-rendered route
+// that is missing from the list already fails TestOpenAPI_AllRoutesDocumented;
+// an entry left behind by a deleted route would silently widen the blind spot,
+// so it fails here instead.
+func TestOpenAPI_HTMLUIExclusionsAreCurrent(t *testing.T) {
+	t.Parallel()
+
+	registered := make(map[string]struct{})
+	for _, route := range extractRegisteredRoutes(t) {
+		registered[route.String()] = struct{}{}
+	}
+
+	for route := range htmlUIRoutes {
+		assert.Containsf(t, registered, route,
+			"htmlUIRoutes withholds %q from the spec, but no Go source registers it any more", route)
+	}
 }

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -32,22 +33,40 @@ const openAPIPath = "openapi.yaml"
 // schema under the same string — see TestOpenAPI_VehicleIDSchemaIsSingleSource.
 const vehicleIDSchemaRef = "#/components/schemas/VehicleID"
 
-// htmlUIRoutes are registered by registerAdminUI in admin_handlers.go, behind
-// the ADMIN_UI_ENABLED flag. They serve HTML pages and static assets rather
-// than the JSON API, so openapi.yaml does not describe them.
+// htmlUIRoutes are the server-rendered admin UI routes — the pages and form
+// posts registered by registerAdminUI in admin_page_handlers.go, plus the
+// static asset mount. They serve HTML and assets rather than the JSON API, so
+// openapi.yaml does not describe them.
 //
 // They are excluded by name rather than by scanning main.go alone, so that
 // adding a server-rendered route fails TestOpenAPI_AllRoutesDocumented until
 // someone decides whether it belongs in the spec.
 var htmlUIRoutes = map[string]struct{}{
-	"GET /static/":         {},
-	"GET /admin/login":     {},
-	"GET /admin/signup":    {},
-	"GET /admin/map":       {},
-	"GET /admin/dashboard": {},
-	"GET /admin/vehicles":  {},
-	"GET /admin/users":     {},
-	"GET /admin/trips":     {},
+	"GET /static/":                                       {},
+	"GET /admin":                                         {},
+	"GET /admin/{$}":                                     {},
+	"GET /admin/login":                                   {},
+	"POST /admin/login":                                  {},
+	"POST /admin/logout":                                 {},
+	"GET /admin/dashboard":                               {},
+	"GET /admin/map":                                     {},
+	"GET /admin/trips":                                   {},
+	"GET /admin/vehicles":                                {},
+	"GET /admin/vehicles/new":                            {},
+	"POST /admin/vehicles":                               {},
+	"GET /admin/vehicles/{id}/edit":                      {},
+	"POST /admin/vehicles/{id}":                          {},
+	"POST /admin/vehicles/{id}/activate":                 {},
+	"POST /admin/vehicles/{id}/deactivate":               {},
+	"GET /admin/users":                                   {},
+	"GET /admin/users/new":                               {},
+	"POST /admin/users":                                  {},
+	"GET /admin/users/{id}/edit":                         {},
+	"POST /admin/users/{id}":                             {},
+	"POST /admin/users/{id}/activate":                    {},
+	"POST /admin/users/{id}/deactivate":                  {},
+	"POST /admin/users/{id}/vehicles":                    {},
+	"POST /admin/users/{id}/vehicles/{vehicleID}/remove": {},
 }
 
 // operationMethods are the path-item fields that describe an operation. Every
@@ -125,27 +144,31 @@ type registeredRoute struct {
 
 func (r registeredRoute) String() string { return r.method + " " + r.path }
 
-// extractRegisteredRoutes parses every non-test Go file in the repo root and
+// extractRegisteredRoutes parses every non-test Go file in this module and
 // returns the routes they register.
 //
 // It walks the AST rather than grepping the source, so a `mux.Handle(` inside a
 // comment or an unrelated string cannot invent a phantom route, and a
 // registration whose pattern is not a literal string is reported loudly instead
-// of slipping past unseen. Reading every file rather than just main.go means
-// routes registered elsewhere — registerAdminUI in admin_handlers.go, today —
-// are visible too.
+// of slipping past unseen. Walking the whole module rather than just main.go
+// means routes registered elsewhere — registerAdminUI in
+// admin_page_handlers.go, today — are visible too, and a future move into a
+// subpackage would not blind the guard.
 func extractRegisteredRoutes(t *testing.T) []registeredRoute {
 	t.Helper()
 
-	files, err := filepath.Glob("*.go")
-	require.NoError(t, err)
-
 	fileSet := token.NewFileSet()
-	routes := make([]registeredRoute, 0, len(files))
+	routes := make([]registeredRoute, 0, len(htmlUIRoutes))
 
-	for _, file := range files {
-		if strings.HasSuffix(file, "_test.go") {
-			continue
+	walkErr := filepath.WalkDir(".", func(file string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return skipNonModuleDir(file, entry)
+		}
+		if !strings.HasSuffix(file, ".go") || strings.HasSuffix(file, "_test.go") {
+			return nil
 		}
 
 		parsed, err := parser.ParseFile(fileSet, file, nil, parser.SkipObjectResolution)
@@ -178,10 +201,30 @@ func extractRegisteredRoutes(t *testing.T) []registeredRoute {
 			})
 			return true
 		})
-	}
+		return nil
+	})
+	require.NoError(t, walkErr)
 
 	require.NotEmpty(t, routes, "expected mux route registrations in the server source")
 	return routes
+}
+
+// skipNonModuleDir keeps the walk inside this module. It skips hidden
+// directories, testdata, and — the one that matters — any directory carrying
+// its own go.mod: a nested module is a separate build whose routes are not
+// ours to document, and a developer checkout sitting in the tree should not be
+// able to fail this suite.
+func skipNonModuleDir(dir string, entry fs.DirEntry) error {
+	if dir == "." {
+		return nil
+	}
+	if strings.HasPrefix(entry.Name(), ".") || entry.Name() == "testdata" {
+		return filepath.SkipDir
+	}
+	if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+		return filepath.SkipDir
+	}
+	return nil
 }
 
 // apiRoutes returns the registered routes openapi.yaml is expected to document,
@@ -350,6 +393,7 @@ func TestOpenAPI_ConstraintsMatchCode(t *testing.T) {
 	const (
 		upsertVehicle = "#/components/schemas/UpsertVehicleRequest/properties"
 		historyLimit  = "#/components/schemas/HistoryLimit"
+		tripListLimit = "#/components/schemas/TripListLimit"
 	)
 
 	constraints := []struct {
@@ -364,6 +408,8 @@ func TestOpenAPI_ConstraintsMatchCode(t *testing.T) {
 		{upsertVehicle + "/agency_tag", "maxLength", maxFieldLength, "maxFieldLength"},
 		{historyLimit, "maximum", maxHistoryLimit, "maxHistoryLimit"},
 		{historyLimit, "default", defaultHistoryLimit, "defaultHistoryLimit"},
+		{tripListLimit, "maximum", maxTripListLimit, "maxTripListLimit"},
+		{tripListLimit, "default", defaultTripListLimit, "defaultTripListLimit"},
 	}
 
 	for _, constraint := range constraints {


### PR DESCRIPTION
## Summary

Adds Milestone 5 deliverable 4: an OpenAPI 3.1 spec for the Vehicle Positions API, along with CI-enforced drift-guard tests that keep the spec in lock-step with the code.

Rebased onto current `main` (`81e7433`) and updated for review feedback — see **Changes since review** at the bottom.

## What

**`openapi.yaml`** is an OpenAPI 3.1.0 spec covering all 26 JSON API routes the server registers (21 paths, 27 schemas). Schemas, validation rules, and status codes were derived by reading each handler file, not from a plan document. It validates clean against `redocly lint`.

Vehicle-id constraints live in one shared `VehicleID` schema that every vehicle-id-shaped field references, rather than being restated per-field.

**`openapi_test.go`** parses the server's Go source with `go/ast` and holds the spec to it. Five of the eight tests are drift guards — each fails when the spec and the code disagree:

- `TestOpenAPI_AllRoutesDocumented` / `TestOpenAPI_NoExtraRoutes` — routes must match the mux registrations in both directions.
- `TestOpenAPI_AuthRequirementsMatchCode` — an operation's `security` block must match whether its handler is wrapped in `authMiddleware`, and authenticated routes must document `401`.
- `TestOpenAPI_AdminRoutesDocumentForbidden` — every route behind `adminMiddleware` must document `403`.
- `TestOpenAPI_ConstraintsMatchCode` — spec keywords must equal the Go constants they mirror: `vehicleIDPattern`, `maxVehicleIDLength`, `maxFieldLength`, `maxHistoryLimit`, `defaultHistoryLimit`, `maxTripListLimit`, `defaultTripListLimit`. Constraints that are bare literals in the handlers are deliberately not listed, since comparing a literal to a literal proves nothing.

The other three are structural rather than drift guards: `VehicleIDSchemaIsSingleSource` fails if anyone re-inlines the vehicle-id pattern, `AllRefsResolve` follows every `$ref`, and `HTMLUIExclusionsAreCurrent` keeps the admin-UI exclusion list from going stale.

Each guard was verified by mutation — introducing the drift it is meant to catch and confirming it fails — rather than by observing a green run.

**Coverage boundary:** the 25 server-rendered admin UI routes (`/admin/*` pages and form posts, plus `/static/`) are HTML rather than JSON, so the spec does not describe them. They are withheld by an explicit list in `openapi_test.go`, so adding a new one fails the suite until someone decides whether it belongs in the spec.

Route extraction walks the module rather than globbing the repo root, so moving a registration into a subpackage cannot blind the guard. Directories carrying their own `go.mod` are skipped — a nested module is a separate build.

**`README.md`** got a one-line Milestone 5 bullet that now links to `openapi.yaml`.

**`go.mod`** has `gopkg.in/yaml.v3` promoted from indirect to direct since the tests use it. No new transitive deps.

## Why

Milestone 5 in the README calls for an OpenAPI/Swagger spec as part of the architecture documentation, and nothing in the repo currently provides one. A static YAML file alone would rot the moment someone adds a route, so the real value here is the drift tests. They turn "keep the spec in sync" from a human-discipline problem into a CI failure.

The route check has now paid for itself three times: it caught two routes from an unmerged PR during development, then the four assignment endpoints from #60 on the first rebase, then 21 more from #86, #89, and #92 on the second. Every one of those would have been a silent documentation gap.

## Scope

Docs and tests only. No handler, route, middleware, schema, migration, or response code changed. The only module-graph change is promoting `yaml.v3` to a direct require.

## Changes since review

### Review of 2026-07-31

| # | Item | Resolution |
|---|---|---|
| 1 | Four assignment routes from #60 undocumented | All four documented with schemas read from `assignment_handlers.go` — the 1 KiB cap, the 404-vs-409 FK/duplicate split, the `200`-with-body on delete rather than `204`, and the empty array (not `404`) both list endpoints return for an unknown id |
| 2 | Confirm the guard survives #87's `newMux` refactor | Confirmed. The guard no longer depends on where routes live |
| 3 | `accuracy` documented `minimum: 0` that nothing enforces | Removed; documented as unvalidated |
| 4 | "latitude and longitude cannot both be zero" undocumented | Documented on `LocationReport` — a cross-field rule no JSON Schema keyword can express |
| 5 | Constants guard only covered `LocationReport.vehicle_id` | Shared `VehicleID` schema holds the constraints once; a second test fails if anyone re-inlines the pattern |
| 6 | Four of seven tests were self-referential | Removed, replaced with guards anchored to Go symbols |
| 7 | `registerAdminUI` routes invisible to a `main.go`-only scan | Visible and explicitly withheld — see **Coverage boundary** |
| 8 | `muxRegistrationPattern` matched inside comments | Gone; extraction parses the AST |

Also surfaced during that rebase: **#79 was closed, not merged.** #87 landed instead and applied `adminMiddleware` to all five admin user routes, so the spec's "the admin-role check is missing" notes described behavior that no longer existed. Removed, and the `403`s they promised are documented. Item 6's `403` guard would have caught this on its own.

### Review of 2026-09-02

| # | Item | Resolution |
|---|---|---|
| 9 | Rebase; 21 routes failing on current `main` | Rebased onto `81e7433`, no conflicts. Failure reproduced first, then fixed |
| 10 | Document `GET /api/v1/admin/vehicles/live` | Tracker snapshot joined with vehicle labels and active-trip context. Documented as live state, distinct from the recorded trail |
| 11 | Document `GET /api/v1/admin/trips` | `status` / `vehicle_id` / `q` filters, offset paging, `has_more` from reading one row past `limit` |
| 12 | Document `GET /api/v1/admin/trips/{id}/locations` | Trip summary plus trail. Documents `404` — not `400` — for a non-numeric id, because the handler treats an unparseable id as a missing trip |
| 13 | Add the 18 admin-UI routes from #92 to the exclusion list | Exclusion list rebuilt from source: 8 routes to 25, now including the form posts |
| 14 | Drop `GET /admin/signup` | Removed; #92 deleted the route |
| 15 | `POST /api/v1/auth/login` should document `429` | Documented, including that the limiter keys on client IP and submitted email and that a successful login clears the email's counter |

Two things not on that list, found while in there:

- **`ADMIN_UI_ENABLED` now defaults to on.** The spec still described the UI as registered "only when `ADMIN_UI_ENABLED` is set", which #92 made false. Corrected.
- `maxTripListLimit` and `defaultTripListLimit` are pinned into the constants guard via a named `TripListLimit` schema, alongside the existing ones.

## Notes

`redocly lint` reports 30 warnings, all stylistic and pre-existing: missing `operationId` on each operation, `localhost` as the dev server URL, and three endpoints with no 4xx response (`/health`, `/ready`, and the feed genuinely have none). Adding `operationId`s would help client codegen but is a separate concern.

## Local testing

- `go fmt ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — pass
- `npx @redocly/cli lint openapi.yaml` — valid OpenAPI 3.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive API documentation covering authentication, vehicle locations, trips, rides, administration, health checks, and GTFS-RT feeds.
  - Documented rider-mode configuration, location-data retention and privacy guidance, and clarified API and GTFS-RT references.

- **Tests**
  - Added automated checks to ensure API documentation matches available routes, authorization behavior, validation rules, response formats, and schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->