### PR TITLE
fix: gate admin user-management routes with adminMiddleware and add route-wiring regression tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,68 @@ import (
 //go:embed web/templates web/static
 var files embed.FS
 
+// appStore is the combined store interface required by newMux.
+// *Store implements all embedded interfaces.
+type appStore interface {
+	UserFetcher
+	UserLister
+	UserGetter
+	UserCreator
+	UserUpdater
+	UserDeleter
+	VehicleManager
+	LocationSaver
+	AssignmentCreator
+	AssignmentDeleter
+	AssignmentListerByUser
+	AssignmentListerByVehicle
+	TripStarter
+	TripEnder
+	HealthChecker
+}
+
+// newMux wires all application routes and returns the configured ServeMux.
+// Extracting route registration here allows tests to build the real mux
+// without a live database, catching middleware wiring gaps like the one fixed
+// in issue #82.
+func newMux(store appStore, tracker *Tracker, rateLimiter *VehicleRateLimiter, jwtSecret []byte, startTime time.Time) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	authMiddleware := requireAuth(jwtSecret)
+	adminMiddleware := requireAdmin()
+
+	mux.Handle("POST /api/v1/auth/login", handleLogin(store, jwtSecret))
+	mux.HandleFunc("GET /gtfs-rt/vehicle-positions", handleGetFeed(tracker))
+	mux.Handle("GET /api/v1/admin/status", authMiddleware(adminMiddleware(handleAdminStatus(tracker, startTime))))
+	mux.Handle("GET /api/v1/admin/vehicles", authMiddleware(adminMiddleware(handleListVehicles(store))))
+	mux.Handle("GET /api/v1/admin/vehicles/{id}", authMiddleware(adminMiddleware(handleGetVehicle(store))))
+	mux.Handle("POST /api/v1/admin/vehicles", authMiddleware(adminMiddleware(handleUpsertVehicle(store))))
+	mux.Handle("DELETE /api/v1/admin/vehicles/{id}", authMiddleware(adminMiddleware(handleDeactivateVehicle(store))))
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("GET /ready", handleReadiness(store))
+
+	mux.Handle("POST /api/v1/locations", authMiddleware(handlePostLocation(store, tracker, rateLimiter)))
+	mux.Handle("POST /api/v1/trips/start", authMiddleware(handleStartTrip(store)))
+	mux.Handle("POST /api/v1/trips/end", authMiddleware(handleEndTrip(store)))
+
+	// Admin user management
+	mux.Handle("GET /api/v1/admin/users", authMiddleware(adminMiddleware(handleListUsers(store))))
+	mux.Handle("GET /api/v1/admin/users/{id}", authMiddleware(adminMiddleware(handleGetUser(store))))
+	mux.Handle("POST /api/v1/admin/users", authMiddleware(adminMiddleware(handleCreateUser(store))))
+	mux.Handle("PUT /api/v1/admin/users/{id}", authMiddleware(adminMiddleware(handleUpdateUser(store))))
+	mux.Handle("DELETE /api/v1/admin/users/{id}", authMiddleware(adminMiddleware(handleDeleteUser(store))))
+
+	// Admin user-vehicle assignments
+	mux.Handle("POST /api/v1/admin/assignments", authMiddleware(adminMiddleware(handleCreateAssignment(store))))
+	mux.Handle("DELETE /api/v1/admin/users/{userID}/vehicles/{vehicleID}", authMiddleware(adminMiddleware(handleDeleteAssignment(store))))
+	mux.Handle("GET /api/v1/admin/users/{id}/vehicles", authMiddleware(adminMiddleware(handleListUserVehicles(store))))
+	mux.Handle("GET /api/v1/admin/vehicles/{id}/users", authMiddleware(adminMiddleware(handleListVehicleUsers(store))))
+
+	return mux
+}
+
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 
@@ -72,39 +134,7 @@ func main() {
 
 	startTime := time.Now()
 
-	mux := http.NewServeMux()
-
-	authMiddleware := requireAuth(jwtSecret)
-	adminMiddleware := requireAdmin()
-
-	mux.Handle("POST /api/v1/auth/login", handleLogin(store, jwtSecret))
-	mux.HandleFunc("GET /gtfs-rt/vehicle-positions", handleGetFeed(tracker))
-	mux.Handle("GET /api/v1/admin/status", authMiddleware(adminMiddleware(handleAdminStatus(tracker, startTime))))
-	mux.Handle("GET /api/v1/admin/vehicles", authMiddleware(adminMiddleware(handleListVehicles(store))))
-	mux.Handle("GET /api/v1/admin/vehicles/{id}", authMiddleware(adminMiddleware(handleGetVehicle(store))))
-	mux.Handle("POST /api/v1/admin/vehicles", authMiddleware(adminMiddleware(handleUpsertVehicle(store))))
-	mux.Handle("DELETE /api/v1/admin/vehicles/{id}", authMiddleware(adminMiddleware(handleDeactivateVehicle(store))))
-	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
-	})
-	mux.HandleFunc("GET /ready", handleReadiness(store))
-
-	mux.Handle("POST /api/v1/locations", authMiddleware(handlePostLocation(store, tracker, rateLimiter)))
-	mux.Handle("POST /api/v1/trips/start", authMiddleware(handleStartTrip(store)))
-	mux.Handle("POST /api/v1/trips/end", authMiddleware(handleEndTrip(store)))
-
-	// Admin user management
-	mux.Handle("GET /api/v1/admin/users", authMiddleware(handleListUsers(store)))
-	mux.Handle("GET /api/v1/admin/users/{id}", authMiddleware(handleGetUser(store)))
-	mux.Handle("POST /api/v1/admin/users", authMiddleware(handleCreateUser(store)))
-	mux.Handle("PUT /api/v1/admin/users/{id}", authMiddleware(handleUpdateUser(store)))
-	mux.Handle("DELETE /api/v1/admin/users/{id}", authMiddleware(handleDeleteUser(store)))
-
-	// Admin user-vehicle assignments
-	mux.Handle("POST /api/v1/admin/assignments", authMiddleware(adminMiddleware(handleCreateAssignment(store))))
-	mux.Handle("DELETE /api/v1/admin/users/{userID}/vehicles/{vehicleID}", authMiddleware(adminMiddleware(handleDeleteAssignment(store))))
-	mux.Handle("GET /api/v1/admin/users/{id}/vehicles", authMiddleware(adminMiddleware(handleListUserVehicles(store))))
-	mux.Handle("GET /api/v1/admin/vehicles/{id}/users", authMiddleware(adminMiddleware(handleListVehicleUsers(store))))
+	mux := newMux(store, tracker, rateLimiter, jwtSecret, startTime)
 
 	// Admin UI (server-rendered HTML). This is a proof-of-concept with
 	// placeholder data and no authentication, so it is disabled by default and

--- a/route_wiring_test.go
+++ b/route_wiring_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// noopStore satisfies appStore with no-op method bodies.
+// For driver-token tests, requireAdmin short-circuits before any store method
+// is called. For admin-token tests, handlers do reach the store; stubs return
+// zero values, which is safe for wiring-only assertions.
+type noopStore struct{}
+
+func (n *noopStore) GetUserByEmail(_ context.Context, _ string) (*User, error) {
+	return nil, nil
+}
+func (n *noopStore) ListUsers(_ context.Context) ([]UserResponse, error) {
+	return make([]UserResponse, 0), nil
+}
+func (n *noopStore) GetUser(_ context.Context, _ int64) (*UserResponse, error) {
+	return nil, nil
+}
+func (n *noopStore) CreateUser(_ context.Context, _, _, _, _ string) (*UserResponse, error) {
+	return nil, nil
+}
+func (n *noopStore) UpdateUser(_ context.Context, _ int64, _, _, _ string) (*UserResponse, error) {
+	return nil, nil
+}
+func (n *noopStore) DeleteUser(_ context.Context, _ int64) error {
+	return nil
+}
+func (n *noopStore) ListVehicles(_ context.Context) ([]VehicleResponse, error) {
+	return make([]VehicleResponse, 0), nil
+}
+func (n *noopStore) GetVehicle(_ context.Context, _ string) (*VehicleResponse, error) {
+	return nil, nil
+}
+func (n *noopStore) UpsertVehicle(_ context.Context, _, _, _ string) (*VehicleResponse, error) {
+	return nil, nil
+}
+func (n *noopStore) DeactivateVehicle(_ context.Context, _ string) error {
+	return nil
+}
+func (n *noopStore) SaveLocation(_ context.Context, _ *LocationReport) error {
+	return nil
+}
+func (n *noopStore) CreateAssignment(_ context.Context, _ int64, _ string) (*AssignmentResponse, error) {
+	return nil, nil
+}
+func (n *noopStore) DeleteAssignment(_ context.Context, _ int64, _ string) error {
+	return nil
+}
+func (n *noopStore) ListAssignmentsByUser(_ context.Context, _ int64) ([]AssignmentResponse, error) {
+	return make([]AssignmentResponse, 0), nil
+}
+func (n *noopStore) ListAssignmentsByVehicle(_ context.Context, _ string) ([]AssignmentResponse, error) {
+	return make([]AssignmentResponse, 0), nil
+}
+func (n *noopStore) StartTrip(_ context.Context, _ int64, _, _, _ string) (*TripResponse, error) {
+	return nil, nil
+}
+func (n *noopStore) EndTrip(_ context.Context, _, _ int64) error {
+	return nil
+}
+func (n *noopStore) Ping(_ context.Context) error {
+	return nil
+}
+
+// TestAdminRoutes_DriverTokenRejected verifies that every /api/v1/admin/* route
+// is wrapped with adminMiddleware. A valid driver-role JWT must receive 403 on
+// all admin routes — not 200, 401, or 404 — proving the middleware is wired.
+// Add new admin routes to the table so this test catches future wiring gaps.
+func TestAdminRoutes_DriverTokenRejected(t *testing.T) {
+	driverToken, err := generateJWT(&User{ID: 1, Email: "driver@test.com", Role: "driver"}, testSecret)
+	require.NoError(t, err)
+
+	// nil tracker and rateLimiter are safe: adminMiddleware rejects driver
+	// tokens before any handler body runs, so neither is dereferenced.
+	mux := newMux(&noopStore{}, nil, nil, testSecret, time.Time{})
+
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{"GET", "/api/v1/admin/status"},
+		{"GET", "/api/v1/admin/vehicles"},
+		{"GET", "/api/v1/admin/vehicles/bus-1"},
+		{"POST", "/api/v1/admin/vehicles"},
+		{"DELETE", "/api/v1/admin/vehicles/bus-1"},
+		{"GET", "/api/v1/admin/users"},
+		{"GET", "/api/v1/admin/users/1"},
+		{"POST", "/api/v1/admin/users"},
+		{"PUT", "/api/v1/admin/users/1"},
+		{"DELETE", "/api/v1/admin/users/1"},
+		{"POST", "/api/v1/admin/assignments"},
+		{"DELETE", "/api/v1/admin/users/1/vehicles/bus-1"},
+		{"GET", "/api/v1/admin/users/1/vehicles"},
+		{"GET", "/api/v1/admin/vehicles/bus-1/users"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+driverToken)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusForbidden, w.Code, "route %s %s must require admin role", tc.method, tc.path)
+
+			var resp map[string]string
+			err := json.NewDecoder(w.Body).Decode(&resp)
+			require.NoError(t, err)
+			assert.Equal(t, "admin access required", resp["error"])
+		})
+	}
+}
+
+// TestAdminRoutes_AdminTokenAllowed verifies that an admin-role JWT is not
+// blocked by adminMiddleware. Handler errors (nil store) are expected and
+// irrelevant — we only assert the middleware itself does not return 403.
+func TestAdminRoutes_AdminTokenAllowed(t *testing.T) {
+	adminToken, err := generateJWT(&User{ID: 2, Email: "admin@test.com", Role: "admin"}, testSecret)
+	require.NoError(t, err)
+
+	tracker := NewTracker(5 * time.Minute)
+	defer tracker.Stop()
+
+	mux := newMux(&noopStore{}, tracker, nil, testSecret, time.Time{})
+
+	// Same 14 routes as the driver-rejection table — every admin route must
+	// let a valid admin token through both middleware layers.
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{"GET", "/api/v1/admin/status"},
+		{"GET", "/api/v1/admin/vehicles"},
+		{"GET", "/api/v1/admin/vehicles/bus-1"},
+		{"POST", "/api/v1/admin/vehicles"},
+		{"DELETE", "/api/v1/admin/vehicles/bus-1"},
+		{"GET", "/api/v1/admin/users"},
+		{"GET", "/api/v1/admin/users/1"},
+		{"POST", "/api/v1/admin/users"},
+		{"PUT", "/api/v1/admin/users/1"},
+		{"DELETE", "/api/v1/admin/users/1"},
+		{"POST", "/api/v1/admin/assignments"},
+		{"DELETE", "/api/v1/admin/users/1/vehicles/bus-1"},
+		{"GET", "/api/v1/admin/users/1/vehicles"},
+		{"GET", "/api/v1/admin/vehicles/bus-1/users"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+adminToken)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			assert.NotEqual(t, http.StatusForbidden, w.Code, "admin token must not be blocked by adminMiddleware on %s %s", tc.method, tc.path)
+			assert.NotEqual(t, http.StatusUnauthorized, w.Code, "admin token must not be rejected by authMiddleware on %s %s", tc.method, tc.path)
+		})
+	}
+}


### PR DESCRIPTION
fixes : #85
## Summary

Fixes a privilege-escalation bug (#82) where the five `/api/v1/admin/users/*` routes were wrapped with `authMiddleware` only — any authenticated driver could list, create, update, and deactivate user accounts. Adds the route-wiring regression tests requested in #85 so the same gap can never silently reappear.


## What changed

**Modified (1)**

- **`main.go`** — Extracted all route registration into `newMux(store, tracker, rateLimiter, jwtSecret, startTime)` so tests can build the real mux without a live database. Added `adminMiddleware` to the five user-management routes that were missing it.

**New (1)**

- **`route_wiring_test.go`** — Two table-driven tests over all 14 `/api/v1/admin/*` routes:
  - `TestAdminRoutes_DriverTokenRejected` — a valid driver JWT must receive `403 + "admin access required"` on every admin route.
  - `TestAdminRoutes_AdminTokenAllowed` — a valid admin JWT must not be blocked by either middleware layer on any admin route.

## Design decisions

**Extract `newMux` instead of duplicating route registration in tests.** Copying the route table into the test would let the test pass even when `main.go`'s wiring is wrong. By calling the same `newMux` function, the test exercises the actual production wiring — a missing `adminMiddleware` in `main.go` fails the test directly.

**`noopStore` with zero-value stubs.** The driver-rejection tests never reach handler code (middleware short-circuits first), so store methods are never called. For the admin-allowed tests, stubs return safe zero values — enough to confirm middleware passes the request through without needing a real database.

**Both negative and positive paths.** Testing only that drivers get `403` is not enough — a double-wrapped or misconfigured middleware could also block admins. `TestAdminRoutes_AdminTokenAllowed` guards against that.

## Testing

- `go fmt ./...` — clean
-  `go vet ./...` — clean
-  `go test ./...` — all pass (28 new subtests across 2 test functions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to verify admin route access control and permission enforcement.

* **Refactor**
  * Improved internal code organization for route registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->