### PR TITLE
 fix: harden assignment store unique-constraint check and extract classifyAssignmentError

### DIFF
--- a/assignment_store.go
+++ b/assignment_store.go
@@ -51,21 +51,7 @@ func (s *Store) CreateAssignment(ctx context.Context, userID int64, vehicleID st
 		VehicleID: vehicleID,
 	})
 	if err != nil {
-		if isUniqueViolation(err) {
-			return nil, ErrAssignmentExists
-		}
-		if isFKViolation(err) {
-			name := fkConstraintName(err)
-			switch name {
-			case "user_vehicles_user_id_fkey":
-				return nil, ErrUserNotFoundFK
-			case "user_vehicles_vehicle_id_fkey":
-				return nil, ErrVehicleNotFoundFK
-			default:
-				return nil, fmt.Errorf("create assignment: unrecognized FK constraint %q: %w", name, err)
-			}
-		}
-		return nil, fmt.Errorf("create assignment: %w", err)
+		return nil, classifyAssignmentError(err)
 	}
 
 	return &AssignmentResponse{
@@ -73,6 +59,32 @@ func (s *Store) CreateAssignment(ctx context.Context, userID int64, vehicleID st
 		VehicleID: row.VehicleID,
 		CreatedAt: row.CreatedAt.Time,
 	}, nil
+}
+
+// classifyAssignmentError maps pgx constraint errors to domain errors.
+// Both the unique and FK paths check the constraint name explicitly: unrecognized
+// constraints return a wrapped 500 rather than a misleading domain sentinel, so
+// future schema additions surface as server errors instead of silent misclassifications.
+func classifyAssignmentError(err error) error {
+	if isUniqueViolation(err) {
+		name := pgConstraintName(err)
+		if name == "user_vehicles_pkey" {
+			return ErrAssignmentExists
+		}
+		return fmt.Errorf("create assignment: unrecognized unique constraint %q: %w", name, err)
+	}
+	if isFKViolation(err) {
+		name := pgConstraintName(err)
+		switch name {
+		case "user_vehicles_user_id_fkey":
+			return ErrUserNotFoundFK
+		case "user_vehicles_vehicle_id_fkey":
+			return ErrVehicleNotFoundFK
+		default:
+			return fmt.Errorf("create assignment: unrecognized FK constraint %q: %w", name, err)
+		}
+	}
+	return fmt.Errorf("create assignment: %w", err)
 }
 
 // DeleteAssignment removes a user-vehicle assignment. Returns ErrAssignmentNotFound if no row matched.
@@ -130,7 +142,7 @@ func isFKViolation(err error) bool {
 	return errors.As(err, &pgErr) && pgErr.Code == "23503"
 }
 
-func fkConstraintName(err error) string {
+func pgConstraintName(err error) string {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
 		return pgErr.ConstraintName

--- a/assignment_store_test.go
+++ b/assignment_store_test.go
@@ -316,52 +316,52 @@ func TestStore_CascadeDeleteVehicle(t *testing.T) {
 
 func TestPgErrorHelpers(t *testing.T) {
 	tests := []struct {
-		name           string
-		code           string
-		constraintName string
-		wantUnique     bool
-		wantFK         bool
-		wantFKName     string
+		name               string
+		code               string
+		constraintName     string
+		wantUnique         bool
+		wantFK             bool
+		wantConstraintName string
 	}{
 		{
-			name:           "unique violation",
-			code:           "23505",
-			constraintName: "user_vehicles_pkey",
-			wantUnique:     true,
-			wantFK:         false,
-			wantFKName:     "user_vehicles_pkey",
+			name:               "unique violation",
+			code:               "23505",
+			constraintName:     "user_vehicles_pkey",
+			wantUnique:         true,
+			wantFK:             false,
+			wantConstraintName: "user_vehicles_pkey",
 		},
 		{
-			name:           "FK violation user_id",
-			code:           "23503",
-			constraintName: "user_vehicles_user_id_fkey",
-			wantUnique:     false,
-			wantFK:         true,
-			wantFKName:     "user_vehicles_user_id_fkey",
+			name:               "FK violation user_id",
+			code:               "23503",
+			constraintName:     "user_vehicles_user_id_fkey",
+			wantUnique:         false,
+			wantFK:             true,
+			wantConstraintName: "user_vehicles_user_id_fkey",
 		},
 		{
-			name:           "FK violation vehicle_id",
-			code:           "23503",
-			constraintName: "user_vehicles_vehicle_id_fkey",
-			wantUnique:     false,
-			wantFK:         true,
-			wantFKName:     "user_vehicles_vehicle_id_fkey",
+			name:               "FK violation vehicle_id",
+			code:               "23503",
+			constraintName:     "user_vehicles_vehicle_id_fkey",
+			wantUnique:         false,
+			wantFK:             true,
+			wantConstraintName: "user_vehicles_vehicle_id_fkey",
 		},
 		{
-			name:           "FK violation unrecognized constraint",
-			code:           "23503",
-			constraintName: "user_vehicles_unknown_fkey",
-			wantUnique:     false,
-			wantFK:         true,
-			wantFKName:     "user_vehicles_unknown_fkey",
+			name:               "FK violation unrecognized constraint",
+			code:               "23503",
+			constraintName:     "user_vehicles_unknown_fkey",
+			wantUnique:         false,
+			wantFK:             true,
+			wantConstraintName: "user_vehicles_unknown_fkey",
 		},
 		{
-			name:           "other error code",
-			code:           "42P01",
-			constraintName: "",
-			wantUnique:     false,
-			wantFK:         false,
-			wantFKName:     "",
+			name:               "other error code",
+			code:               "42P01",
+			constraintName:     "",
+			wantUnique:         false,
+			wantFK:             false,
+			wantConstraintName: "",
 		},
 	}
 
@@ -370,14 +370,82 @@ func TestPgErrorHelpers(t *testing.T) {
 			pgErr := &pgconn.PgError{Code: tc.code, ConstraintName: tc.constraintName}
 			assert.Equal(t, tc.wantUnique, isUniqueViolation(pgErr))
 			assert.Equal(t, tc.wantFK, isFKViolation(pgErr))
-			assert.Equal(t, tc.wantFKName, fkConstraintName(pgErr))
+			assert.Equal(t, tc.wantConstraintName, pgConstraintName(pgErr))
 		})
 	}
 }
 
-func TestFkConstraintName_NonPgError(t *testing.T) {
+func TestPgConstraintName_NonPgError(t *testing.T) {
 	err := errors.New("not a pg error")
-	assert.Equal(t, "", fkConstraintName(err))
+	assert.Equal(t, "", pgConstraintName(err))
 	assert.False(t, isUniqueViolation(err))
 	assert.False(t, isFKViolation(err))
+}
+
+func TestClassifyAssignmentError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantIs      error
+		wantNoneOf  []error
+		wantContain string
+		wantWraps   bool
+	}{
+		{
+			name:   "known unique constraint maps to ErrAssignmentExists",
+			err:    &pgconn.PgError{Code: "23505", ConstraintName: "user_vehicles_pkey"},
+			wantIs: ErrAssignmentExists,
+		},
+		{
+			name:        "unknown unique constraint returns wrapped 500",
+			err:         &pgconn.PgError{Code: "23505", ConstraintName: "user_vehicles_email_key"},
+			wantNoneOf:  []error{ErrAssignmentExists, ErrUserNotFoundFK, ErrVehicleNotFoundFK},
+			wantContain: "unrecognized unique constraint",
+			wantWraps:   true,
+		},
+		{
+			name:   "user FK violation maps to ErrUserNotFoundFK",
+			err:    &pgconn.PgError{Code: "23503", ConstraintName: "user_vehicles_user_id_fkey"},
+			wantIs: ErrUserNotFoundFK,
+		},
+		{
+			name:   "vehicle FK violation maps to ErrVehicleNotFoundFK",
+			err:    &pgconn.PgError{Code: "23503", ConstraintName: "user_vehicles_vehicle_id_fkey"},
+			wantIs: ErrVehicleNotFoundFK,
+		},
+		{
+			name:        "unknown FK constraint returns wrapped 500",
+			err:         &pgconn.PgError{Code: "23503", ConstraintName: "user_vehicles_unknown_fkey"},
+			wantNoneOf:  []error{ErrAssignmentExists, ErrUserNotFoundFK, ErrVehicleNotFoundFK},
+			wantContain: "unrecognized FK constraint",
+			wantWraps:   true,
+		},
+		{
+			name:        "non-constraint error is wrapped generically",
+			err:         errors.New("connection reset"),
+			wantNoneOf:  []error{ErrAssignmentExists, ErrUserNotFoundFK, ErrVehicleNotFoundFK},
+			wantContain: "create assignment",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := classifyAssignmentError(tc.err)
+			require.Error(t, result)
+
+			if tc.wantIs != nil {
+				assert.ErrorIs(t, result, tc.wantIs)
+			}
+			for _, sentinel := range tc.wantNoneOf {
+				assert.False(t, errors.Is(result, sentinel), "result must not match sentinel %v", sentinel)
+			}
+			if tc.wantContain != "" {
+				assert.Contains(t, result.Error(), tc.wantContain)
+			}
+			if tc.wantWraps {
+				var pgErr *pgconn.PgError
+				assert.True(t, errors.As(result, &pgErr), "expected original pgError to be preserved in the wrapped error chain")
+			}
+		})
+	}
 }


### PR DESCRIPTION
 Closes #83
## Summary

`CreateAssignment` mapped any `23505` Postgres error to `ErrAssignmentExists` / HTTP 409 without checking the constraint name. Today that's safe because `user_vehicles_pkey` is the only unique constraint on the table — but a future migration adding a second unique index would silently produce a misleading 409 with no server-side error logged.

Extracts a `classifyAssignmentError` helper that mirrors the existing FK path: verifies `ConstraintName == "user_vehicles_pkey"` before returning `ErrAssignmentExists`, and falls through to a wrapped 500 for anything unrecognized. Also renames `fkConstraintName` → `pgConstraintName` since the function returns `pgErr.ConstraintName` for any Postgres error, not just FK violations.

## What changed

**Modified (2)**

- **`assignment_store.go`** — Extracted `classifyAssignmentError`; unique-violation path now checks the constraint name; renamed `fkConstraintName` → `pgConstraintName`.
- **`assignment_store_test.go`** — Added `TestClassifyAssignmentError`: 6 table-driven cases covering all branches, including both previously-untested `default` arms. Updated `TestPgErrorHelpers` and `TestPgConstraintName_NonPgError` to use the renamed helper.

## Testing

-  `go fmt ./...` — clean
-  `go vet ./...` — clean
-  `go test ./...` — all pass