### PR TITLE
docs: document full response contract for POST /api/v1/locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,37 +154,56 @@ The server updates its in-memory state with the latest position and persists the
 
 **`POST /api/v1/locations` validation and error contract**
 
-The ingest endpoint performs strict request validation before writing data:
+The ingest endpoint requires a driver JWT (`Authorization: Bearer <token>`)
+and performs strict request validation before writing data:
 
 - `Content-Type` must be `application/json` (charset parameters are allowed).
 - The request body must contain exactly one JSON object.
 - Unknown JSON fields are rejected.
 - Standard payload validation still applies (`vehicle_id`, coordinates, timestamp).
+- Reports are rate limited to one per five seconds per driver.
 
 Response codes:
 
 - `201 Created` — location accepted and persisted.
 - `400 Bad Request` — invalid JSON or payload validation failure.
+- `401 Unauthorized` — missing, malformed, or expired bearer token.
 - `415 Unsupported Media Type` — non-JSON `Content-Type`.
+- `429 Too Many Requests` — driver exceeded the ingest rate limit.
+- `500 Internal Server Error` — the location could not be persisted. The
+  in-memory tracker is left untouched, so a failed write never reaches the
+  GTFS-RT feed.
 
 Examples:
 
 ```bash
 # Valid request
 curl -i -X POST http://localhost:8080/api/v1/locations \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"vehicle_id":"bus-1","trip_id":"route-5","latitude":-1.29,"longitude":36.82,"timestamp":1752566400}'
+  -d '{"vehicle_id":"bus-1","trip_id":"route-5","latitude":-1.29,"longitude":36.82,"timestamp":'"$(date +%s)"'}'
+
+# Missing bearer token -> 401
+curl -i -X POST http://localhost:8080/api/v1/locations \
+  -H "Content-Type: application/json" \
+  -d '{"vehicle_id":"bus-1","latitude":-1.29,"longitude":36.82,"timestamp":'"$(date +%s)"'}'
 
 # Invalid content type -> 415
 curl -i -X POST http://localhost:8080/api/v1/locations \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: text/plain" \
-  -d '{"vehicle_id":"bus-1","latitude":-1.29,"longitude":36.82,"timestamp":1752566400}'
+  -d '{"vehicle_id":"bus-1","latitude":-1.29,"longitude":36.82,"timestamp":'"$(date +%s)"'}'
 
 # Trailing JSON value -> 400
 curl -i -X POST http://localhost:8080/api/v1/locations \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"vehicle_id":"bus-1","latitude":-1.29,"longitude":36.82,"timestamp":1752566400}{"extra":1}'
+  -d '{"vehicle_id":"bus-1","latitude":-1.29,"longitude":36.82,"timestamp":'"$(date +%s)"'}{"extra":1}'
 ```
+
+`$TOKEN` is the JWT returned by `POST /api/v1/auth/login`. The examples use
+`$(date +%s)` rather than a fixed timestamp because reports more than five
+minutes from server time are rejected with `400`.
 
 **Technology Stack:**
 


### PR DESCRIPTION
The README lists 201, 400, and 415 for the ingest endpoint, but the handler also returns 401 from `requireAuth`, 429 from the per-driver rate limiter, and 500 when `SaveLocation` fails. A client written against these docs has no way to know it has to handle those.

This documents the three missing codes and notes the bearer-token and rate-limit requirements alongside the existing validation rules.

I also fixed the curl examples in the same section, since none of them currently produce the response they claim to demonstrate: they send no `Authorization` header, so they all return 401, and the hard-coded `1752566400` timestamps are outside the five-minute skew window enforced in `handlers.go`, so they would return 400 even with a valid token. They now use `$TOKEN` and `$(date +%s)`, and I added a 401 example.

Docs only — no code changes.

Closes #73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated location-ingest guidance to require bearer-token authentication.
  * Documented role-based access errors, including `401 Unauthorized` and `403 Forbidden` responses.
  * Documented five-second per-driver rate limiting and possible `429` and `500` responses.
  * Clarified timestamp freshness requirements, including rejection of reports more than five minutes from server time.
  * Explained that failed persistence leaves tracking and feed data unchanged.
  * Added authenticated request examples, token guidance, and a missing-token `401` example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->