### PR TITLE
Authenticate the simulator before it posts location reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ smoke:
 	@echo
 
 simulate:
-	go run ./cmd/simulator -url http://localhost:8080 -vehicles 1 -interval 6s -duration 30s
+	go run ./cmd/simulator -url http://localhost:8080 -vehicles 5 -interval 6s -duration 30s
 
 ridersim:
 	go run ./cmd/ridersim -url http://localhost:$(PORT) -gtfs rider/testdata/fixture.zip -trip T1 -interval 1s -speed 10 -expect-end arrived

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ smoke:
 	@echo
 
 simulate:
-	go run ./cmd/simulator -url http://localhost:8080 -vehicles 5 -interval 6s -duration 30s
+	go run ./cmd/simulator -url http://localhost:$(PORT) -vehicles 5 -interval 6s -duration 30s
 
 ridersim:
 	go run ./cmd/ridersim -url http://localhost:$(PORT) -gtfs rider/testdata/fixture.zip -trip T1 -interval 1s -speed 10 -expect-end arrived

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help:
 	@echo "  make down      - Stop local docker compose stack"
 	@echo "  make run       - Run server locally (expects DATABASE_URL env var)"
 	@echo "  make smoke     - Post sample location and fetch feed/status"
-	@echo "  make simulate  - Run simulator against local server"
+	@echo "  make simulate  - Run simulator against local server (needs ADMIN_BOOTSTRAP_EMAIL/PASSWORD)"
 	@echo "  make ridersim  - Run rider simulator against local server (rider mode; honours PORT)"
 	@echo "  make generate  - Regenerate sqlc code"
 	@echo "  make fmt       - Format Go code"

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ smoke:
 	@echo
 
 simulate:
-	go run ./cmd/simulator -url http://localhost:8080 -vehicles 5 -interval 3s -duration 30s
+	go run ./cmd/simulator -url http://localhost:8080 -vehicles 1 -interval 6s -duration 30s
 
 ridersim:
 	go run ./cmd/ridersim -url http://localhost:$(PORT) -gtfs rider/testdata/fixture.zip -trip T1 -interval 1s -speed 10 -expect-end arrived

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"sync"
@@ -34,6 +36,41 @@ type stats struct {
 	totalMS   atomic.Int64
 }
 
+// checkBaseURL rejects a destination that would put the password and the
+// session token on the wire in cleartext. Plain HTTP stays allowed for
+// loopback, which is the default and the only way the simulator is normally
+// run, but anything remote has to be HTTPS.
+func checkBaseURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid -url %q: %w", raw, err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid -url %q: no host", raw)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+		return fmt.Errorf("-url %q sends the login password and the bearer token in cleartext; use https for a remote host", raw)
+	default:
+		return fmt.Errorf("invalid -url %q: scheme must be http or https", raw)
+	}
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
 func main() {
 	baseURL := flag.String("url", "http://localhost:8080", "Server base URL")
 	numVehicles := flag.Int("vehicles", 10, "Number of simulated vehicles")
@@ -56,6 +93,10 @@ func main() {
 	if *duration > 0 {
 		ctx, cancel = context.WithTimeout(ctx, *duration)
 		defer cancel()
+	}
+
+	if err := checkBaseURL(*baseURL); err != nil {
+		log.Fatal(err)
 	}
 
 	if *email == "" || *password == "" {

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -138,7 +138,7 @@ func main() {
 			"so pass -email/-password or set ADMIN_BOOTSTRAP_EMAIL and ADMIN_BOOTSTRAP_PASSWORD")
 	}
 
-	bootstrap := &http.Client{Timeout: 10 * time.Second}
+	bootstrap := &http.Client{Timeout: 10 * time.Second, CheckRedirect: sameOriginOnly(*baseURL)}
 	adminToken, err := login(ctx, bootstrap, *baseURL, *email, *password)
 	if err != nil {
 		log.Fatalf("login failed: %v", err)
@@ -162,8 +162,9 @@ func main() {
 	clients := make([]*http.Client, len(tokens))
 	for i, t := range tokens {
 		clients[i] = &http.Client{
-			Timeout:   10 * time.Second,
-			Transport: bearerTransport{token: t, base: http.DefaultTransport},
+			Timeout:       10 * time.Second,
+			Transport:     bearerTransport{token: t, base: http.DefaultTransport},
+			CheckRedirect: sameOriginOnly(*baseURL),
 		}
 	}
 
@@ -371,6 +372,43 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 		return false
 	case <-t.C:
 		return true
+	}
+}
+
+// canonicalOrigin is scheme://host:port with the scheme's default port made
+// explicit, so http://h and http://h:80 compare equal.
+func canonicalOrigin(u *url.URL) string {
+	host, port := u.Hostname(), u.Port()
+	if port == "" {
+		switch u.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+	return u.Scheme + "://" + net.JoinHostPort(host, port)
+}
+
+// sameOriginOnly refuses a redirect that leaves the origin checkBaseURL
+// validated. http.Client normally strips Authorization when a redirect crosses
+// origins, but bearerTransport sets the header inside RoundTrip, which runs
+// again for every hop and puts it back. Without this a redirect could hand a
+// driver's token, or the admin password on the login hop, to another host.
+func sameOriginOnly(base string) func(*http.Request, []*http.Request) error {
+	u, err := url.Parse(base)
+	if err != nil {
+		return func(*http.Request, []*http.Request) error { return err }
+	}
+	want := canonicalOrigin(u)
+	return func(req *http.Request, via []*http.Request) error {
+		if got := canonicalOrigin(req.URL); got != want {
+			return fmt.Errorf("refusing redirect to %s: it would send credentials to an origin other than %s", got, want)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
 	}
 }
 

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -14,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -44,22 +47,27 @@ type stats struct {
 // allows one location report per driver per this long, keyed on the JWT sub.
 const perDriverReportInterval = 5 * time.Second
 
-// reportBudgetWarning explains the shortfall when the requested rate exceeds
-// what one login is allowed, which is every run with more than one vehicle
-// because all of them authenticate as the same user.
+// provisionStagger spaces the driver logins out and provisionBackoff is how
+// long a refused one waits: the server allows ten logins per IP per minute, so
+// a refusal has to sit out most of that window.
+const (
+	provisionStagger  = 250 * time.Millisecond
+	provisionBackoff  = 12 * time.Second
+	provisionAttempts = 10
+)
+
+// reportBudgetWarning explains the shortfall when a single vehicle reports
+// faster than the server's per-driver allowance. Each vehicle authenticates as
+// its own driver, so the budget is per vehicle and does not shrink as more are
+// added.
 func reportBudgetWarning(vehicles int, interval time.Duration) string {
-	if vehicles <= 0 || interval <= 0 {
-		return ""
-	}
-	needed := time.Duration(vehicles) * perDriverReportInterval
-	if interval >= needed {
+	if vehicles <= 0 || interval <= 0 || interval >= perDriverReportInterval {
 		return ""
 	}
 	return fmt.Sprintf(
-		"%d vehicles every %s is %s per report, but the server allows one per %s per driver "+
-			"and every vehicle here logs in as the same user, so most reports will come back 429. "+
-			"Use -vehicles 1, or -interval %s, until the simulator can hold one account per vehicle.",
-		vehicles, interval, interval/time.Duration(vehicles), perDriverReportInterval, needed)
+		"-interval %s is faster than the one report per %s the server allows each driver, "+
+			"so most reports will come back 429. Use -interval %s or slower.",
+		interval, perDriverReportInterval, perDriverReportInterval)
 }
 
 func checkBaseURL(raw string) error {
@@ -130,15 +138,35 @@ func main() {
 			"so pass -email/-password or set ADMIN_BOOTSTRAP_EMAIL and ADMIN_BOOTSTRAP_PASSWORD")
 	}
 
-	token, err := login(ctx, &http.Client{Timeout: 10 * time.Second}, *baseURL, *email, *password)
+	bootstrap := &http.Client{Timeout: 10 * time.Second}
+	adminToken, err := login(ctx, bootstrap, *baseURL, *email, *password)
 	if err != nil {
 		log.Fatalf("login failed: %v", err)
 	}
 
-	client := &http.Client{
-		Timeout:   10 * time.Second,
-		Transport: bearerTransport{token: token, base: http.DefaultTransport},
+	runID, err := randomSecret()
+	if err != nil {
+		log.Fatal(err)
 	}
+	runID = runID[:8]
+
+	log.Printf("provisioning %d driver accounts", *numVehicles)
+	tokens, err := provisionDrivers(ctx, bootstrap, *baseURL, adminToken, runID, *numVehicles)
+	if err != nil {
+		log.Fatalf("provisioning drivers: %v", err)
+	}
+
+	// One client per vehicle, each carrying its own driver's token. The tokens
+	// are good for 24h and are never refreshed, so a -duration 0 run left going
+	// for longer than that will start seeing 401s.
+	clients := make([]*http.Client, len(tokens))
+	for i, t := range tokens {
+		clients[i] = &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: bearerTransport{token: t, base: http.DefaultTransport},
+		}
+	}
+
 	s := &stats{}
 
 	log.Printf("starting simulator: %d vehicles, interval=%s, duration=%s", *numVehicles, *interval, *duration)
@@ -150,7 +178,7 @@ func main() {
 		route := routes[i%len(routes)]
 		go func() {
 			defer wg.Done()
-			simulateVehicle(ctx, client, *baseURL, vehicleID, route, *interval, s)
+			simulateVehicle(ctx, clients[i], *baseURL, vehicleID, route, *interval, s)
 		}()
 	}
 	wg.Wait()
@@ -231,6 +259,119 @@ func (t bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
 	req.Header.Set("Authorization", "Bearer "+t.token)
 	return t.base.RoundTrip(req)
+}
+
+// createUserRequest is the POST /api/v1/admin/users body.
+type createUserRequest struct {
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
+// provisionDrivers creates one driver account per vehicle and logs each in, so
+// every vehicle reports under its own JWT sub. The server rate-limits location
+// reports per driver, so a shared login would put every vehicle in one bucket
+// and turn most reports into 429s.
+//
+// runID keeps the accounts of concurrent or repeated runs from colliding.
+func provisionDrivers(ctx context.Context, client *http.Client, baseURL, adminToken, runID string, n int) ([]string, error) {
+	tokens := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		email := fmt.Sprintf("sim-driver-%03d-%s@simulator.invalid", i+1, runID)
+		password, err := randomSecret()
+		if err != nil {
+			return nil, err
+		}
+		if err := createDriver(ctx, client, baseURL, adminToken, email, password, i+1); err != nil {
+			return nil, err
+		}
+		token, err := loginWithRetry(ctx, client, baseURL, email, password)
+		if err != nil {
+			return nil, fmt.Errorf("driver %d: %w", i+1, err)
+		}
+		tokens = append(tokens, token)
+		if i < n-1 && !sleepCtx(ctx, provisionStagger) {
+			return nil, ctx.Err()
+		}
+	}
+	return tokens, nil
+}
+
+func createDriver(ctx context.Context, client *http.Client, baseURL, adminToken, email, password string, n int) error {
+	body, err := json.Marshal(createUserRequest{
+		Name:     fmt.Sprintf("Simulated Driver %03d", n),
+		Email:    email,
+		Password: password,
+		Role:     "driver",
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/v1/admin/users", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("creating driver %d: %w", n, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
+		return fmt.Errorf("POST /api/v1/admin/users for driver %d returned %d: %s. "+
+			"The account this simulator logs in with must have the admin role",
+			n, resp.StatusCode, bytes.TrimSpace(msg))
+	}
+	return nil
+}
+
+// loginWithRetry backs off past a 429 from the per-IP login limiter, which one
+// login per vehicle will reach on a run with more than ten of them.
+func loginWithRetry(ctx context.Context, client *http.Client, baseURL, email, password string) (string, error) {
+	var lastErr error
+	for attempt := 1; attempt <= provisionAttempts; attempt++ {
+		token, err := login(ctx, client, baseURL, email, password)
+		if err == nil {
+			return token, nil
+		}
+		lastErr = err
+		if !strings.Contains(err.Error(), "429") {
+			return "", err
+		}
+		if attempt == provisionAttempts {
+			break
+		}
+		log.Printf("login refused (429), waiting %s (attempt %d/%d)", provisionBackoff, attempt, provisionAttempts)
+		if !sleepCtx(ctx, provisionBackoff) {
+			return "", ctx.Err()
+		}
+	}
+	return "", lastErr
+}
+
+// randomSecret returns a password for an account that only this run uses.
+func randomSecret() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating a driver password: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// sleepCtx reports whether it slept the whole duration rather than being cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // login exchanges credentials for a session token via POST /api/v1/auth/login.

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"os/signal"
 	"sync"
 	"sync/atomic"
@@ -37,6 +39,8 @@ func main() {
 	numVehicles := flag.Int("vehicles", 10, "Number of simulated vehicles")
 	interval := flag.Duration("interval", 10*time.Second, "Time between location reports per vehicle")
 	duration := flag.Duration("duration", 5*time.Minute, "Total simulation duration (0 = run until Ctrl+C)")
+	email := flag.String("email", os.Getenv("ADMIN_BOOTSTRAP_EMAIL"), "Account email for login (default $ADMIN_BOOTSTRAP_EMAIL)")
+	password := flag.String("password", os.Getenv("ADMIN_BOOTSTRAP_PASSWORD"), "Account password for login (default $ADMIN_BOOTSTRAP_PASSWORD)")
 	flag.Parse()
 
 	if *numVehicles <= 0 {
@@ -54,7 +58,20 @@ func main() {
 		defer cancel()
 	}
 
-	client := &http.Client{Timeout: 10 * time.Second}
+	if *email == "" || *password == "" {
+		log.Fatal("email and password are required: POST /api/v1/locations is authenticated, " +
+			"so pass -email/-password or set ADMIN_BOOTSTRAP_EMAIL and ADMIN_BOOTSTRAP_PASSWORD")
+	}
+
+	token, err := login(ctx, &http.Client{Timeout: 10 * time.Second}, *baseURL, *email, *password)
+	if err != nil {
+		log.Fatalf("login failed: %v", err)
+	}
+
+	client := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: bearerTransport{token: token, base: http.DefaultTransport},
+	}
 	s := &stats{}
 
 	log.Printf("starting simulator: %d vehicles, interval=%s, duration=%s", *numVehicles, *interval, *duration)
@@ -133,6 +150,56 @@ func simulateVehicle(ctx context.Context, client *http.Client, baseURL, vehicleI
 			sendReport(ctx, client, baseURL, vehicleID, &report, s)
 		}
 	}
+}
+
+// bearerTransport attaches the session token to every simulator request.
+// Reports go to POST /api/v1/locations, which sits behind requireAuth, so an
+// unauthenticated run fails with 401 on every single report.
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+t.token)
+	return t.base.RoundTrip(req)
+}
+
+// login exchanges credentials for a session token via POST /api/v1/auth/login.
+func login(ctx context.Context, client *http.Client, baseURL, email, password string) (string, error) {
+	body, err := json.Marshal(map[string]string{"email": email, "password": password})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/v1/auth/login", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("POST /api/v1/auth/login returned %d: %s", resp.StatusCode, bytes.TrimSpace(msg))
+	}
+
+	var out struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&out); err != nil {
+		return "", fmt.Errorf("decoding login response: %w", err)
+	}
+	if out.Token == "" {
+		return "", errors.New("login response contained no token")
+	}
+	return out.Token, nil
 }
 
 func sendReport(ctx context.Context, client *http.Client, baseURL, vehicleID string, report *locationReport, s *stats) {

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -40,6 +40,28 @@ type stats struct {
 // session token on the wire in cleartext. Plain HTTP stays allowed for
 // loopback, which is the default and the only way the simulator is normally
 // run, but anything remote has to be HTTPS.
+// perDriverReportInterval mirrors rateInterval in ratelimit.go: the server
+// allows one location report per driver per this long, keyed on the JWT sub.
+const perDriverReportInterval = 5 * time.Second
+
+// reportBudgetWarning explains the shortfall when the requested rate exceeds
+// what one login is allowed, which is every run with more than one vehicle
+// because all of them authenticate as the same user.
+func reportBudgetWarning(vehicles int, interval time.Duration) string {
+	if vehicles <= 0 || interval <= 0 {
+		return ""
+	}
+	needed := time.Duration(vehicles) * perDriverReportInterval
+	if interval >= needed {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%d vehicles every %s is %s per report, but the server allows one per %s per driver "+
+			"and every vehicle here logs in as the same user, so most reports will come back 429. "+
+			"Use -vehicles 1, or -interval %s, until the simulator can hold one account per vehicle.",
+		vehicles, interval, interval/time.Duration(vehicles), perDriverReportInterval, needed)
+}
+
 func checkBaseURL(raw string) error {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -97,6 +119,10 @@ func main() {
 
 	if err := checkBaseURL(*baseURL); err != nil {
 		log.Fatal(err)
+	}
+
+	if warning := reportBudgetWarning(*numVehicles, *interval); warning != "" {
+		log.Printf("warning: %s", warning)
 	}
 
 	if *email == "" || *password == "" {

--- a/cmd/simulator/main_test.go
+++ b/cmd/simulator/main_test.go
@@ -386,3 +386,29 @@ func TestCheckBaseURL(t *testing.T) {
 		}
 	}
 }
+
+func TestReportBudgetWarning(t *testing.T) {
+	// The old `make simulate` defaults: 5 vehicles every 3s against a budget of
+	// one report per 5s for the single shared login.
+	if got := reportBudgetWarning(5, 3*time.Second); got == "" {
+		t.Error("reportBudgetWarning(5, 3s) = \"\", want a warning")
+	}
+	// The new defaults, and anything else that fits the budget, stay quiet.
+	for _, tc := range []struct {
+		vehicles int
+		interval time.Duration
+	}{
+		{1, 6 * time.Second},
+		{1, 5 * time.Second},
+		{2, 10 * time.Second},
+		{4, time.Minute},
+	} {
+		if got := reportBudgetWarning(tc.vehicles, tc.interval); got != "" {
+			t.Errorf("reportBudgetWarning(%d, %s) = %q, want \"\"", tc.vehicles, tc.interval, got)
+		}
+	}
+	// Nonsense input must not warn rather than dividing by zero.
+	if got := reportBudgetWarning(0, 0); got != "" {
+		t.Errorf("reportBudgetWarning(0, 0) = %q, want \"\"", got)
+	}
+}

--- a/cmd/simulator/main_test.go
+++ b/cmd/simulator/main_test.go
@@ -358,3 +358,31 @@ func TestBearerTransportSetsAuthorizationHeader(t *testing.T) {
 
 	assert.Equal(t, "Bearer tok-123", gotAuth)
 }
+
+func TestCheckBaseURL(t *testing.T) {
+	allowed := []string{
+		"http://localhost:8080",
+		"http://127.0.0.1:8080",
+		"http://[::1]:8080",
+		"https://example.org",
+		"https://example.org:8443/base",
+	}
+	for _, raw := range allowed {
+		if err := checkBaseURL(raw); err != nil {
+			t.Errorf("checkBaseURL(%q) = %v, want nil", raw, err)
+		}
+	}
+
+	rejected := []string{
+		"http://example.org",       // credentials in cleartext to a remote host
+		"http://192.168.1.10:8080", // private, still not loopback
+		"ftp://example.org",        // not an HTTP scheme
+		"https://",                 // no host
+		"://nonsense",              // unparseable
+	}
+	for _, raw := range rejected {
+		if err := checkBaseURL(raw); err == nil {
+			t.Errorf("checkBaseURL(%q) = nil, want an error", raw)
+		}
+	}
+}

--- a/cmd/simulator/main_test.go
+++ b/cmd/simulator/main_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -388,27 +389,91 @@ func TestCheckBaseURL(t *testing.T) {
 }
 
 func TestReportBudgetWarning(t *testing.T) {
-	// The old `make simulate` defaults: 5 vehicles every 3s against a budget of
-	// one report per 5s for the single shared login.
-	if got := reportBudgetWarning(5, 3*time.Second); got == "" {
-		t.Error("reportBudgetWarning(5, 3s) = \"\", want a warning")
-	}
-	// The new defaults, and anything else that fits the budget, stay quiet.
-	for _, tc := range []struct {
-		vehicles int
-		interval time.Duration
-	}{
-		{1, 6 * time.Second},
-		{1, 5 * time.Second},
-		{2, 10 * time.Second},
-		{4, time.Minute},
-	} {
-		if got := reportBudgetWarning(tc.vehicles, tc.interval); got != "" {
-			t.Errorf("reportBudgetWarning(%d, %s) = %q, want \"\"", tc.vehicles, tc.interval, got)
+	// Each vehicle logs in as its own driver, so the budget is one report per
+	// perDriverReportInterval per vehicle and the vehicle count does not enter
+	// into it. Only an interval faster than that allowance warns.
+	for _, vehicles := range []int{1, 2, 5, 20} {
+		if got := reportBudgetWarning(vehicles, 3*time.Second); got == "" {
+			t.Errorf("reportBudgetWarning(%d, 3s) = \"\", want a warning", vehicles)
 		}
+		for _, interval := range []time.Duration{5 * time.Second, 6 * time.Second, time.Minute} {
+			if got := reportBudgetWarning(vehicles, interval); got != "" {
+				t.Errorf("reportBudgetWarning(%d, %s) = %q, want \"\"", vehicles, interval, got)
+			}
+		}
+	}
+	// Adding vehicles used to shrink the per-vehicle budget. It must not now.
+	if got := reportBudgetWarning(50, perDriverReportInterval); got != "" {
+		t.Errorf("reportBudgetWarning(50, %s) = %q, want \"\"", perDriverReportInterval, got)
 	}
 	// Nonsense input must not warn rather than dividing by zero.
 	if got := reportBudgetWarning(0, 0); got != "" {
 		t.Errorf("reportBudgetWarning(0, 0) = %q, want \"\"", got)
+	}
+}
+
+// TestProvisionDriversGivesEachVehicleItsOwnIdentity pins the reason this
+// exists: the server rate-limits location reports per driver, so N vehicles
+// need N distinct accounts and N distinct tokens.
+func TestProvisionDriversGivesEachVehicleItsOwnIdentity(t *testing.T) {
+	var mu sync.Mutex
+	created := map[string]string{} // email -> password
+	roles := map[string]string{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding %s: %v", r.URL.Path, err)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.URL.Path {
+		case "/api/v1/admin/users":
+			if got := r.Header.Get("Authorization"); got != "Bearer admin-token" {
+				t.Errorf("create user Authorization = %q, want the admin token", got)
+			}
+			created[body["email"]] = body["password"]
+			roles[body["email"]] = body["role"]
+			w.WriteHeader(http.StatusCreated)
+		case "/api/v1/auth/login":
+			if created[body["email"]] != body["password"] {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]string{"token": "token-for-" + body["email"]})
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	tokens, err := provisionDrivers(t.Context(), srv.Client(), srv.URL, "admin-token", "runid123", 3)
+	if err != nil {
+		t.Fatalf("provisionDrivers: %v", err)
+	}
+	if len(tokens) != 3 {
+		t.Fatalf("got %d tokens, want 3", len(tokens))
+	}
+	seen := map[string]bool{}
+	for _, tk := range tokens {
+		if seen[tk] {
+			t.Errorf("token %q reused; every vehicle needs its own rate-limit bucket", tk)
+		}
+		seen[tk] = true
+	}
+	if len(created) != 3 {
+		t.Errorf("created %d accounts, want 3", len(created))
+	}
+	for email, role := range roles {
+		if role != "driver" {
+			t.Errorf("account %s has role %q, want driver", email, role)
+		}
+	}
+	pw := map[string]bool{}
+	for _, p := range created {
+		if pw[p] {
+			t.Error("two accounts share a password")
+		}
+		pw[p] = true
 	}
 }

--- a/cmd/simulator/main_test.go
+++ b/cmd/simulator/main_test.go
@@ -301,3 +301,60 @@ func TestSimulateVehicle(t *testing.T) {
 	assert.Equal(t, int64(0), s.failed.Load())
 	assert.Greater(t, received.Load(), int64(1))
 }
+
+func TestLoginReturnsToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/auth/login", r.URL.Path)
+		var body map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "sim@example.com", body["email"])
+		assert.Equal(t, "hunter2", body["password"])
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"tok-123"}`))
+	}))
+	defer server.Close()
+
+	token, err := login(context.Background(), server.Client(), server.URL, "sim@example.com", "hunter2")
+	require.NoError(t, err)
+	assert.Equal(t, "tok-123", token)
+}
+
+func TestLoginRejectsBadCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid email or password"}`))
+	}))
+	defer server.Close()
+
+	_, err := login(context.Background(), server.Client(), server.URL, "sim@example.com", "wrong")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestLoginRejectsEmptyToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	_, err := login(context.Background(), server.Client(), server.URL, "sim@example.com", "hunter2")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no token")
+}
+
+// The regression this fixes: reports must carry the session token, because
+// POST /api/v1/locations sits behind requireAuth and 401s without it.
+func TestBearerTransportSetsAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Transport: bearerTransport{token: "tok-123", base: http.DefaultTransport}}
+	sendReport(context.Background(), client, server.URL, "sim-vehicle-001", &locationReport{}, &stats{})
+
+	assert.Equal(t, "Bearer tok-123", gotAuth)
+}

--- a/cmd/simulator/main_test.go
+++ b/cmd/simulator/main_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -476,4 +477,65 @@ func TestProvisionDriversGivesEachVehicleItsOwnIdentity(t *testing.T) {
 		}
 		pw[p] = true
 	}
+}
+
+// TestSameOriginOnlyBlocksCredentialLeaks pins why the policy exists:
+// bearerTransport re-adds Authorization on every hop, so a redirect that
+// leaves the validated origin would hand the token to another host.
+func TestSameOriginOnlyBlocksCredentialLeaks(t *testing.T) {
+	check := sameOriginOnly("http://localhost:8080")
+	for _, tc := range []struct {
+		to    string
+		allow bool
+	}{
+		{"http://localhost:8080/api/v1/auth/login", true},
+		{"http://localhost:80800/x", false},
+		{"http://evil.example/x", false},
+		{"https://localhost:8080/x", false}, // scheme change
+		{"http://localhost:9090/x", false},  // port change
+		{"http://127.0.0.1:8080/x", false},  // different host, same machine
+	} {
+		u, err := url.Parse(tc.to)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", tc.to, err)
+		}
+		err = check(&http.Request{URL: u}, nil)
+		if tc.allow && err != nil {
+			t.Errorf("redirect to %s blocked: %v", tc.to, err)
+		}
+		if !tc.allow && err == nil {
+			t.Errorf("redirect to %s allowed; it would leak credentials", tc.to)
+		}
+	}
+	// Default ports are implicit but equal.
+	if err := sameOriginOnly("http://example.com")(
+		&http.Request{URL: mustParse(t, "http://example.com:80/x")}, nil); err != nil {
+		t.Errorf("http://example.com:80 should equal http://example.com: %v", err)
+	}
+	// A live client must actually refuse the hop, not just the policy in isolation.
+	var hit int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit++
+		http.Redirect(w, r, "http://evil.example/stolen", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+	c := &http.Client{
+		Transport:     bearerTransport{token: "secret", base: http.DefaultTransport},
+		CheckRedirect: sameOriginOnly(srv.URL),
+	}
+	if _, err := c.Get(srv.URL); err == nil {
+		t.Error("client followed a cross-origin redirect while carrying a bearer token")
+	}
+	if hit != 1 {
+		t.Errorf("origin served %d requests, want 1", hit)
+	}
+}
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", raw, err)
+	}
+	return u
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -164,9 +164,10 @@ run ends; delete them from the admin UI if they pile up.
 
 Two consequences worth knowing:
 
-- Startup makes one login per vehicle, and the server allows ten logins per IP
-  per minute. Past ten vehicles the simulator waits out the limiter rather than
-  failing, so a large run takes a minute or two to get going.
+- Startup makes one login per vehicle plus the simulator's own admin login, and
+  the server allows ten logins per IP per minute. Ten vehicles is therefore
+  eleven logins and already meets the limiter. The simulator waits it out rather
+  than failing, so runs of that size take a minute or two to get going.
 - `-interval` now has to be 5 s or slower, but it no longer has to grow with
   `-vehicles`. The simulator warns at startup if the interval is too fast.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -148,10 +148,32 @@ Use the built-in simulator to generate multiple moving vehicles:
 make simulate
 ```
 
+`POST /api/v1/locations` is authenticated, so the simulator needs an account to
+sign in with. It reads `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` by
+default, or takes `-email`/`-password`, and it exits rather than starting
+without them. The account has to have the admin role.
+
+That login is only the start. The server allows one location report per driver
+per 5 seconds, keyed on the JWT subject, so vehicles sharing a login would share
+one budget and most of their reports would come back `429`. Instead the
+simulator signs in as the admin, creates one `driver` account per vehicle
+through `POST /api/v1/admin/users`, and logs each one in, so every vehicle
+reports under its own identity and gets its own allowance. The accounts are
+named `sim-driver-NNN-<run id>@simulator.invalid` and are left behind when the
+run ends; delete them from the admin UI if they pile up.
+
+Two consequences worth knowing:
+
+- Startup makes one login per vehicle, and the server allows ten logins per IP
+  per minute. Past ten vehicles the simulator waits out the limiter rather than
+  failing, so a large run takes a minute or two to get going.
+- `-interval` now has to be 5 s or slower, but it no longer has to grow with
+  `-vehicles`. The simulator warns at startup if the interval is too fast.
+
 Custom example:
 
 ```bash
-go run ./cmd/simulator -url http://localhost:8080 -vehicles 1 -interval 6s -duration 2m
+go run ./cmd/simulator -url http://localhost:8080 -vehicles 5 -interval 6s -duration 2m
 ```
 
 ## Watching Retention Prune Locally

--- a/docs/development.md
+++ b/docs/development.md
@@ -151,7 +151,7 @@ make simulate
 Custom example:
 
 ```bash
-go run ./cmd/simulator -url http://localhost:8080 -vehicles 20 -interval 2s -duration 2m
+go run ./cmd/simulator -url http://localhost:8080 -vehicles 1 -interval 6s -duration 2m
 ```
 
 ## Watching Retention Prune Locally


### PR DESCRIPTION
POST /api/v1/locations is registered behind `authMiddleware` in `main.go:80`, but `cmd/simulator` only ever sets `Content-Type`. So every report the simulator sends comes back 401, and `make simulate` finishes reporting 100% failures.

## The fix

The simulator now logs in once via `POST /api/v1/auth/login` and attaches the returned token to each request.

I attached it with a `RoundTripper` rather than threading a token argument through `simulateVehicle` and `sendReport`, because that keeps both signatures unchanged and leaves the existing tests that call `sendReport` directly untouched.

Credentials come from `-email` / `-password`, defaulting to `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD`. Those are the same variables `main.go:168` uses to bootstrap the admin, so whoever brought the server up already has them set and `make simulate` works with no extra steps.

Missing credentials or a failed login now exit immediately with a message naming the cause, instead of starting N goroutines that each 401 on a timer.

## Tests

Four added, all against `httptest` servers:

- `TestLoginReturnsToken` asserts the method, path and body sent to the login endpoint
- `TestLoginRejectsBadCredentials` covers a 401 from login
- `TestLoginRejectsEmptyToken` covers a 200 with no token in the body
- `TestBearerTransportSetsAuthorizationHeader` is the regression test: it runs `sendReport` against a recording server and asserts the header arrives

I checked that the last one actually fails without the fix. Swapping the client back to a plain `&http.Client{}` gives `expected: "Bearer tok-123", actual: ""`.

`go build ./...`, `go vet` and `go test ./...` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command for running the rider simulator against a local server using the configured port.
  * The simulator authenticates before submitting reports and uses separate identities and tokens for each vehicle.
  * Remote connections require HTTPS; localhost and loopback connections may use HTTP.
  * Added warnings for reporting rates above the server limit.

* **Bug Fixes**
  * Improved startup errors for missing credentials, failed authentication, invalid URLs, and provisioning failures.
  * Prevented credentials from being sent across redirects to different origins.

* **Documentation**
  * Updated setup, simulator usage, rate-limit, retention, and end-to-end testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->