### PR TITLE
Add opt-in API key authentication for the GTFS-RT feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,12 @@ its own. Turning it on is a breaking change for feed consumers: every consumer
 that doesn't send a key starts getting `401`. Issue keys first, then flip the
 flag.
 
+`FEED_AUTH_ENABLED` accepts only what Go's `strconv.ParseBool` accepts —
+`true`/`false`, `1`/`0`, `t`/`f`, and their capitalizations. Anything else
+(`yes`, `on`, a typo) stops the server at startup instead of falling back to a
+default, so a misspelled flag can't leave the feed public while you believe it
+is locked.
+
 Keys are managed through the admin API, which needs an admin JWT:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -225,18 +225,21 @@ The feed is served at a configurable HTTP endpoint (e.g., `GET /gtfs-rt/vehicle-
 
 **API Design:**
 
-|Endpoint                        |Method|Purpose                                             |
-|--------------------------------|------|----------------------------------------------------|
-|`POST /api/v1/auth/login`       |POST  |Driver login → returns JWT                          |
-|`POST /api/v1/locations`        |POST  |Single location report from driver app              |
-|`GET /gtfs-rt/vehicle-positions`|GET   |GTFS-RT feed (protobuf or JSON)                     |
-|`GET /api/v1/admin/vehicles`    |GET   |List vehicles                                       |
-|`POST /api/v1/admin/vehicles`   |POST  |Create/update vehicle                               |
-|`GET /api/v1/admin/users`       |GET   |List users                                          |
-|`POST /api/v1/admin/users`      |POST  |Create/update user                                  |
-|`POST /api/v1/trips/start`      |POST  |Driver starts a trip (assigns vehicle to route/trip)|
-|`POST /api/v1/trips/end`        |POST  |Driver ends a trip                                  |
-|`GET /api/v1/admin/status`      |GET   |System health, active vehicles, feed stats          |
+|Endpoint                            |Method|Purpose                                             |
+|------------------------------------|------|----------------------------------------------------|
+|`POST /api/v1/auth/login`           |POST  |Driver login → returns JWT                          |
+|`POST /api/v1/locations`            |POST  |Single location report from driver app              |
+|`GET /gtfs-rt/vehicle-positions`    |GET   |GTFS-RT feed (protobuf or JSON) — see Feed API Keys |
+|`GET /api/v1/admin/vehicles`        |GET   |List vehicles                                       |
+|`POST /api/v1/admin/vehicles`       |POST  |Create/update vehicle                               |
+|`GET /api/v1/admin/users`           |GET   |List users                                          |
+|`POST /api/v1/admin/users`          |POST  |Create/update user                                  |
+|`GET /api/v1/admin/api-keys`        |GET   |List feed API keys                                  |
+|`POST /api/v1/admin/api-keys`       |POST  |Create a feed API key (raw key shown once)          |
+|`DELETE /api/v1/admin/api-keys/{id}`|DELETE|Revoke a feed API key                               |
+|`POST /api/v1/trips/start`          |POST  |Driver starts a trip (assigns vehicle to route/trip)|
+|`POST /api/v1/trips/end`            |POST  |Driver ends a trip                                  |
+|`GET /api/v1/admin/status`          |GET   |System health, active vehicles, feed stats          |
 
 **Location Report Payload:**
 
@@ -318,6 +321,65 @@ Example — keep 90 days of history, sweeping hourly:
 export LOCATION_RETENTION_PERIOD=2160h
 export LOCATION_PRUNE_INTERVAL=1h
 ```
+
+**Feed API Keys**
+
+`GET /gtfs-rt/vehicle-positions` is the only data endpoint the server can serve
+without authentication. An agency that doesn't want its live fleet positions on
+the open internet can require an API key on it:
+
+|Variable           |Default|Purpose                                          |
+|-------------------|-------|-------------------------------------------------|
+|`FEED_AUTH_ENABLED`|`false`|Require an `X-API-Key` header on the GTFS-RT feed|
+
+**Upgrade note.** Feed auth is off by default, so upgrading changes nothing on
+its own. Turning it on is a breaking change for feed consumers: every consumer
+that doesn't send a key starts getting `401`. Issue keys first, then flip the
+flag.
+
+Keys are managed through the admin API, which needs an admin JWT:
+
+```bash
+# Create a key. The raw key is in this response and nowhere else — only its
+# SHA-256 hash is stored, so it can never be recovered or re-displayed.
+curl -X POST http://localhost:8080/api/v1/admin/api-keys \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"transit-app"}'
+# 201 {"id":1,"name":"transit-app","active":true,"last_used_at":null,...,"key":"<raw key>"}
+
+# List keys — metadata only, hashes are never returned
+curl http://localhost:8080/api/v1/admin/api-keys \
+  -H "Authorization: Bearer $ADMIN_JWT"
+
+# Revoke a key -> 204, or 404 if no key has that id
+curl -X DELETE http://localhost:8080/api/v1/admin/api-keys/1 \
+  -H "Authorization: Bearer $ADMIN_JWT"
+
+# Read the feed with a key
+curl -H "X-API-Key: <raw key>" \
+  'http://localhost:8080/gtfs-rt/vehicle-positions?format=json'
+```
+
+With `FEED_AUTH_ENABLED=true` the feed returns `401` and a JSON error body for a
+missing (`missing API key`), unknown (`invalid API key`), or revoked
+(`inactive API key`) key.
+
+Notes for operators:
+
+- **Revoking deactivates, it doesn't delete.** `DELETE` clears the key's active
+  flag and keeps the row, so `last_used_at` survives — which is exactly what you
+  want to look at when you're revoking a key.
+- Keys are 32 random bytes from `crypto/rand`, hex-encoded, and stored only as a
+  SHA-256 hash. bcrypt is deliberately not used: its work factor protects
+  low-entropy passwords and would add latency to the busiest endpoint in the
+  system for no gain against a 256-bit random value.
+- `last_used_at` is best-effort. If that write fails the request is still
+  served and the failure is logged, so an audit column can't take the feed down.
+- For local development, [`seed_dev.sql`](seed_dev.sql) seeds the key
+  `local-dev-feed-key`. It is public in this repository — never use it anywhere
+  but a local machine.
+- Per-key rate limiting isn't implemented yet; the feed is unthrottled.
 
 **Technology Stack:**
 

--- a/api_key.go
+++ b/api_key.go
@@ -1,0 +1,16 @@
+package main
+
+import "time"
+
+// APIKey is an api_keys row. KeyHash is never serialized: the raw key is
+// returned once at creation and is unrecoverable afterward, since only its
+// hash is stored.
+type APIKey struct {
+	ID         int64      `json:"id"`
+	Name       string     `json:"name"`
+	KeyHash    string     `json:"-"`
+	Active     bool       `json:"active"`
+	LastUsedAt *time.Time `json:"last_used_at"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+}

--- a/api_key_auth.go
+++ b/api_key_auth.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+)
+
+// apiKeyHeader carries the raw feed API key.
+const apiKeyHeader = "X-API-Key"
+
+// hashAPIKey returns the hex-encoded SHA-256 of a raw key. Keys are
+// high-entropy values from crypto/rand, not user-chosen passwords: bcrypt's
+// work factor exists to slow brute force against low-entropy secrets and
+// would only add latency to the feed, the hottest endpoint in the system.
+// Because lookup is by hash there is no secret-dependent comparison, so the
+// timing side-channel that handleLogin guards against does not arise here.
+func hashAPIKey(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// generateAPIKey returns a new 256-bit random key, hex-encoded.
+func generateAPIKey() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate api key: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// requireAPIKey is middleware that gates the GTFS-RT feed on a valid, active
+// API key sent in the X-API-Key header. trustProxy selects which address the
+// denial logs attribute a request to, matching the rest of the server.
+func requireAPIKey(store APIKeyStore, trustProxy bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rawKey := r.Header.Get(apiKeyHeader)
+			if rawKey == "" {
+				slog.Warn("feed access denied: missing api key", "path", r.URL.Path, "client_ip", clientIP(r, trustProxy))
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing API key"})
+				return
+			}
+
+			apiKey, err := store.GetAPIKeyByHash(r.Context(), hashAPIKey(rawKey))
+			if err != nil {
+				if errors.Is(err, ErrAPIKeyNotFound) {
+					slog.Warn("feed access denied: invalid api key", "path", r.URL.Path, "client_ip", clientIP(r, trustProxy))
+					writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid API key"})
+					return
+				}
+				slog.Error("failed to look up api key", "error", err)
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+				return
+			}
+
+			if !apiKey.Active {
+				slog.Warn("feed access denied: inactive api key", "api_key_id", apiKey.ID, "path", r.URL.Path, "client_ip", clientIP(r, trustProxy))
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "inactive API key"})
+				return
+			}
+
+			// last_used_at is an audit convenience, not a security control:
+			// failing to record it must not deny a consumer whose key already
+			// validated, on the system's hottest endpoint.
+			if err := store.UpdateAPIKeyLastUsed(r.Context(), apiKey.ID); err != nil {
+				slog.Error("failed to update api key last_used_at", "api_key_id", apiKey.ID, "error", err)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/api_key_auth_test.go
+++ b/api_key_auth_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeAPIKeyStore is the read path requireAPIKey depends on. It recognizes at
+// most one key and records the last_used_at writes it receives.
+type fakeAPIKeyStore struct {
+	key           *APIKey
+	getErr        error
+	lastUsedErr   error
+	lastUsedCalls int
+	lastUsedID    int64
+}
+
+func (f *fakeAPIKeyStore) GetAPIKeyByHash(_ context.Context, keyHash string) (*APIKey, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.key == nil || f.key.KeyHash != keyHash {
+		return nil, ErrAPIKeyNotFound
+	}
+	return f.key, nil
+}
+
+func (f *fakeAPIKeyStore) UpdateAPIKeyLastUsed(_ context.Context, id int64) error {
+	f.lastUsedCalls++
+	f.lastUsedID = id
+	return f.lastUsedErr
+}
+
+// storeWithKey returns a fake holding one key with the given raw value.
+func storeWithKey(rawKey string, active bool) *fakeAPIKeyStore {
+	return &fakeAPIKeyStore{key: &APIKey{ID: 7, Name: "consumer", KeyHash: hashAPIKey(rawKey), Active: active}}
+}
+
+// serveFeedAuth runs a request through requireAPIKey and reports whether the
+// wrapped handler ran.
+func serveFeedAuth(store APIKeyStore, req *http.Request) (*httptest.ResponseRecorder, bool) {
+	return serveFeedAuthTrusting(store, req, false)
+}
+
+func serveFeedAuthTrusting(store APIKeyStore, req *http.Request, trustProxy bool) (*httptest.ResponseRecorder, bool) {
+	reached := false
+	handler := requireAPIKey(store, trustProxy)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w, reached
+}
+
+func TestHashAPIKey(t *testing.T) {
+	// Published SHA-256 vectors: the hash must stay interoperable with any
+	// key hashed by an earlier release.
+	assert.Equal(t, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", hashAPIKey("abc"))
+	assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hashAPIKey(""))
+	assert.Equal(t, hashAPIKey("repeat-me"), hashAPIKey("repeat-me"), "hashing must be deterministic")
+	assert.NotEqual(t, hashAPIKey("key-a"), hashAPIKey("key-b"))
+}
+
+func TestGenerateAPIKey(t *testing.T) {
+	first, err := generateAPIKey()
+	require.NoError(t, err)
+	second, err := generateAPIKey()
+	require.NoError(t, err)
+
+	assert.Len(t, first, 64, "32 random bytes hex-encoded")
+	raw, err := hex.DecodeString(first)
+	require.NoError(t, err)
+	assert.Len(t, raw, 32)
+	assert.NotEqual(t, first, second, "keys must not repeat")
+}
+
+func TestRequireAPIKey_Denials(t *testing.T) {
+	tests := []struct {
+		name       string
+		store      *fakeAPIKeyStore
+		header     string
+		wantStatus int
+		wantError  string
+	}{
+		{
+			name:       "missing header",
+			store:      storeWithKey("valid-key", true),
+			header:     "",
+			wantStatus: http.StatusUnauthorized,
+			wantError:  "missing API key",
+		},
+		{
+			name:       "unknown key",
+			store:      storeWithKey("valid-key", true),
+			header:     "some-other-key",
+			wantStatus: http.StatusUnauthorized,
+			wantError:  "invalid API key",
+		},
+		{
+			name:       "revoked key",
+			store:      storeWithKey("valid-key", false),
+			header:     "valid-key",
+			wantStatus: http.StatusUnauthorized,
+			wantError:  "inactive API key",
+		},
+		{
+			name:       "store failure",
+			store:      &fakeAPIKeyStore{getErr: errors.New("connection refused")},
+			header:     "valid-key",
+			wantStatus: http.StatusInternalServerError,
+			wantError:  "internal server error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/gtfs-rt/vehicle-positions", nil)
+			if tc.header != "" {
+				req.Header.Set(apiKeyHeader, tc.header)
+			}
+
+			w, reached := serveFeedAuth(tc.store, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			assert.Equal(t, tc.wantError, decodeError(t, w))
+			assert.False(t, reached, "the feed handler must not run for a denied request")
+			assert.Zero(t, tc.store.lastUsedCalls, "a denied request must not stamp last_used_at")
+		})
+	}
+}
+
+func TestRequireAPIKey_ValidKey(t *testing.T) {
+	store := storeWithKey("valid-key", true)
+	req := httptest.NewRequest(http.MethodGet, "/gtfs-rt/vehicle-positions", nil)
+	req.Header.Set(apiKeyHeader, "valid-key")
+
+	w, reached := serveFeedAuth(store, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, reached, "a valid key must reach the feed handler")
+	assert.Equal(t, 1, store.lastUsedCalls)
+	assert.Equal(t, int64(7), store.lastUsedID)
+}
+
+// TestRequireAPIKey_UpdateLastUsedFailure pins that a failed last_used_at
+// write is logged and ignored: it is an audit convenience, and failing it
+// must not deny a consumer whose key already validated.
+func TestRequireAPIKey_UpdateLastUsedFailure(t *testing.T) {
+	store := storeWithKey("valid-key", true)
+	store.lastUsedErr = errors.New("write failed")
+
+	req := httptest.NewRequest(http.MethodGet, "/gtfs-rt/vehicle-positions", nil)
+	req.Header.Set(apiKeyHeader, "valid-key")
+
+	w, reached := serveFeedAuth(store, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, reached, "the feed must still be served when last_used_at cannot be written")
+}
+
+// TestRequireAPIKey_RawKeyNeverLogged guards against a denial log leaking the
+// credential a client presented.
+// Not safe for t.Parallel(); uses global logger
+func TestRequireAPIKey_RawKeyNeverLogged(t *testing.T) {
+	var buf bytes.Buffer
+	original := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(original) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	const rawKey = "sup3r-secret-raw-key"
+	req := httptest.NewRequest(http.MethodGet, "/gtfs-rt/vehicle-positions", nil)
+	req.Header.Set(apiKeyHeader, rawKey)
+
+	w, _ := serveFeedAuth(storeWithKey("a-different-key", true), req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	logged := buf.String()
+	require.NotEmpty(t, logged, "the denial must be logged")
+	assert.NotContains(t, logged, rawKey, "the raw key must never reach the logs")
+	assert.NotContains(t, logged, hashAPIKey(rawKey), "the key hash must not reach the logs either")
+}
+
+// TestRequireAPIKey_LogsForwardedClientIP checks that denial logs name the
+// real consumer behind a reverse proxy rather than the proxy itself, which is
+// how an operator finds who is hammering the feed.
+// Not safe for t.Parallel(); uses global logger
+func TestRequireAPIKey_LogsForwardedClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		trustProxy bool
+		wantIP     string
+	}{
+		{"proxy trusted", true, "203.0.113.9"},
+		{"proxy untrusted", false, "192.0.2.1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			original := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(original) })
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+
+			req := httptest.NewRequest(http.MethodGet, "/gtfs-rt/vehicle-positions", nil)
+			req.Header.Set("X-Forwarded-For", "203.0.113.9")
+
+			w, _ := serveFeedAuthTrusting(&fakeAPIKeyStore{}, req, tc.trustProxy)
+			require.Equal(t, http.StatusUnauthorized, w.Code)
+
+			var entry map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+			assert.Equal(t, tc.wantIP, entry["client_ip"])
+		})
+	}
+}

--- a/api_key_handlers.go
+++ b/api_key_handlers.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type createAPIKeyRequest struct {
+	Name string `json:"name"`
+}
+
+func (r *createAPIKeyRequest) validate() error {
+	if r.Name == "" {
+		return errors.New("name is required")
+	}
+	if len(r.Name) > maxFieldLength {
+		return fmt.Errorf("name must be at most %d characters", maxFieldLength)
+	}
+	return nil
+}
+
+// createAPIKeyResponse is the only response carrying the raw key. It is shown
+// once here and cannot be recovered later, since only its hash is stored.
+type createAPIKeyResponse struct {
+	APIKey
+	Key string `json:"key"`
+}
+
+func handleListAPIKeys(store APIKeyManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		keys, err := store.ListAPIKeys(r.Context())
+		if err != nil {
+			slog.Error("failed to list api keys", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+		writeJSON(w, http.StatusOK, keys)
+	}
+}
+
+func handleCreateAPIKey(store APIKeyManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil || !strings.EqualFold(mediaType, "application/json") {
+			writeJSON(w, http.StatusUnsupportedMediaType, map[string]string{"error": "Content-Type must be application/json"})
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<10) // 1KB
+
+		var req createAPIKeyRequest
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&req); err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "request body too large"})
+				return
+			}
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + sanitizeJSONError(err)})
+			return
+		}
+		if err := decoder.Decode(new(json.RawMessage)); err == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: request body must contain a single JSON object and no trailing data"})
+			return
+		} else if err != io.EOF {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + sanitizeJSONError(err)})
+			return
+		}
+
+		if err := req.validate(); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
+		rawKey, err := generateAPIKey()
+		if err != nil {
+			slog.Error("failed to generate api key", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		key, err := store.CreateAPIKey(r.Context(), req.Name, hashAPIKey(rawKey))
+		if err != nil {
+			slog.Error("failed to create api key", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		slog.Info("api key created", "api_key_id", key.ID, "name", key.Name)
+		writeJSON(w, http.StatusCreated, createAPIKeyResponse{APIKey: *key, Key: rawKey})
+	}
+}
+
+func handleDeactivateAPIKey(store APIKeyManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+		if err != nil || id <= 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid api key id"})
+			return
+		}
+
+		if err := store.DeactivateAPIKey(r.Context(), id); err != nil {
+			if errors.Is(err, ErrAPIKeyNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "api key not found"})
+				return
+			}
+			slog.Error("failed to deactivate api key", "api_key_id", id, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+			return
+		}
+
+		slog.Info("api key revoked", "api_key_id", id)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/api_key_handlers_test.go
+++ b/api_key_handlers_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeAPIKeyManager is the admin CRUD surface, recording what the handlers
+// persist so tests can assert on the stored row rather than the response only.
+type fakeAPIKeyManager struct {
+	keys          []APIKey
+	createErr     error
+	listErr       error
+	deactivateErr error
+	deactivated   []int64
+}
+
+func (f *fakeAPIKeyManager) CreateAPIKey(_ context.Context, name, keyHash string) (*APIKey, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	key := APIKey{
+		ID:        int64(len(f.keys) + 1),
+		Name:      name,
+		KeyHash:   keyHash,
+		Active:    true,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	f.keys = append(f.keys, key)
+	return &key, nil
+}
+
+func (f *fakeAPIKeyManager) ListAPIKeys(_ context.Context) ([]APIKey, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	keys := make([]APIKey, 0, len(f.keys))
+	return append(keys, f.keys...), nil
+}
+
+func (f *fakeAPIKeyManager) DeactivateAPIKey(_ context.Context, id int64) error {
+	if f.deactivateErr != nil {
+		return f.deactivateErr
+	}
+	f.deactivated = append(f.deactivated, id)
+	return nil
+}
+
+// createAPIKeyRequestWith posts a raw body to handleCreateAPIKey under the
+// given Content-Type.
+func createAPIKeyRequestWith(store APIKeyManager, contentType, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/api-keys", strings.NewReader(body))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	w := httptest.NewRecorder()
+	handleCreateAPIKey(store)(w, req)
+	return w
+}
+
+func TestHandleCreateAPIKey_Validation(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		wantStatus  int
+		wantError   string
+	}{
+		{
+			name:        "name at the length limit",
+			contentType: "application/json",
+			body:        `{"name":"` + strings.Repeat("a", maxFieldLength) + `"}`,
+			wantStatus:  http.StatusCreated,
+		},
+		{
+			name:        "name past the length limit",
+			contentType: "application/json",
+			body:        `{"name":"` + strings.Repeat("a", maxFieldLength+1) + `"}`,
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "name must be at most 255 characters",
+		},
+		{
+			name:        "empty name",
+			contentType: "application/json",
+			body:        `{"name":""}`,
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "name is required",
+		},
+		{
+			name:        "missing content type",
+			contentType: "",
+			body:        `{"name":"feed"}`,
+			wantStatus:  http.StatusUnsupportedMediaType,
+			wantError:   "Content-Type must be application/json",
+		},
+		{
+			name:        "non-JSON content type",
+			contentType: "text/plain",
+			body:        `{"name":"feed"}`,
+			wantStatus:  http.StatusUnsupportedMediaType,
+			wantError:   "Content-Type must be application/json",
+		},
+		{
+			name:        "unknown field",
+			contentType: "application/json",
+			body:        `{"name":"feed","active":true}`,
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "unknown field",
+		},
+		{
+			name:        "trailing data",
+			contentType: "application/json",
+			body:        `{"name":"feed"}{"name":"second"}`,
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "no trailing data",
+		},
+		{
+			name:        "empty body",
+			contentType: "application/json",
+			body:        ``,
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "invalid JSON",
+		},
+		{
+			name:        "malformed JSON",
+			contentType: "application/json",
+			body:        `{"name":`,
+			wantStatus:  http.StatusBadRequest,
+			wantError:   "invalid JSON",
+		},
+		{
+			name:        "wrong field type",
+			contentType: "application/json",
+			body:        `{"name":42}`,
+			wantStatus:  http.StatusBadRequest,
+			wantError:   `field "name" has invalid type`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := createAPIKeyRequestWith(&fakeAPIKeyManager{}, tc.contentType, tc.body)
+
+			require.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantError != "" {
+				assert.Contains(t, decodeError(t, w), tc.wantError)
+			}
+		})
+	}
+}
+
+// TestHandleCreateAPIKey_ReturnsRawKeyOnce checks the one moment the raw key
+// is visible: the 201 body carries it, and only its hash is persisted.
+func TestHandleCreateAPIKey_ReturnsRawKeyOnce(t *testing.T) {
+	store := &fakeAPIKeyManager{}
+
+	w := createAPIKeyRequestWith(store, "application/json", `{"name":"transit-app"}`)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp createAPIKeyResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Len(t, resp.Key, 64, "the response carries a freshly generated raw key")
+	assert.Equal(t, "transit-app", resp.Name)
+	assert.True(t, resp.Active)
+	assert.Nil(t, resp.LastUsedAt, "a new key has never been used")
+
+	require.Len(t, store.keys, 1)
+	assert.Equal(t, hashAPIKey(resp.Key), store.keys[0].KeyHash, "only the hash is stored")
+	assert.NotContains(t, store.keys[0].KeyHash, resp.Key)
+}
+
+func TestHandleCreateAPIKey_StoreError(t *testing.T) {
+	w := createAPIKeyRequestWith(&fakeAPIKeyManager{createErr: errors.New("insert failed")}, "application/json", `{"name":"feed"}`)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, "internal server error", decodeError(t, w))
+}
+
+func TestHandleCreateAPIKey_OversizedBodyRejected(t *testing.T) {
+	w := createAPIKeyRequestWith(&fakeAPIKeyManager{}, "application/json", `{"name":"`+strings.Repeat("a", 2<<10)+`"}`)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+	assert.Equal(t, "request body too large", decodeError(t, w))
+}
+
+func listAPIKeys(store APIKeyManager) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/api-keys", nil)
+	w := httptest.NewRecorder()
+	handleListAPIKeys(store)(w, req)
+	return w
+}
+
+// TestHandleListAPIKeys_NeverLeaksHash is the counterpart to the `json:"-"`
+// tag on APIKey.KeyHash: the listing must expose metadata only.
+func TestHandleListAPIKeys_NeverLeaksHash(t *testing.T) {
+	const hash = "df1a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8"
+	lastUsed := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	store := &fakeAPIKeyManager{keys: []APIKey{
+		{ID: 1, Name: "transit-app", KeyHash: hash, Active: true, LastUsedAt: &lastUsed},
+		{ID: 2, Name: "revoked", KeyHash: hash + "00", Active: false},
+	}}
+
+	w := listAPIKeys(store)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	body := w.Body.String()
+	assert.NotContains(t, body, "key_hash")
+	assert.NotContains(t, body, hash)
+
+	var keys []APIKey
+	require.NoError(t, json.Unmarshal([]byte(body), &keys))
+	require.Len(t, keys, 2)
+	assert.Equal(t, "transit-app", keys[0].Name)
+	assert.Equal(t, lastUsed, keys[0].LastUsedAt.UTC())
+	assert.False(t, keys[1].Active)
+	assert.Nil(t, keys[1].LastUsedAt, "a key that was never used serializes as null")
+}
+
+func TestHandleListAPIKeys_EmptyReturnsArray(t *testing.T) {
+	w := listAPIKeys(&fakeAPIKeyManager{})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "[]", strings.TrimSpace(w.Body.String()), "an empty list must not serialize as null")
+}
+
+func TestHandleListAPIKeys_StoreError(t *testing.T) {
+	w := listAPIKeys(&fakeAPIKeyManager{listErr: errors.New("query failed")})
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, "internal server error", decodeError(t, w))
+}
+
+func deactivateAPIKey(store APIKeyManager, id string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/api-keys/"+id, nil)
+	req.SetPathValue("id", id)
+	w := httptest.NewRecorder()
+	handleDeactivateAPIKey(store)(w, req)
+	return w
+}
+
+func TestHandleDeactivateAPIKey_Success(t *testing.T) {
+	store := &fakeAPIKeyManager{}
+
+	w := deactivateAPIKey(store, "3")
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Body.String())
+	assert.Equal(t, []int64{3}, store.deactivated)
+}
+
+func TestHandleDeactivateAPIKey_NotFound(t *testing.T) {
+	w := deactivateAPIKey(&fakeAPIKeyManager{deactivateErr: ErrAPIKeyNotFound}, "404")
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "api key not found", decodeError(t, w))
+}
+
+func TestHandleDeactivateAPIKey_StoreError(t *testing.T) {
+	w := deactivateAPIKey(&fakeAPIKeyManager{deactivateErr: errors.New("update failed")}, "1")
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, "internal server error", decodeError(t, w))
+}
+
+func TestHandleDeactivateAPIKey_InvalidID(t *testing.T) {
+	for _, id := range []string{"abc", "0", "-1", ""} {
+		t.Run("id="+id, func(t *testing.T) {
+			store := &fakeAPIKeyManager{}
+
+			w := deactivateAPIKey(store, id)
+
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Equal(t, "invalid api key id", decodeError(t, w))
+			assert.Empty(t, store.deactivated, "a rejected id must never reach the store")
+		})
+	}
+}

--- a/db/models.go
+++ b/db/models.go
@@ -8,6 +8,16 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+type ApiKey struct {
+	ID         int64
+	Name       string
+	KeyHash    string
+	Active     bool
+	LastUsedAt pgtype.Timestamptz
+	CreatedAt  pgtype.Timestamptz
+	UpdatedAt  pgtype.Timestamptz
+}
+
 type LocationPoint struct {
 	ID         int64
 	VehicleID  string

--- a/db/query.sql
+++ b/db/query.sql
@@ -299,3 +299,32 @@ SELECT COUNT(*) FROM ride_points WHERE ride_id = $1;
 
 -- name: DeleteRidePointsBefore :execrows
 DELETE FROM ride_points WHERE received_at < $1;
+
+-- name: GetAPIKeyByHash :one
+-- Inactive keys are returned too: the middleware distinguishes a revoked key
+-- from an unknown one.
+SELECT id, name, key_hash, active, last_used_at, created_at, updated_at
+FROM api_keys
+WHERE key_hash = $1;
+
+-- name: UpdateAPIKeyLastUsed :exec
+UPDATE api_keys
+SET last_used_at = NOW()
+WHERE id = $1;
+
+-- name: CreateAPIKey :one
+INSERT INTO api_keys (name, key_hash)
+VALUES ($1, $2)
+RETURNING id, name, key_hash, active, last_used_at, created_at, updated_at;
+
+-- name: ListAPIKeys :many
+-- safety bound; not pagination
+SELECT id, name, key_hash, active, last_used_at, created_at, updated_at
+FROM api_keys
+ORDER BY created_at DESC
+LIMIT 1000;
+
+-- name: DeactivateAPIKey :execrows
+UPDATE api_keys
+SET active = false, updated_at = NOW()
+WHERE id = $1;

--- a/db/query.sql.go
+++ b/db/query.sql.go
@@ -180,6 +180,32 @@ func (q *Queries) CountUsersByRole(ctx context.Context, role string) (int64, err
 	return count, err
 }
 
+const createAPIKey = `-- name: CreateAPIKey :one
+INSERT INTO api_keys (name, key_hash)
+VALUES ($1, $2)
+RETURNING id, name, key_hash, active, last_used_at, created_at, updated_at
+`
+
+type CreateAPIKeyParams struct {
+	Name    string
+	KeyHash string
+}
+
+func (q *Queries) CreateAPIKey(ctx context.Context, arg CreateAPIKeyParams) (ApiKey, error) {
+	row := q.db.QueryRow(ctx, createAPIKey, arg.Name, arg.KeyHash)
+	var i ApiKey
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.KeyHash,
+		&i.Active,
+		&i.LastUsedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (name, email, password_hash, role)
 VALUES ($1, $2, $3, $4)
@@ -237,6 +263,20 @@ type CreateVehicleParams struct {
 
 func (q *Queries) CreateVehicle(ctx context.Context, arg CreateVehicleParams) (int64, error) {
 	result, err := q.db.Exec(ctx, createVehicle, arg.ID, arg.Label, arg.AgencyTag)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const deactivateAPIKey = `-- name: DeactivateAPIKey :execrows
+UPDATE api_keys
+SET active = false, updated_at = NOW()
+WHERE id = $1
+`
+
+func (q *Queries) DeactivateAPIKey(ctx context.Context, id int64) (int64, error) {
+	result, err := q.db.Exec(ctx, deactivateAPIKey, id)
 	if err != nil {
 		return 0, err
 	}
@@ -358,6 +398,29 @@ func (q *Queries) EndTrip(ctx context.Context, arg EndTripParams) (int64, error)
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const getAPIKeyByHash = `-- name: GetAPIKeyByHash :one
+SELECT id, name, key_hash, active, last_used_at, created_at, updated_at
+FROM api_keys
+WHERE key_hash = $1
+`
+
+// Inactive keys are returned too: the middleware distinguishes a revoked key
+// from an unknown one.
+func (q *Queries) GetAPIKeyByHash(ctx context.Context, keyHash string) (ApiKey, error) {
+	row := q.db.QueryRow(ctx, getAPIKeyByHash, keyHash)
+	var i ApiKey
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.KeyHash,
+		&i.Active,
+		&i.LastUsedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const getActiveTripByUser = `-- name: GetActiveTripByUser :one
@@ -735,6 +798,42 @@ func (q *Queries) InsertRide(ctx context.Context, arg InsertRideParams) (Ride, e
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const listAPIKeys = `-- name: ListAPIKeys :many
+SELECT id, name, key_hash, active, last_used_at, created_at, updated_at
+FROM api_keys
+ORDER BY created_at DESC
+LIMIT 1000
+`
+
+// safety bound; not pagination
+func (q *Queries) ListAPIKeys(ctx context.Context) ([]ApiKey, error) {
+	rows, err := q.db.Query(ctx, listAPIKeys)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ApiKey
+	for rows.Next() {
+		var i ApiKey
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.KeyHash,
+			&i.Active,
+			&i.LastUsedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listActiveTripsByVehicle = `-- name: ListActiveTripsByVehicle :many
@@ -1348,6 +1447,17 @@ func (q *Queries) UnassignUserVehicle(ctx context.Context, arg UnassignUserVehic
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const updateAPIKeyLastUsed = `-- name: UpdateAPIKeyLastUsed :exec
+UPDATE api_keys
+SET last_used_at = NOW()
+WHERE id = $1
+`
+
+func (q *Queries) UpdateAPIKeyLastUsed(ctx context.Context, id int64) error {
+	_, err := q.db.Exec(ctx, updateAPIKeyLastUsed, id)
+	return err
 }
 
 const updateRideProgress = `-- name: UpdateRideProgress :execrows

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,6 +65,7 @@ You can run Postgres in Docker and run the Go server directly:
    export JWT_SECRET=$(openssl rand -hex 32)   # required; the server exits without 32+ bytes
    export STALENESS_THRESHOLD=5m
    export FEED_AUTH_ENABLED=false   # true requires an X-API-Key on the GTFS-RT feed
+                                    # only true/false/1/0 parse; anything else exits at startup
    ```
 
    Location retention is optional and off unless you set it:

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,6 +64,7 @@ You can run Postgres in Docker and run the Go server directly:
    export DATABASE_URL='postgres://postgres:postgres@localhost:5432/vehicle_positions?sslmode=disable'
    export JWT_SECRET=$(openssl rand -hex 32)   # required; the server exits without 32+ bytes
    export STALENESS_THRESHOLD=5m
+   export FEED_AUTH_ENABLED=false   # true requires an X-API-Key on the GTFS-RT feed
    ```
 
    Location retention is optional and off unless you set it:
@@ -358,6 +359,44 @@ Timestamps go over the wire as whole seconds and the server ignores a fix that
 is not newer than the last one, so `-interval` below `1s` samples the shape
 more finely but still uploads at most one fix per second.
 
+## Feed API Keys Locally
+
+With `FEED_AUTH_ENABLED=true` the GTFS-RT feed requires an `X-API-Key` header.
+`seed_dev.sql` seeds the key `local-dev-feed-key`, so the quickest check is:
+
+```bash
+curl -H 'X-API-Key: local-dev-feed-key' \
+  'http://localhost:8080/gtfs-rt/vehicle-positions?format=json'   # 200
+
+curl -i 'http://localhost:8080/gtfs-rt/vehicle-positions'         # 401
+```
+
+To walk the real flow instead, mint a key through the admin API:
+
+```bash
+ADMIN_JWT=$(curl -s -X POST http://localhost:8080/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@test.com","password":"password"}' | jq -r .token)
+
+# The raw key is in this response only; it is stored as a SHA-256 hash
+KEY=$(curl -s -X POST http://localhost:8080/api/v1/admin/api-keys \
+  -H "Authorization: Bearer $ADMIN_JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"local test"}' | jq -r .key)
+
+curl -s -o /dev/null -w '%{http_code}\n' -H "X-API-Key: $KEY" \
+  http://localhost:8080/gtfs-rt/vehicle-positions   # 200
+
+# Revoke it, then the same key is rejected
+ID=$(curl -s -H "Authorization: Bearer $ADMIN_JWT" \
+  http://localhost:8080/api/v1/admin/api-keys | jq -r '.[0].id')
+curl -s -X DELETE -H "Authorization: Bearer $ADMIN_JWT" \
+  "http://localhost:8080/api/v1/admin/api-keys/$ID"
+
+curl -s -H "X-API-Key: $KEY" \
+  http://localhost:8080/gtfs-rt/vehicle-positions   # 401 inactive API key
+```
+
 ## API Sanity Checks
 
 ### Submit one location
@@ -383,6 +422,9 @@ curl -X POST http://localhost:8080/api/v1/locations \
 curl 'http://localhost:8080/gtfs-rt/vehicle-positions?format=json'
 ```
 
+Add `-H 'X-API-Key: local-dev-feed-key'` when running with
+`FEED_AUTH_ENABLED=true`.
+
 ### Get admin status
 
 ```bash
@@ -399,6 +441,9 @@ curl http://localhost:8080/api/v1/admin/status
 - `address already in use` for `0.0.0.0:5432` when running `make up`:
    - another local Postgres is using port `5432`
    - stop that service, or update [docker-compose.yml](docker-compose.yml) to map a different host port and adjust `DATABASE_URL` accordingly
+- `401` from the feed:
+   - `FEED_AUTH_ENABLED=true` requires an `X-API-Key` header; the seeded dev key is `local-dev-feed-key`
+   - `inactive API key` means the key exists but was revoked — mint a new one via `POST /api/v1/admin/api-keys`
 - empty feed:
    - make sure timestamp is within 5 minutes of server time (this is request validation in `handlers.go`, independent of `STALENESS_THRESHOLD`)
   - ensure coordinates are valid and non-zero

--- a/handler_composition_test.go
+++ b/handler_composition_test.go
@@ -18,7 +18,7 @@ func newTestHandler(t *testing.T, enabled bool) http.Handler {
 	t.Cleanup(tracker.Stop)
 	ll := NewLoginRateLimiter()
 	t.Cleanup(ll.Stop)
-	h, err := newHandler(&noopStore{}, tracker, nil, ll, testSecret, time.Now(), adminUIConfig{enabled: enabled, stalenessThreshold: 5 * time.Minute}, nil)
+	h, err := newHandler(&noopStore{}, tracker, nil, ll, testSecret, time.Now(), adminUIConfig{enabled: enabled, stalenessThreshold: 5 * time.Minute}, false, nil)
 	require.NoError(t, err)
 	return h
 }

--- a/main.go
+++ b/main.go
@@ -183,6 +183,21 @@ func main() {
 	}
 	jwtSecret := []byte(jwtSecretStr)
 
+	// Feed auth is opt-in: enabling it rejects every existing consumer that
+	// does not yet send a key, so an upgrade must not turn it on silently.
+	// A value that isn't a boolean is fatal rather than defaulted: ParseBool
+	// rejects "yes" and "on", and falling back to false would leave the feed
+	// public while the operator believes it is locked. Checked before the
+	// database is touched so a typo fails immediately.
+	feedAuthEnabled, err := envBool("FEED_AUTH_ENABLED", false)
+	if err != nil {
+		slog.Error("refusing to start: cannot tell whether the GTFS-RT feed should be public", "error", err)
+		os.Exit(1)
+	}
+	if feedAuthEnabled {
+		slog.Info("GTFS-RT feed authentication enabled; consumers must send an X-API-Key header")
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
@@ -271,13 +286,6 @@ func main() {
 
 	startTime := time.Now()
 
-	// Feed auth is opt-in: enabling it rejects every existing consumer that
-	// does not yet send a key, so an upgrade must not turn it on silently.
-	feedAuthEnabled := envBoolOrDefault("FEED_AUTH_ENABLED", false)
-	if feedAuthEnabled {
-		slog.Info("GTFS-RT feed authentication enabled; consumers must send an X-API-Key header")
-	}
-
 	handler, err := newHandler(store, tracker, rateLimiter, loginLimiter, jwtSecret, startTime,
 		adminUIConfig{enabled: adminUIEnabled(), trustProxy: trustProxyHeaders(), stalenessThreshold: maxAge}, feedAuthEnabled, riderSvc)
 	if err != nil {
@@ -359,6 +367,22 @@ func envInt32OrDefault(key string, fallback int32) int32 {
 		return int32(n)
 	}
 	return fallback
+}
+
+// envBool reads a boolean from the environment, returning fallback when the
+// variable is unset. Unlike the envOrDefault helpers above it reports a bad
+// value instead of warning and defaulting, so a caller gating a security
+// control can refuse to start rather than guess which way the operator meant.
+func envBool(key string, fallback bool) (bool, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("%s must be true or false, got %q", key, v)
+	}
+	return b, nil
 }
 
 type statusRecorder struct {

--- a/main.go
+++ b/main.go
@@ -60,13 +60,15 @@ type appStore interface {
 	RideLister
 	RiderStatsReader
 	RidePointPruner
+	APIKeyStore
+	APIKeyManager
 }
 
 // newMux wires all application routes and returns the configured ServeMux.
 // Extracting route registration here allows tests to build the real mux
 // without a live database, catching middleware wiring gaps like the one fixed
 // in issue #82.
-func newMux(store appStore, tracker *Tracker, rateLimiter *VehicleRateLimiter, jwtSecret []byte, startTime time.Time, loginLimiter *LoginRateLimiter, trustProxy bool, riderSvc *riderService) *http.ServeMux {
+func newMux(store appStore, tracker *Tracker, rateLimiter *VehicleRateLimiter, jwtSecret []byte, startTime time.Time, loginLimiter *LoginRateLimiter, trustProxy, feedAuthEnabled bool, riderSvc *riderService) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	authMiddleware := requireAuth(jwtSecret)
@@ -74,7 +76,12 @@ func newMux(store appStore, tracker *Tracker, rateLimiter *VehicleRateLimiter, j
 	riderEstimates, riderStatus := riderOrOff(riderSvc)
 
 	mux.Handle("POST /api/v1/auth/login", handleLogin(store, jwtSecret, loginLimiter, trustProxy))
-	mux.HandleFunc("GET /gtfs-rt/vehicle-positions", handleGetFeed(tracker, riderEstimates))
+	feed := handleGetFeed(tracker, riderEstimates)
+	if feedAuthEnabled {
+		mux.Handle("GET /gtfs-rt/vehicle-positions", requireAPIKey(store, trustProxy)(feed))
+	} else {
+		mux.Handle("GET /gtfs-rt/vehicle-positions", feed)
+	}
 	mux.Handle("GET /api/v1/admin/status", authMiddleware(adminMiddleware(handleAdminStatus(tracker, startTime))))
 	mux.Handle("GET /api/v1/admin/vehicles", authMiddleware(adminMiddleware(handleListVehicles(store))))
 	mux.Handle("GET /api/v1/admin/vehicles/live", authMiddleware(adminMiddleware(handleLiveVehicles(tracker, store, store))))
@@ -108,6 +115,11 @@ func newMux(store appStore, tracker *Tracker, rateLimiter *VehicleRateLimiter, j
 	mux.Handle("GET /api/v1/admin/users/{id}/vehicles", authMiddleware(adminMiddleware(handleListUserVehicles(store))))
 	mux.Handle("GET /api/v1/admin/vehicles/{id}/users", authMiddleware(adminMiddleware(handleListVehicleUsers(store))))
 
+	// Admin feed API keys
+	mux.Handle("GET /api/v1/admin/api-keys", authMiddleware(adminMiddleware(handleListAPIKeys(store))))
+	mux.Handle("POST /api/v1/admin/api-keys", authMiddleware(adminMiddleware(handleCreateAPIKey(store))))
+	mux.Handle("DELETE /api/v1/admin/api-keys/{id}", authMiddleware(adminMiddleware(handleDeactivateAPIKey(store))))
+
 	// Rider mode. The admin endpoints exist whether or not it is enabled — a
 	// disabled server reports {"enabled":false} rather than 404 — while the
 	// rider API itself is registered only when there is a service to serve it.
@@ -126,9 +138,9 @@ func newMux(store appStore, tracker *Tracker, rateLimiter *VehicleRateLimiter, j
 // and cross-cutting middleware come together.
 func newHandler(store appStore, tracker *Tracker, rateLimiter *VehicleRateLimiter,
 	loginLimiter *LoginRateLimiter, jwtSecret []byte, startTime time.Time,
-	cfg adminUIConfig, riderSvc *riderService) (http.Handler, error) {
+	cfg adminUIConfig, feedAuthEnabled bool, riderSvc *riderService) (http.Handler, error) {
 
-	mux := newMux(store, tracker, rateLimiter, jwtSecret, startTime, loginLimiter, cfg.trustProxy, riderSvc)
+	mux := newMux(store, tracker, rateLimiter, jwtSecret, startTime, loginLimiter, cfg.trustProxy, feedAuthEnabled, riderSvc)
 
 	if cfg.enabled {
 		ui, err := newAdminUI(store, tracker, jwtSecret, loginLimiter, cfg)
@@ -259,8 +271,15 @@ func main() {
 
 	startTime := time.Now()
 
+	// Feed auth is opt-in: enabling it rejects every existing consumer that
+	// does not yet send a key, so an upgrade must not turn it on silently.
+	feedAuthEnabled := envBoolOrDefault("FEED_AUTH_ENABLED", false)
+	if feedAuthEnabled {
+		slog.Info("GTFS-RT feed authentication enabled; consumers must send an X-API-Key header")
+	}
+
 	handler, err := newHandler(store, tracker, rateLimiter, loginLimiter, jwtSecret, startTime,
-		adminUIConfig{enabled: adminUIEnabled(), trustProxy: trustProxyHeaders(), stalenessThreshold: maxAge}, riderSvc)
+		adminUIConfig{enabled: adminUIEnabled(), trustProxy: trustProxyHeaders(), stalenessThreshold: maxAge}, feedAuthEnabled, riderSvc)
 	if err != nil {
 		slog.Error("failed to build handler", "error", err)
 		os.Exit(1)

--- a/main_test.go
+++ b/main_test.go
@@ -103,3 +103,52 @@ func TestEnvInt32OrDefault(t *testing.T) {
 		})
 	}
 }
+
+// TestEnvBool covers the strict parse behind FEED_AUTH_ENABLED: a value that
+// isn't a boolean must be reported, not silently defaulted, so main can refuse
+// to start rather than leave the feed public on a typo.
+func TestEnvBool(t *testing.T) {
+	const key = "TEST_FEED_AUTH_ENABLED"
+
+	tests := []struct {
+		name     string
+		value    string
+		set      bool
+		fallback bool
+		want     bool
+		wantErr  bool
+	}{
+		{name: "unset falls back to false", fallback: false, want: false},
+		{name: "unset falls back to true", fallback: true, want: true},
+		{name: "empty falls back", value: "", set: true, fallback: true, want: true},
+		{name: "true", value: "true", set: true, want: true},
+		{name: "false", value: "false", set: true, fallback: true, want: false},
+		{name: "1", value: "1", set: true, want: true},
+		{name: "0", value: "0", set: true, fallback: true, want: false},
+		{name: "TRUE", value: "TRUE", set: true, want: true},
+		{name: "yes is not a boolean", value: "yes", set: true, wantErr: true},
+		{name: "on is not a boolean", value: "on", set: true, wantErr: true},
+		{name: "garbage", value: "maybe", set: true, fallback: true, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(key, tc.value)
+			}
+
+			got, err := envBool(key, tc.fallback)
+
+			if tc.wantErr {
+				require.Error(t, err, "a non-boolean value must be reported, not defaulted")
+				assert.Contains(t, err.Error(), key, "the error must name the variable")
+				assert.Contains(t, err.Error(), tc.value, "the error must show the rejected value")
+				assert.False(t, got, "a rejected value must not report the fallback as if it parsed")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/migrations/000013_add_api_keys.down.sql
+++ b/migrations/000013_add_api_keys.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS api_keys;

--- a/migrations/000013_add_api_keys.up.sql
+++ b/migrations/000013_add_api_keys.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS api_keys (
+    id           BIGSERIAL PRIMARY KEY,
+    name         TEXT NOT NULL CHECK (name != ''),
+    key_hash     TEXT NOT NULL UNIQUE CHECK (key_hash != ''),
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
+    last_used_at TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/rider_wiring_test.go
+++ b/rider_wiring_test.go
@@ -107,7 +107,7 @@ func TestNewRiderRuntime_LoadsIndexAndEndsStaleRides(t *testing.T) {
 }
 
 func TestRiderRoutes_NotRegisteredWhenDisabled(t *testing.T) {
-	mux := newMux(&noopStore{}, nil, nil, testSecret, time.Time{}, nil, false, nil)
+	mux := newMux(&noopStore{}, nil, nil, testSecret, time.Time{}, nil, false, false, nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, httptest.NewRequest("POST", "/api/v1/rider/register", nil))
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -125,7 +125,7 @@ func TestRiderRoutes_RoleIsolation(t *testing.T) {
 	env := newRiderTestEnv(t)
 	tracker := NewTracker(time.Minute)
 	defer tracker.Stop()
-	mux := newMux(&noopStore{}, tracker, nil, testSecret, time.Time{}, nil, false, env.svc)
+	mux := newMux(&noopStore{}, tracker, nil, testSecret, time.Time{}, nil, false, false, env.svc)
 	_, riderTok := env.register(t)
 	driverTok, _ := generateJWT(&User{ID: 1, Email: "d@test.com", Role: "driver"}, testSecret)
 	adminTok, _ := generateJWT(&User{ID: 2, Email: "a@test.com", Role: "admin"}, testSecret)

--- a/route_wiring_test.go
+++ b/route_wiring_test.go
@@ -126,6 +126,21 @@ func (n *noopStore) ListTripLocations(_ context.Context, _ int64) ([]LocationPoi
 func (n *noopStore) ListActiveTripsByVehicle(_ context.Context) (map[string]ActiveTripInfo, error) {
 	return nil, nil
 }
+func (n *noopStore) GetAPIKeyByHash(_ context.Context, _ string) (*APIKey, error) {
+	return nil, ErrAPIKeyNotFound
+}
+func (n *noopStore) UpdateAPIKeyLastUsed(_ context.Context, _ int64) error {
+	return nil
+}
+func (n *noopStore) CreateAPIKey(_ context.Context, _, _ string) (*APIKey, error) {
+	return &APIKey{}, nil
+}
+func (n *noopStore) ListAPIKeys(_ context.Context) ([]APIKey, error) {
+	return make([]APIKey, 0), nil
+}
+func (n *noopStore) DeactivateAPIKey(_ context.Context, _ int64) error {
+	return nil
+}
 
 // Rider-mode store methods. Rider routes are not registered on a mux built
 // with a nil rider service, so only the two admin rider endpoints reach these;
@@ -168,7 +183,7 @@ func TestAdminRoutes_DriverTokenRejected(t *testing.T) {
 
 	// nil tracker and rateLimiter are safe: adminMiddleware rejects driver
 	// tokens before any handler body runs, so neither is dereferenced.
-	mux := newMux(&noopStore{}, nil, nil, testSecret, time.Time{}, nil, false, nil)
+	mux := newMux(&noopStore{}, nil, nil, testSecret, time.Time{}, nil, false, false, nil)
 
 	tests := []struct {
 		method string
@@ -195,6 +210,9 @@ func TestAdminRoutes_DriverTokenRejected(t *testing.T) {
 		{"GET", "/api/v1/admin/vehicles/bus-1/users"},
 		{"GET", "/api/v1/admin/rider/status"},
 		{"GET", "/api/v1/admin/rider/rides"},
+		{"GET", "/api/v1/admin/api-keys"},
+		{"POST", "/api/v1/admin/api-keys"},
+		{"DELETE", "/api/v1/admin/api-keys/1"},
 	}
 
 	for _, tc := range tests {
@@ -224,7 +242,7 @@ func TestAdminRoutes_AdminTokenAllowed(t *testing.T) {
 	tracker := NewTracker(5 * time.Minute)
 	defer tracker.Stop()
 
-	mux := newMux(&noopStore{}, tracker, nil, testSecret, time.Time{}, nil, false, nil)
+	mux := newMux(&noopStore{}, tracker, nil, testSecret, time.Time{}, nil, false, false, nil)
 
 	// Same routes as the driver-rejection table — every admin route must
 	// let a valid admin token through both middleware layers.
@@ -253,6 +271,9 @@ func TestAdminRoutes_AdminTokenAllowed(t *testing.T) {
 		{"GET", "/api/v1/admin/vehicles/bus-1/users"},
 		{"GET", "/api/v1/admin/rider/status"},
 		{"GET", "/api/v1/admin/rider/rides"},
+		{"GET", "/api/v1/admin/api-keys"},
+		{"POST", "/api/v1/admin/api-keys"},
+		{"DELETE", "/api/v1/admin/api-keys/1"},
 	}
 
 	for _, tc := range tests {
@@ -283,7 +304,7 @@ func TestLiveVehiclesRoute_DoesNotHitGetVehicle(t *testing.T) {
 	tracker := NewTracker(5 * time.Minute)
 	defer tracker.Stop()
 
-	mux := newMux(&noopStore{}, tracker, nil, testSecret, time.Time{}, nil, false, nil)
+	mux := newMux(&noopStore{}, tracker, nil, testSecret, time.Time{}, nil, false, false, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/vehicles/live", nil)
 	req.Header.Set("Authorization", "Bearer "+adminToken)
@@ -367,7 +388,7 @@ func TestDriverVehiclesRoute_Wiring(t *testing.T) {
 	driverToken, err := generateJWT(&User{ID: 1, Email: "driver@test.com", Role: "driver"}, testSecret)
 	require.NoError(t, err)
 
-	mux := newMux(&noopStore{}, nil, nil, testSecret, time.Time{}, nil, false, nil)
+	mux := newMux(&noopStore{}, nil, nil, testSecret, time.Time{}, nil, false, false, nil)
 
 	tests := []struct {
 		name       string
@@ -388,6 +409,64 @@ func TestDriverVehiclesRoute_Wiring(t *testing.T) {
 			mux.ServeHTTP(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// apiKeyStubStore is a noopStore that recognizes exactly one API key, so the
+// wired feed route can be exercised with a key that actually validates.
+type apiKeyStubStore struct {
+	noopStore
+	rawKey string
+}
+
+func (s *apiKeyStubStore) GetAPIKeyByHash(_ context.Context, keyHash string) (*APIKey, error) {
+	if keyHash != hashAPIKey(s.rawKey) {
+		return nil, ErrAPIKeyNotFound
+	}
+	return &APIKey{ID: 1, Name: "feed consumer", KeyHash: keyHash, Active: true}, nil
+}
+
+// TestFeedRoute_Wiring verifies that FEED_AUTH_ENABLED actually gates the
+// wired GTFS-RT route. Middleware unit tests cannot catch a refactor that
+// drops the requireAPIKey wrapper from newMux — the feed would silently go
+// public again and every other test would still pass — so for this security
+// control the wiring is the thing worth pinning. It also pins the other
+// direction: with feed auth off the route stays open, which is what every
+// existing deployment upgrades into.
+func TestFeedRoute_Wiring(t *testing.T) {
+	const rawKey = "wired-feed-key"
+
+	tests := []struct {
+		name            string
+		feedAuthEnabled bool
+		apiKey          string
+		wantStatus      int
+	}{
+		{"auth disabled, no key", false, "", http.StatusOK},
+		{"auth enabled, no key", true, "", http.StatusUnauthorized},
+		{"auth enabled, wrong key", true, "not-the-key", http.StatusUnauthorized},
+		{"auth enabled, valid key", true, rawKey, http.StatusOK},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := NewTracker(5 * time.Minute)
+			defer tracker.Stop()
+
+			mux := newMux(&apiKeyStubStore{rawKey: rawKey}, tracker, nil, testSecret, time.Time{}, nil, false, tc.feedAuthEnabled, nil)
+
+			req := httptest.NewRequest(http.MethodGet, "/gtfs-rt/vehicle-positions", nil)
+			if tc.apiKey != "" {
+				req.Header.Set(apiKeyHeader, tc.apiKey)
+			}
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			if tc.wantStatus == http.StatusUnauthorized {
+				assert.Contains(t, decodeError(t, w), "API key")
+			}
 		})
 	}
 }

--- a/seed_dev.sql
+++ b/seed_dev.sql
@@ -19,3 +19,14 @@ VALUES (
     'admin'
 )
 ON CONFLICT (email) DO NOTHING;
+
+-- Seed a feed API key for local development only. The raw key below is public
+-- in this file, so it must never be used anywhere but a local machine; real
+-- keys come from POST /api/v1/admin/api-keys and are shown only once.
+-- Raw key: local-dev-feed-key
+INSERT INTO api_keys (name, key_hash)
+VALUES (
+    'Local Development',
+    '33975e14c74d0070a8fd7b1b52dd6dc01695edffaf5b91cf4cf190691b05c971'
+)
+ON CONFLICT (key_hash) DO NOTHING;

--- a/store_api_keys.go
+++ b/store_api_keys.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/OneBusAway/vehicle-positions/db"
+	"github.com/jackc/pgx/v5"
+)
+
+// ErrAPIKeyNotFound is returned when no api_keys row matches the lookup.
+var ErrAPIKeyNotFound = errors.New("api key not found")
+
+// APIKeyStore is the read path the feed middleware needs: look a key up by
+// its hash and record that it was used.
+type APIKeyStore interface {
+	GetAPIKeyByHash(ctx context.Context, keyHash string) (*APIKey, error)
+	UpdateAPIKeyLastUsed(ctx context.Context, id int64) error
+}
+
+// APIKeyManager is the admin CRUD surface. It is kept separate from
+// APIKeyStore so the feed middleware cannot create or revoke keys.
+type APIKeyManager interface {
+	CreateAPIKey(ctx context.Context, name, keyHash string) (*APIKey, error)
+	ListAPIKeys(ctx context.Context) ([]APIKey, error)
+	DeactivateAPIKey(ctx context.Context, id int64) error
+}
+
+var (
+	_ APIKeyStore   = (*Store)(nil)
+	_ APIKeyManager = (*Store)(nil)
+)
+
+// GetAPIKeyByHash returns the key with the given hash, active or not, so
+// callers can tell a revoked key from an unknown one.
+func (s *Store) GetAPIKeyByHash(ctx context.Context, keyHash string) (*APIKey, error) {
+	row, err := s.queries.GetAPIKeyByHash(ctx, keyHash)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrAPIKeyNotFound
+		}
+		return nil, fmt.Errorf("get api key by hash: %w", err)
+	}
+	key := toAPIKey(row)
+	return &key, nil
+}
+
+// UpdateAPIKeyLastUsed stamps the key's last_used_at with the current time.
+func (s *Store) UpdateAPIKeyLastUsed(ctx context.Context, id int64) error {
+	if err := s.queries.UpdateAPIKeyLastUsed(ctx, id); err != nil {
+		return fmt.Errorf("update api key last used: %w", err)
+	}
+	return nil
+}
+
+// CreateAPIKey stores a new key. keyHash is the hash of the raw key; the raw
+// key itself never reaches the database.
+func (s *Store) CreateAPIKey(ctx context.Context, name, keyHash string) (*APIKey, error) {
+	row, err := s.queries.CreateAPIKey(ctx, db.CreateAPIKeyParams{Name: name, KeyHash: keyHash})
+	if err != nil {
+		return nil, fmt.Errorf("create api key: %w", err)
+	}
+	key := toAPIKey(row)
+	return &key, nil
+}
+
+// ListAPIKeys returns all keys, newest first.
+func (s *Store) ListAPIKeys(ctx context.Context) ([]APIKey, error) {
+	rows, err := s.queries.ListAPIKeys(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list api keys: %w", err)
+	}
+
+	keys := make([]APIKey, 0, len(rows))
+	for _, row := range rows {
+		keys = append(keys, toAPIKey(row))
+	}
+	return keys, nil
+}
+
+// DeactivateAPIKey revokes a key by clearing its active flag. The row is kept
+// so last_used_at survives the revocation, which is exactly what an operator
+// investigating a key wants to see.
+func (s *Store) DeactivateAPIKey(ctx context.Context, id int64) error {
+	rows, err := s.queries.DeactivateAPIKey(ctx, id)
+	if err != nil {
+		return fmt.Errorf("deactivate api key: %w", err)
+	}
+	if rows == 0 {
+		return ErrAPIKeyNotFound
+	}
+	return nil
+}
+
+// toAPIKey maps a DB row to the API type. created_at and updated_at are NOT
+// NULL in the schema, so .Valid is always true; last_used_at is nullable and
+// stays nil until the key is first used.
+func toAPIKey(row db.ApiKey) APIKey {
+	key := APIKey{
+		ID:        row.ID,
+		Name:      row.Name,
+		KeyHash:   row.KeyHash,
+		Active:    row.Active,
+		CreatedAt: row.CreatedAt.Time,
+		UpdatedAt: row.UpdatedAt.Time,
+	}
+	if row.LastUsedAt.Valid {
+		lastUsed := row.LastUsedAt.Time
+		key.LastUsedAt = &lastUsed
+	}
+	return key
+}

--- a/store_api_keys_test.go
+++ b/store_api_keys_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func clearAPIKeys(t *testing.T, store *Store) {
+	t.Helper()
+	_, err := store.pool.Exec(context.Background(), "DELETE FROM api_keys")
+	require.NoError(t, err)
+}
+
+func TestStore_CreateAndGetAPIKeyByHash(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	clearAPIKeys(t, store)
+
+	hash := hashAPIKey("round-trip-key")
+	created, err := store.CreateAPIKey(ctx, "transit-app", hash)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	assert.NotZero(t, created.ID)
+	assert.Equal(t, "transit-app", created.Name)
+	assert.Equal(t, hash, created.KeyHash)
+	assert.True(t, created.Active, "new keys are active")
+	assert.Nil(t, created.LastUsedAt, "a key that has never been used must be nil, not the zero time")
+	assert.False(t, created.CreatedAt.IsZero())
+
+	fetched, err := store.GetAPIKeyByHash(ctx, hash)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+
+	assert.Equal(t, created.ID, fetched.ID)
+	assert.Equal(t, created.Name, fetched.Name)
+	assert.Equal(t, created.KeyHash, fetched.KeyHash)
+	assert.Equal(t, created.Active, fetched.Active)
+	assert.Nil(t, fetched.LastUsedAt)
+	assert.WithinDuration(t, created.CreatedAt, fetched.CreatedAt, 0)
+}
+
+func TestStore_GetAPIKeyByHash_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	clearAPIKeys(t, store)
+
+	key, err := store.GetAPIKeyByHash(context.Background(), hashAPIKey("no-such-key"))
+
+	assert.Nil(t, key)
+	assert.True(t, errors.Is(err, ErrAPIKeyNotFound), "an unknown hash must be distinguishable from a DB failure, got %v", err)
+}
+
+func TestStore_UpdateAPIKeyLastUsed(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	clearAPIKeys(t, store)
+
+	hash := hashAPIKey("last-used-key")
+	created, err := store.CreateAPIKey(ctx, "feed consumer", hash)
+	require.NoError(t, err)
+	require.Nil(t, created.LastUsedAt)
+
+	require.NoError(t, store.UpdateAPIKeyLastUsed(ctx, created.ID))
+
+	fetched, err := store.GetAPIKeyByHash(ctx, hash)
+	require.NoError(t, err)
+	require.NotNil(t, fetched.LastUsedAt, "last_used_at must be set after use")
+	assert.False(t, fetched.LastUsedAt.Before(fetched.CreatedAt))
+}
+
+func TestStore_DeactivateAPIKey(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	clearAPIKeys(t, store)
+
+	hash := hashAPIKey("revoke-me")
+	created, err := store.CreateAPIKey(ctx, "leaving consumer", hash)
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpdateAPIKeyLastUsed(ctx, created.ID))
+	require.NoError(t, store.DeactivateAPIKey(ctx, created.ID))
+
+	fetched, err := store.GetAPIKeyByHash(ctx, hash)
+	require.NoError(t, err)
+
+	assert.False(t, fetched.Active)
+	assert.True(t, fetched.UpdatedAt.After(created.UpdatedAt), "revoking must bump updated_at")
+	assert.NotNil(t, fetched.LastUsedAt, "revoking keeps last_used_at, which is what an operator investigating the key needs")
+}
+
+func TestStore_DeactivateAPIKey_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	clearAPIKeys(t, store)
+
+	err := store.DeactivateAPIKey(context.Background(), 999999)
+
+	assert.True(t, errors.Is(err, ErrAPIKeyNotFound), "revoking an unknown id must not report success, got %v", err)
+}
+
+func TestStore_ListAPIKeys(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	clearAPIKeys(t, store)
+
+	empty, err := store.ListAPIKeys(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, empty, "an empty list must marshal as [], not null")
+	assert.Empty(t, empty)
+
+	first, err := store.CreateAPIKey(ctx, "first", hashAPIKey("first-key"))
+	require.NoError(t, err)
+	second, err := store.CreateAPIKey(ctx, "second", hashAPIKey("second-key"))
+	require.NoError(t, err)
+
+	keys, err := store.ListAPIKeys(ctx)
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	ids := []int64{keys[0].ID, keys[1].ID}
+	assert.ElementsMatch(t, []int64{first.ID, second.ID}, ids)
+}
+
+// TestStore_CreateAPIKey_DuplicateHash covers the UNIQUE constraint on
+// key_hash: the second insert must fail and leave nothing behind.
+func TestStore_CreateAPIKey_DuplicateHash(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	clearAPIKeys(t, store)
+
+	hash := hashAPIKey("duplicate-key")
+	_, err := store.CreateAPIKey(ctx, "original", hash)
+	require.NoError(t, err)
+
+	duplicate, err := store.CreateAPIKey(ctx, "copy", hash)
+	require.Error(t, err)
+	assert.Nil(t, duplicate)
+
+	keys, err := store.ListAPIKeys(ctx)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "the rejected insert must not leave a row behind")
+	assert.Equal(t, "original", keys[0].Name)
+}


### PR DESCRIPTION
Summary

GET /gtfs-rt/vehicle-positions is the only data endpoint without middleware. This PR adds opt-in API key authentication for the feed and admin endpoints to create, list, and revoke keys.

Authentication

* Keys are generated as 32 random bytes using crypto/rand.
* Only the SHA-256 hash is stored; the raw key is returned once and cannot be recovered afterward.
* Revoking a key clears its active status while retaining the row so last_used_at history is preserved.
* Authentication is disabled by default via FEED_AUTH_ENABLED=false, so there is no behavior change unless explicitly enabled.
* Enabling authentication is a breaking change for feed consumers and is documented as an upgrade note.

Review / Follow-up

This picks up #68 by @ShinLiX; the design is theirs.

Both review rounds have been addressed:

* A failed last_used_at write is logged and does not cause the feed request to return a 500.
* Every authentication denial and both 500 paths are logged.
* No updated_at trigger was added.
* route_wiring_test.go now exercises the real mux and verifies that the feed returns 401 without an API key.

Migration

The migration is currently 000012. Both #93 and #94 claim 000011; happy to renumber this during rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional API-key protection for GTFS-RT feed access.
  * Added admin endpoints to create, list, and revoke feed API keys.
  * Feed keys use the `X-API-Key` header and are shown only once when created.
  * Added clear errors for missing, invalid, or inactive keys.
  * Added local-development configuration and seeded credentials.

* **Documentation**
  * Expanded API and development documentation with authentication, configuration, troubleshooting, and data-retention guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->