### PR TITLE
Bound and paginate the admin vehicle and user lists

### DIFF
--- a/admin_page_handlers.go
+++ b/admin_page_handlers.go
@@ -72,6 +72,8 @@ type adminUI struct {
 	activeTrips    ActiveTripLister
 	trips          TripLister
 	vehicles       VehicleManager
+	vehiclePager   VehiclePager
+	userPager      UserPager
 	vehicleEditor  vehicleEditor
 	vehicleCreator VehicleCreator
 	userManager    userManager
@@ -99,6 +101,8 @@ func newAdminUI(store appStore, tracker *Tracker, jwtSecret []byte, limiter *Log
 		activeTrips:    store,
 		trips:          store,
 		vehicles:       store,
+		vehiclePager:   store,
+		userPager:      store,
 		vehicleEditor:  store,
 		vehicleCreator: store,
 		userManager:    store,
@@ -386,6 +390,36 @@ func humanizeDuration(d time.Duration) string {
 	}
 }
 
+// adminPageSize is the number of rows shown per page on the admin list
+// pages. Each list is queried with adminPageSize+1 so an extra row past the
+// page boundary reveals whether there's a next page (HasMore), without a
+// separate COUNT query.
+const adminPageSize = 50
+
+// maxAdminPage bounds the ?page= query param so the offset arithmetic can
+// never overflow into a negative OFFSET; values past it fall back to page 1.
+const maxAdminPage = 1_000_000
+
+// adminPageNumber reads the ?page= param for the admin list pages. A
+// missing, non-numeric, or out-of-range value falls back to page 1 rather
+// than erroring, since it's a bookmarkable/shareable URL param that's easy
+// to hand-edit into something invalid.
+func adminPageNumber(q url.Values) int {
+	if raw := q.Get("page"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n >= 1 && n <= maxAdminPage {
+			return n
+		}
+	}
+	return 1
+}
+
+// adminPageOffset converts a page number into the SQL offset for a page of
+// adminPageSize rows. maxAdminPage keeps the result well inside int32, the
+// offset type the paged store queries take.
+func adminPageOffset(page int) int {
+	return (page - 1) * adminPageSize
+}
+
 // vehicleRow is a single row in the vehicle list table: the vehicle's
 // stored fields plus whatever live state we can join in (last-seen from the
 // tracker, current driver from the active-trips map).
@@ -398,24 +432,43 @@ type vehicleRow struct {
 	Driver    string
 }
 
-// vehiclesPage renders the vehicle list: real vehicles from the store,
-// joined with the tracker's live last-seen data and the current driver (if
-// any) from the active-trips map. Inactive vehicles are hidden unless
-// ?include_inactive=1 is set — the store itself always returns everything;
-// filtering happens here so the store's ListVehicles stays a plain listing.
+// vehiclesPageURL builds an /admin/vehicles link preserving the inactive
+// filter with page set to the given page number, for the prev/next
+// pagination links.
+func vehiclesPageURL(includeInactive bool, page int) string {
+	v := url.Values{}
+	if includeInactive {
+		v.Set("include_inactive", "1")
+	}
+	v.Set("page", strconv.Itoa(page))
+	return "/admin/vehicles?" + v.Encode()
+}
+
+// vehiclesPage renders the vehicle list: one page of vehicles from the
+// store, joined with the tracker's live last-seen data and the current
+// driver (if any) from the active-trips map. Rows are ordered newest-first
+// by the store. Inactive vehicles are hidden unless ?include_inactive=1 is
+// set; that filter runs in SQL so a page holds a full page of rows.
 func (ui *adminUI) vehiclesPage(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	includeInactive := r.URL.Query().Get("include_inactive") == "1"
+	query := r.URL.Query()
+	includeInactive := query.Get("include_inactive") == "1"
+	page := adminPageNumber(query)
 
-	all, err := ui.vehicles.ListVehicles(ctx)
+	vehicles, err := ui.vehiclePager.ListVehiclesPage(ctx, includeInactive, adminPageSize+1, int32(adminPageOffset(page)))
 	if err != nil {
-		slog.Error("vehicles: list vehicles", "error", err)
+		slog.Error("vehicles: list vehicles page", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
+	hasMore := len(vehicles) > adminPageSize
+	if hasMore {
+		vehicles = vehicles[:adminPageSize]
+	}
 
-	lastSeen := make(map[string]string, len(all))
-	for _, v := range ui.tracker.ActiveVehicles() {
+	reporting := ui.tracker.ActiveVehicles()
+	lastSeen := make(map[string]string, len(reporting))
+	for _, v := range reporting {
 		lastSeen[v.VehicleID] = humanizeAge(v.UpdatedAt)
 	}
 
@@ -426,11 +479,8 @@ func (ui *adminUI) vehiclesPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows := make([]vehicleRow, 0, len(all))
-	for _, v := range all {
-		if !v.Active && !includeInactive {
-			continue
-		}
+	rows := make([]vehicleRow, 0, len(vehicles))
+	for _, v := range vehicles {
 		row := vehicleRow{ID: v.ID, Label: v.Label, AgencyTag: v.AgencyTag, Active: v.Active}
 		row.LastSeen = lastSeen[v.ID]
 		if trip, ok := tripsByVehicle[v.ID]; ok {
@@ -438,13 +488,16 @@ func (ui *adminUI) vehiclesPage(w http.ResponseWriter, r *http.Request) {
 		}
 		rows = append(rows, row)
 	}
-	sort.Slice(rows, func(i, j int) bool { return rows[i].ID < rows[j].ID })
 
 	ui.renderAdmin(w, r, http.StatusOK, "vehicles.html", map[string]interface{}{
 		"Title":           "Vehicles",
 		"Page":            "vehicles",
 		"Vehicles":        rows,
 		"IncludeInactive": includeInactive,
+		"PageNum":         page,
+		"HasMore":         hasMore,
+		"PrevURL":         vehiclesPageURL(includeInactive, page-1),
+		"NextURL":         vehiclesPageURL(includeInactive, page+1),
 	})
 }
 
@@ -612,23 +665,38 @@ type userRow struct {
 	VehicleCount int
 }
 
-// usersPage renders the user list: real users from the store, each joined
-// with its assigned-vehicle count via a per-user ListAssignmentsByUser call.
-// This is an N+1 query pattern, but it's fine at admin scale (dozens of
-// users, not thousands) and keeps the assignment store's query surface
-// simple (no bulk "counts by user" query needed just for this list).
+// usersPageURL builds an /admin/users link with page set to the given page
+// number, for the prev/next pagination links.
+func usersPageURL(page int) string {
+	v := url.Values{}
+	v.Set("page", strconv.Itoa(page))
+	return "/admin/users?" + v.Encode()
+}
+
+// usersPage renders the user list: one page of users from the store, each
+// joined with its assigned-vehicle count via a per-user
+// ListAssignmentsByUser call. This is an N+1 query pattern, but it's fine at
+// admin scale (dozens of users, not thousands) and keeps the assignment
+// store's query surface simple (no bulk "counts by user" query needed just
+// for this list). Paging the list bounds it further: at most adminPageSize
+// lookups per request, whatever the table holds.
 func (ui *adminUI) usersPage(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	page := adminPageNumber(r.URL.Query())
 
-	all, err := ui.userManager.ListUsers(ctx)
+	users, err := ui.userPager.ListUsersPage(ctx, adminPageSize+1, int32(adminPageOffset(page)))
 	if err != nil {
-		slog.Error("users: list users", "error", err)
+		slog.Error("users: list users page", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
+	hasMore := len(users) > adminPageSize
+	if hasMore {
+		users = users[:adminPageSize]
+	}
 
-	rows := make([]userRow, 0, len(all))
-	for _, u := range all {
+	rows := make([]userRow, 0, len(users))
+	for _, u := range users {
 		assignments, err := ui.assignments.ListAssignmentsByUser(ctx, u.ID)
 		if err != nil {
 			slog.Error("users: list assignments", "user_id", u.ID, "error", err)
@@ -646,9 +714,13 @@ func (ui *adminUI) usersPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ui.renderAdmin(w, r, http.StatusOK, "users.html", map[string]interface{}{
-		"Title": "Users",
-		"Page":  "users",
-		"Users": rows,
+		"Title":   "Users",
+		"Page":    "users",
+		"Users":   rows,
+		"PageNum": page,
+		"HasMore": hasMore,
+		"PrevURL": usersPageURL(page - 1),
+		"NextURL": usersPageURL(page + 1),
 	})
 }
 
@@ -1069,16 +1141,6 @@ func (ui *adminUI) userUnassignVehicle(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/admin/users/"+idStr+"/edit", http.StatusSeeOther)
 }
 
-// tripsPageSize is the number of trips shown per page on the admin trips
-// list. ListTrips is called with Limit: tripsPageSize+1 so an extra row past
-// the page boundary reveals whether there's a next page (HasMore), without a
-// separate COUNT query.
-const tripsPageSize = 50
-
-// maxTripsPage bounds the ?page= query param so the offset arithmetic can
-// never overflow into a negative OFFSET; values past it fall back to page 1.
-const maxTripsPage = 1_000_000
-
 // tripRow is a single row in the trips table: a trip's joined display fields
 // plus pre-formatted start/end times and duration, ready for the template.
 type tripRow struct {
@@ -1133,10 +1195,9 @@ func tripsPageURL(status, vehicleID, q string, page int) string {
 }
 
 // tripsPage renders the trip history list: real trips from the store,
-// filtered by status/vehicle/free-text query, 50 per page. status must be
-// ""/active/completed (else 400); an invalid or missing page falls back to
-// page 1 rather than erroring, since it's a bookmarkable/shareable URL param
-// that's easy to hand-edit into something invalid.
+// filtered by status/vehicle/free-text query, adminPageSize per page.
+// status must be ""/active/completed (else 400); an invalid or missing page
+// falls back to page 1, as on the other admin list pages.
 func (ui *adminUI) tripsPage(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	query := r.URL.Query()
@@ -1149,22 +1210,14 @@ func (ui *adminUI) tripsPage(w http.ResponseWriter, r *http.Request) {
 	vehicleID := query.Get("vehicle_id")
 	q := query.Get("q")
 
-	page := 1
-	if raw := query.Get("page"); raw != "" {
-		// The upper bound keeps (page-1)*tripsPageSize from overflowing int
-		// into a negative OFFSET (a Postgres error → 500); an absurd page
-		// number falls back to page 1 like any other invalid value.
-		if n, err := strconv.Atoi(raw); err == nil && n >= 1 && n <= maxTripsPage {
-			page = n
-		}
-	}
+	page := adminPageNumber(query)
 
 	filter := TripFilter{
 		Status:    status,
 		VehicleID: vehicleID,
 		Q:         q,
-		Limit:     tripsPageSize + 1,
-		Offset:    (page - 1) * tripsPageSize,
+		Limit:     adminPageSize + 1,
+		Offset:    adminPageOffset(page),
 	}
 
 	trips, err := ui.trips.ListTrips(ctx, filter)
@@ -1174,9 +1227,9 @@ func (ui *adminUI) tripsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hasMore := len(trips) > tripsPageSize
+	hasMore := len(trips) > adminPageSize
 	if hasMore {
-		trips = trips[:tripsPageSize]
+		trips = trips[:adminPageSize]
 	}
 
 	allVehicles, err := ui.vehicles.ListVehicles(ctx)

--- a/admin_page_handlers_test.go
+++ b/admin_page_handlers_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -365,6 +367,27 @@ func (f *fakeVehicleStore) ListVehicles(_ context.Context) ([]VehicleResponse, e
 	return out, nil
 }
 
+// ListVehiclesPage orders by id so pages are deterministic; the real store
+// orders by created_at DESC with an id tiebreaker. Only the totality of the
+// order matters to the page handler.
+func (f *fakeVehicleStore) ListVehiclesPage(_ context.Context, includeInactive bool, limit, offset int32) ([]VehicleResponse, error) {
+	ids := make([]string, 0, len(f.vehicles))
+	for id := range f.vehicles {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	all := make([]VehicleResponse, 0, len(ids))
+	for _, id := range ids {
+		v := f.vehicles[id]
+		if !includeInactive && !v.Active {
+			continue
+		}
+		all = append(all, *v)
+	}
+	return pageSlice(all, limit, offset), nil
+}
+
 func (f *fakeVehicleStore) GetVehicle(_ context.Context, id string) (*VehicleResponse, error) {
 	v, ok := f.vehicles[id]
 	if !ok {
@@ -423,6 +446,7 @@ func (f *fakeVehicleStore) CreateVehicle(_ context.Context, id, label, agencyTag
 // same fake, mirroring how newAdminUI wires them all from a single appStore.
 func wireFakeVehicleStore(ui *adminUI, f *fakeVehicleStore) {
 	ui.vehicles = f
+	ui.vehiclePager = f
 	ui.vehicleEditor = f
 	ui.vehicleCreator = f
 }
@@ -479,6 +503,100 @@ func TestVehiclesPageInactiveFilter(t *testing.T) {
 		assert.Contains(t, body, "Active Bus")
 		assert.Contains(t, body, "Retired Bus")
 	})
+}
+
+// getAdminPage issues an authenticated GET against a mux serving the admin
+// UI and returns the rendered body, failing the test on a non-200.
+func getAdminPage(t *testing.T, mux *http.ServeMux, path string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.AddCookie(cookieFor(t, "admin"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	return w.Body.String()
+}
+
+// seedVehicles builds n active vehicles with zero-padded ids so a label like
+// "Bus 050" can't be a substring of another row's label.
+func seedVehicles(n int) []VehicleResponse {
+	vehicles := make([]VehicleResponse, 0, n)
+	for i := 1; i <= n; i++ {
+		vehicles = append(vehicles, VehicleResponse{
+			ID:     fmt.Sprintf("bus-%03d", i),
+			Label:  fmt.Sprintf("Bus %03d", i),
+			Active: true,
+		})
+	}
+	return vehicles
+}
+
+// TestVehiclesPagePaginates verifies the list shows at most one page of
+// vehicles, that ?page=2 shows the next slice with no row repeated or
+// skipped, and that prev/next links appear only where there's a page to go
+// to.
+func TestVehiclesPagePaginates(t *testing.T) {
+	ui := newTestAdminUI(t)
+	wireFakeVehicleStore(ui, newFakeVehicleStore(seedVehicles(adminPageSize+5)...))
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	first := getAdminPage(t, mux, "/admin/vehicles")
+	assert.Equal(t, adminPageSize, strings.Count(first, "/edit\""), "page 1 must hold exactly one page of rows")
+	assert.Contains(t, first, "Bus 001")
+	assert.Contains(t, first, fmt.Sprintf("Bus %03d", adminPageSize))
+	assert.NotContains(t, first, fmt.Sprintf("Bus %03d", adminPageSize+1), "the next page's first row must not leak onto page 1")
+	assert.Contains(t, first, `href="/admin/vehicles?page=2"`)
+	assert.NotContains(t, first, "Previous", "page 1 has no previous page")
+
+	second := getAdminPage(t, mux, "/admin/vehicles?page=2")
+	assert.Equal(t, 5, strings.Count(second, "/edit\""), "the last page holds the remaining rows")
+	assert.Contains(t, second, fmt.Sprintf("Bus %03d", adminPageSize+1))
+	assert.NotContains(t, second, fmt.Sprintf("Bus %03d", adminPageSize), "page 1's last row must not repeat on page 2")
+	assert.Contains(t, second, `href="/admin/vehicles?page=1"`)
+	assert.NotContains(t, second, "Next", "the last page has no next page")
+}
+
+// TestVehiclesPageInvalidPageFallsBack verifies a hand-edited ?page= renders
+// page 1 rather than erroring — it's a bookmarkable, shareable URL param.
+func TestVehiclesPageInvalidPageFallsBack(t *testing.T) {
+	ui := newTestAdminUI(t)
+	wireFakeVehicleStore(ui, newFakeVehicleStore(seedVehicles(adminPageSize+5)...))
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	for _, page := range []string{"abc", "0", "-3", "1000001", ""} {
+		t.Run("page="+page, func(t *testing.T) {
+			body := getAdminPage(t, mux, "/admin/vehicles?page="+page)
+			assert.Contains(t, body, "Bus 001", "an invalid page must render page 1")
+			assert.Contains(t, body, "Page 1")
+		})
+	}
+}
+
+// TestVehiclesPageInactiveFilterSurvivesPaging verifies the include_inactive
+// filter is carried through the prev/next links, and that the filter itself
+// still applies on a later page.
+func TestVehiclesPageInactiveFilterSurvivesPaging(t *testing.T) {
+	vehicles := seedVehicles(adminPageSize + 5)
+	vehicles = append(vehicles, VehicleResponse{ID: "bus-900", Label: "Retired Bus", Active: false})
+
+	ui := newTestAdminUI(t)
+	wireFakeVehicleStore(ui, newFakeVehicleStore(vehicles...))
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	first := getAdminPage(t, mux, "/admin/vehicles?include_inactive=1")
+	assert.Contains(t, first, `href="/admin/vehicles?include_inactive=1&amp;page=2"`,
+		"the next link must preserve the filter")
+
+	second := getAdminPage(t, mux, "/admin/vehicles?include_inactive=1&page=2")
+	assert.Contains(t, second, "Retired Bus", "include_inactive still applies on page 2")
+	assert.Contains(t, second, `href="/admin/vehicles?include_inactive=1&amp;page=1"`,
+		"the previous link must preserve the filter")
+
+	filtered := getAdminPage(t, mux, "/admin/vehicles?page=2")
+	assert.NotContains(t, filtered, "Retired Bus", "the default view still hides deactivated vehicles")
 }
 
 // TestVehicleCreate covers the create form's happy path, validation-error
@@ -662,6 +780,22 @@ func (f *fakeUserStore) ListUsers(_ context.Context) ([]UserResponse, error) {
 	return out, nil
 }
 
+// ListUsersPage orders by id so pages are deterministic; the real store
+// orders by created_at DESC with an id tiebreaker.
+func (f *fakeUserStore) ListUsersPage(_ context.Context, limit, offset int32) ([]UserResponse, error) {
+	ids := make([]int64, 0, len(f.users))
+	for id := range f.users {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	all := make([]UserResponse, 0, len(ids))
+	for _, id := range ids {
+		all = append(all, *f.users[id])
+	}
+	return pageSlice(all, limit, offset), nil
+}
+
 func (f *fakeUserStore) GetUser(_ context.Context, id int64) (*UserResponse, error) {
 	u, ok := f.users[id]
 	if !ok {
@@ -727,6 +861,11 @@ func (f *fakeUserStore) UpdateUserPassword(_ context.Context, id int64, password
 type fakeAssignmentStore struct {
 	byUser         map[int64]map[string]bool
 	missingVehicle map[string]bool
+
+	// listCalls counts ListAssignmentsByUser calls, so the users page's
+	// per-user lookup can be asserted to run once per row on the page
+	// rather than once per row in the table.
+	listCalls int
 }
 
 func newFakeAssignmentStore() *fakeAssignmentStore {
@@ -760,6 +899,7 @@ func (f *fakeAssignmentStore) DeleteAssignment(_ context.Context, userID int64, 
 }
 
 func (f *fakeAssignmentStore) ListAssignmentsByUser(_ context.Context, userID int64) ([]AssignmentResponse, error) {
+	f.listCalls++
 	out := make([]AssignmentResponse, 0)
 	for vID := range f.byUser[userID] {
 		out = append(out, AssignmentResponse{UserID: userID, VehicleID: vID})
@@ -772,7 +912,83 @@ func (f *fakeAssignmentStore) ListAssignmentsByUser(_ context.Context, userID in
 // single appStore.
 func wireFakeUserStore(ui *adminUI, u *fakeUserStore, a *fakeAssignmentStore) {
 	ui.userManager = u
+	ui.userPager = u
 	ui.assignments = a
+}
+
+// seedUsers builds n active drivers with zero-padded names so a name like
+// "Driver 050" can't be a substring of another row's name.
+func seedUsers(n int) []UserResponse {
+	users := make([]UserResponse, 0, n)
+	for i := 1; i <= n; i++ {
+		users = append(users, UserResponse{
+			ID:     int64(i),
+			Name:   fmt.Sprintf("Driver %03d", i),
+			Email:  fmt.Sprintf("driver-%03d@test.com", i),
+			Role:   "driver",
+			Active: true,
+		})
+	}
+	return users
+}
+
+// TestUsersPagePaginates verifies the list shows at most one page of users,
+// that ?page=2 shows the next slice with no row repeated or skipped, and
+// that prev/next links appear only where there's a page to go to.
+func TestUsersPagePaginates(t *testing.T) {
+	ui := newTestAdminUI(t)
+	wireFakeUserStore(ui, newFakeUserStore(seedUsers(adminPageSize+5)...), newFakeAssignmentStore())
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	first := getAdminPage(t, mux, "/admin/users")
+	assert.Equal(t, adminPageSize, strings.Count(first, "/edit\""), "page 1 must hold exactly one page of rows")
+	assert.Contains(t, first, "Driver 001")
+	assert.Contains(t, first, fmt.Sprintf("Driver %03d", adminPageSize))
+	assert.NotContains(t, first, fmt.Sprintf("Driver %03d", adminPageSize+1), "the next page's first row must not leak onto page 1")
+	assert.Contains(t, first, `href="/admin/users?page=2"`)
+	assert.NotContains(t, first, "Previous", "page 1 has no previous page")
+
+	second := getAdminPage(t, mux, "/admin/users?page=2")
+	assert.Equal(t, 5, strings.Count(second, "/edit\""), "the last page holds the remaining rows")
+	assert.Contains(t, second, fmt.Sprintf("Driver %03d", adminPageSize+1))
+	assert.NotContains(t, second, fmt.Sprintf("Driver %03d", adminPageSize), "page 1's last row must not repeat on page 2")
+	assert.Contains(t, second, `href="/admin/users?page=1"`)
+	assert.NotContains(t, second, "Next", "the last page has no next page")
+}
+
+// TestUsersPageInvalidPageFallsBack verifies a hand-edited ?page= renders
+// page 1 rather than erroring, matching the other admin list pages.
+func TestUsersPageInvalidPageFallsBack(t *testing.T) {
+	ui := newTestAdminUI(t)
+	wireFakeUserStore(ui, newFakeUserStore(seedUsers(adminPageSize+5)...), newFakeAssignmentStore())
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	for _, page := range []string{"abc", "0", "-3", "1000001", ""} {
+		t.Run("page="+page, func(t *testing.T) {
+			body := getAdminPage(t, mux, "/admin/users?page="+page)
+			assert.Contains(t, body, "Driver 001", "an invalid page must render page 1")
+			assert.Contains(t, body, "Page 1")
+		})
+	}
+}
+
+// TestUsersPage_AssignmentQueriesBoundedByPageSize pins the side effect of
+// paging this list: the per-user assignment lookup (a deliberate N+1, see
+// usersPage) now runs once per row on the page, not once per row in the
+// table, so it can't grow with the user count.
+func TestUsersPage_AssignmentQueriesBoundedByPageSize(t *testing.T) {
+	ui := newTestAdminUI(t)
+	assignments := newFakeAssignmentStore()
+	wireFakeUserStore(ui, newFakeUserStore(seedUsers(adminPageSize*3)...), assignments)
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	body := getAdminPage(t, mux, "/admin/users")
+	require.Contains(t, body, "Driver 001", "the page must have rendered rows for the count to mean anything")
+	assert.Equal(t, adminPageSize, assignments.listCalls,
+		"the assignment lookup must run once per row on the page, not once per user in the table")
 }
 
 // TestUsersPageListsRealData verifies the list page renders each user's

--- a/db/query.sql
+++ b/db/query.sql
@@ -15,9 +15,19 @@ WHERE received_at > $1
 ORDER BY vehicle_id, received_at DESC;
 
 -- name: ListUsers :many
+-- safety bound; not pagination. Callers that need one page at a time use
+-- ListUsersPage. The id tiebreaker makes the order total, so the bound
+-- always truncates the same 1000 rows.
 SELECT id, name, email, role, active, created_at, updated_at
 FROM users
-ORDER BY created_at DESC;
+ORDER BY created_at DESC, id DESC
+LIMIT 1000;
+
+-- name: ListUsersPage :many
+SELECT id, name, email, role, active, created_at, updated_at
+FROM users
+ORDER BY created_at DESC, id DESC
+LIMIT $1 OFFSET $2;
 
 -- name: GetUserByID :one
 SELECT id, name, email, role, active, created_at, updated_at
@@ -52,9 +62,29 @@ SELECT COUNT(*) FROM users WHERE role = $1;
 SELECT COUNT(*) FROM users WHERE role = $1 AND active = true;
 
 -- name: ListVehicles :many
+-- safety bound; not pagination. Callers that need one page at a time use
+-- ListVehiclesPage. The id tiebreaker makes the order total, so the bound
+-- always truncates the same 1000 rows.
 SELECT id, label, agency_tag, active, created_at, updated_at
 FROM vehicles
-ORDER BY created_at DESC;
+ORDER BY created_at DESC, id DESC
+LIMIT 1000;
+
+-- name: ListVehiclesPage :many
+SELECT id, label, agency_tag, active, created_at, updated_at
+FROM vehicles
+ORDER BY created_at DESC, id DESC
+LIMIT $1 OFFSET $2;
+
+-- name: ListActiveVehiclesPage :many
+-- The admin vehicle list hides deactivated vehicles unless
+-- ?include_inactive=1. Filtering here rather than after the fetch keeps
+-- every page a full page.
+SELECT id, label, agency_tag, active, created_at, updated_at
+FROM vehicles
+WHERE active
+ORDER BY created_at DESC, id DESC
+LIMIT $1 OFFSET $2;
 
 -- name: GetVehicleByID :one
 SELECT id, label, agency_tag, active, created_at, updated_at

--- a/db/query.sql.go
+++ b/db/query.sql.go
@@ -551,6 +551,58 @@ func (q *Queries) ListActiveVehiclesByUser(ctx context.Context, userID int64) ([
 	return items, nil
 }
 
+const listActiveVehiclesPage = `-- name: ListActiveVehiclesPage :many
+SELECT id, label, agency_tag, active, created_at, updated_at
+FROM vehicles
+WHERE active
+ORDER BY created_at DESC, id DESC
+LIMIT $1 OFFSET $2
+`
+
+type ListActiveVehiclesPageParams struct {
+	Limit  int32
+	Offset int32
+}
+
+type ListActiveVehiclesPageRow struct {
+	ID        string
+	Label     string
+	AgencyTag string
+	Active    bool
+	CreatedAt pgtype.Timestamptz
+	UpdatedAt pgtype.Timestamptz
+}
+
+// The admin vehicle list hides deactivated vehicles unless
+// ?include_inactive=1. Filtering here rather than after the fetch keeps
+// every page a full page.
+func (q *Queries) ListActiveVehiclesPage(ctx context.Context, arg ListActiveVehiclesPageParams) ([]ListActiveVehiclesPageRow, error) {
+	rows, err := q.db.Query(ctx, listActiveVehiclesPage, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListActiveVehiclesPageRow
+	for rows.Next() {
+		var i ListActiveVehiclesPageRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Label,
+			&i.AgencyTag,
+			&i.Active,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTripLocations = `-- name: ListTripLocations :many
 SELECT lp.latitude, lp.longitude, lp.bearing, lp.speed, lp.accuracy,
        lp.timestamp, lp.trip_id, lp.received_at
@@ -609,7 +661,8 @@ func (q *Queries) ListTripLocations(ctx context.Context, id int64) ([]ListTripLo
 const listUsers = `-- name: ListUsers :many
 SELECT id, name, email, role, active, created_at, updated_at
 FROM users
-ORDER BY created_at DESC
+ORDER BY created_at DESC, id DESC
+LIMIT 1000
 `
 
 type ListUsersRow struct {
@@ -622,6 +675,9 @@ type ListUsersRow struct {
 	UpdatedAt pgtype.Timestamptz
 }
 
+// safety bound; not pagination. Callers that need one page at a time use
+// ListUsersPage. The id tiebreaker makes the order total, so the bound
+// always truncates the same 1000 rows.
 func (q *Queries) ListUsers(ctx context.Context) ([]ListUsersRow, error) {
 	rows, err := q.db.Query(ctx, listUsers)
 	if err != nil {
@@ -679,10 +735,61 @@ func (q *Queries) ListUsersByVehicle(ctx context.Context, vehicleID string) ([]U
 	return items, nil
 }
 
+const listUsersPage = `-- name: ListUsersPage :many
+SELECT id, name, email, role, active, created_at, updated_at
+FROM users
+ORDER BY created_at DESC, id DESC
+LIMIT $1 OFFSET $2
+`
+
+type ListUsersPageParams struct {
+	Limit  int32
+	Offset int32
+}
+
+type ListUsersPageRow struct {
+	ID        int64
+	Name      string
+	Email     string
+	Role      string
+	Active    bool
+	CreatedAt pgtype.Timestamptz
+	UpdatedAt pgtype.Timestamptz
+}
+
+func (q *Queries) ListUsersPage(ctx context.Context, arg ListUsersPageParams) ([]ListUsersPageRow, error) {
+	rows, err := q.db.Query(ctx, listUsersPage, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUsersPageRow
+	for rows.Next() {
+		var i ListUsersPageRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Email,
+			&i.Role,
+			&i.Active,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listVehicles = `-- name: ListVehicles :many
 SELECT id, label, agency_tag, active, created_at, updated_at
 FROM vehicles
-ORDER BY created_at DESC
+ORDER BY created_at DESC, id DESC
+LIMIT 1000
 `
 
 type ListVehiclesRow struct {
@@ -694,6 +801,9 @@ type ListVehiclesRow struct {
 	UpdatedAt pgtype.Timestamptz
 }
 
+// safety bound; not pagination. Callers that need one page at a time use
+// ListVehiclesPage. The id tiebreaker makes the order total, so the bound
+// always truncates the same 1000 rows.
 func (q *Queries) ListVehicles(ctx context.Context) ([]ListVehiclesRow, error) {
 	rows, err := q.db.Query(ctx, listVehicles)
 	if err != nil {
@@ -740,6 +850,54 @@ func (q *Queries) ListVehiclesByUser(ctx context.Context, userID int64) ([]UserV
 	for rows.Next() {
 		var i UserVehicle
 		if err := rows.Scan(&i.UserID, &i.VehicleID, &i.CreatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listVehiclesPage = `-- name: ListVehiclesPage :many
+SELECT id, label, agency_tag, active, created_at, updated_at
+FROM vehicles
+ORDER BY created_at DESC, id DESC
+LIMIT $1 OFFSET $2
+`
+
+type ListVehiclesPageParams struct {
+	Limit  int32
+	Offset int32
+}
+
+type ListVehiclesPageRow struct {
+	ID        string
+	Label     string
+	AgencyTag string
+	Active    bool
+	CreatedAt pgtype.Timestamptz
+	UpdatedAt pgtype.Timestamptz
+}
+
+func (q *Queries) ListVehiclesPage(ctx context.Context, arg ListVehiclesPageParams) ([]ListVehiclesPageRow, error) {
+	rows, err := q.db.Query(ctx, listVehiclesPage, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListVehiclesPageRow
+	for rows.Next() {
+		var i ListVehiclesPageRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Label,
+			&i.AgencyTag,
+			&i.Active,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/handlers.go
+++ b/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"mime"
 	"net/http"
 	"regexp"
@@ -271,6 +272,41 @@ func handleAdminStatus(tracker *Tracker, startTime time.Time) http.HandlerFunc {
 			LastUpdate:           ts.LastUpdate,
 		})
 	}
+}
+
+const (
+	// defaultListLimit and maxListLimit bound the limit query param on the
+	// admin vehicle and user list endpoints, mirroring
+	// defaultTripListLimit/maxTripListLimit (admin_live_handlers.go) so every
+	// admin list endpoint bounds a page the same way.
+	defaultListLimit = 50
+	maxListLimit     = 200
+
+	// maxListOffset is the largest offset those endpoints accept: the paged
+	// queries take an int32 offset, and a larger value would wrap negative
+	// and be rejected by Postgres as a 500 instead of a 400.
+	maxListOffset = math.MaxInt32
+)
+
+// parseListPageParams reads the limit/offset paging params shared by the
+// admin list endpoints. It writes the 400 response itself and reports
+// ok=false, so callers return without repeating the error handling.
+func parseListPageParams(w http.ResponseWriter, r *http.Request) (limit, offset int, ok bool) {
+	q := r.URL.Query()
+
+	limit, err := parseOptionalInt(q.Get("limit"), defaultListLimit)
+	if err != nil || limit < 1 || limit > maxListLimit {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("limit must be between 1 and %d", maxListLimit)})
+		return 0, 0, false
+	}
+
+	offset, err = parseOptionalInt(q.Get("offset"), 0)
+	if err != nil || offset < 0 || offset > maxListOffset {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("offset must be between 0 and %d", maxListOffset)})
+		return 0, 0, false
+	}
+
+	return limit, offset, true
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/handlers_vehicles.go
+++ b/handlers_vehicles.go
@@ -48,9 +48,18 @@ func (r *upsertVehicleRequest) validate() error {
 	return nil
 }
 
-func handleListVehicles(store VehicleManager) http.HandlerFunc {
+// handleListVehicles returns one page of vehicles, newest first, bounded by
+// the limit/offset query params. Deactivated vehicles are included, as they
+// always have been. The response stays a bare JSON array rather than a
+// paging envelope so existing clients keep working.
+func handleListVehicles(store VehiclePager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		vehicles, err := store.ListVehicles(r.Context())
+		limit, offset, ok := parseListPageParams(w, r)
+		if !ok {
+			return
+		}
+
+		vehicles, err := store.ListVehiclesPage(r.Context(), true, int32(limit), int32(offset))
 		if err != nil {
 			slog.Error("failed to list vehicles", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list vehicles"})

--- a/handlers_vehicles_test.go
+++ b/handlers_vehicles_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +21,26 @@ import (
 type mockVehicleStore struct {
 	vehicles map[string]*VehicleResponse
 	err      error
+
+	// Recorded by ListVehiclesPage so paging tests can assert what the
+	// handler asked the store for.
+	gotIncludeInactive bool
+	gotLimit           int32
+	gotOffset          int32
+}
+
+// pageSlice returns the limit/offset window of s, mirroring SQL LIMIT/OFFSET
+// semantics (an offset past the end is an empty page, never nil). Shared by
+// the in-memory paging doubles in this package.
+func pageSlice[T any](s []T, limit, offset int32) []T {
+	if int(offset) >= len(s) {
+		return make([]T, 0)
+	}
+	end := int(offset) + int(limit)
+	if end > len(s) {
+		end = len(s)
+	}
+	return append(make([]T, 0, end-int(offset)), s[int(offset):end]...)
 }
 
 func newMockVehicleStore() *mockVehicleStore {
@@ -35,6 +56,31 @@ func (m *mockVehicleStore) ListVehicles(_ context.Context) ([]VehicleResponse, e
 		result = append(result, *v)
 	}
 	return result, nil
+}
+
+// ListVehiclesPage orders by id so pages are deterministic; the real store
+// orders by created_at DESC with an id tiebreaker. Only the totality of the
+// order matters to the handler.
+func (m *mockVehicleStore) ListVehiclesPage(_ context.Context, includeInactive bool, limit, offset int32) ([]VehicleResponse, error) {
+	m.gotIncludeInactive, m.gotLimit, m.gotOffset = includeInactive, limit, offset
+	if m.err != nil {
+		return nil, m.err
+	}
+	ids := make([]string, 0, len(m.vehicles))
+	for id := range m.vehicles {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	all := make([]VehicleResponse, 0, len(ids))
+	for _, id := range ids {
+		v := m.vehicles[id]
+		if !includeInactive && !v.Active {
+			continue
+		}
+		all = append(all, *v)
+	}
+	return pageSlice(all, limit, offset), nil
 }
 
 func (m *mockVehicleStore) GetVehicle(_ context.Context, id string) (*VehicleResponse, error) {
@@ -126,6 +172,121 @@ func TestHandleListVehicles_ResponseNotNull(t *testing.T) {
 	err := json.NewDecoder(w.Body).Decode(&raw)
 	require.NoError(t, err)
 	assert.Equal(t, "[]", string(raw), "empty vehicle list must be JSON [] not null")
+}
+
+// TestHandleListVehicles_PagingParams covers the limit/offset contract: the
+// defaults applied when the params are absent, the values that reach the
+// store, and every rejection — including the pair at exactly the maximum and
+// one past it. Rejections assert the error message, not just the status, so
+// a case can't pass for the wrong reason.
+func TestHandleListVehicles_PagingParams(t *testing.T) {
+	const limitError = "limit must be between 1 and 200"
+	offsetError := fmt.Sprintf("offset must be between 0 and %d", maxListOffset)
+
+	tests := []struct {
+		name       string
+		query      string
+		wantStatus int
+		wantError  string
+		wantLimit  int32
+		wantOffset int32
+	}{
+		{name: "absent params use the defaults", query: "", wantStatus: http.StatusOK, wantLimit: defaultListLimit},
+		{name: "explicit limit and offset", query: "?limit=10&offset=20", wantStatus: http.StatusOK, wantLimit: 10, wantOffset: 20},
+		{name: "limit at the maximum", query: "?limit=200", wantStatus: http.StatusOK, wantLimit: maxListLimit},
+		{name: "limit one past the maximum", query: "?limit=201", wantStatus: http.StatusBadRequest, wantError: limitError},
+		{name: "limit zero", query: "?limit=0", wantStatus: http.StatusBadRequest, wantError: limitError},
+		{name: "limit negative", query: "?limit=-1", wantStatus: http.StatusBadRequest, wantError: limitError},
+		{name: "limit non-numeric", query: "?limit=abc", wantStatus: http.StatusBadRequest, wantError: limitError},
+		{name: "offset zero", query: "?offset=0", wantStatus: http.StatusOK, wantLimit: defaultListLimit},
+		{name: "offset negative", query: "?offset=-1", wantStatus: http.StatusBadRequest, wantError: offsetError},
+		{name: "offset non-numeric", query: "?offset=abc", wantStatus: http.StatusBadRequest, wantError: offsetError},
+		{name: "offset at the maximum", query: "?offset=2147483647", wantStatus: http.StatusOK, wantLimit: defaultListLimit, wantOffset: maxListOffset},
+		{name: "offset one past the maximum", query: "?offset=2147483648", wantStatus: http.StatusBadRequest, wantError: offsetError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockVehicleStore()
+			handler := handleListVehicles(store)
+			req := httptest.NewRequest("GET", "/api/v1/admin/vehicles"+tt.query, nil)
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code)
+			if tt.wantStatus != http.StatusOK {
+				assert.Equal(t, tt.wantError, decodeErrorResponse(t, w))
+				return
+			}
+			assert.Equal(t, tt.wantLimit, store.gotLimit, "limit passed to the store")
+			assert.Equal(t, tt.wantOffset, store.gotOffset, "offset passed to the store")
+		})
+	}
+}
+
+// TestHandleListVehicles_PagesResults verifies limit/offset actually narrow
+// the response rather than only being validated.
+func TestHandleListVehicles_PagesResults(t *testing.T) {
+	store := newMockVehicleStore()
+	now := time.Now()
+	for _, id := range []string{"bus-1", "bus-2", "bus-3"} {
+		store.vehicles[id] = &VehicleResponse{ID: id, Label: id, Active: true, CreatedAt: now, UpdatedAt: now}
+	}
+
+	handler := handleListVehicles(store)
+	req := httptest.NewRequest("GET", "/api/v1/admin/vehicles?limit=2&offset=1", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var vehicles []VehicleResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&vehicles))
+	require.Len(t, vehicles, 2)
+	assert.Equal(t, "bus-2", vehicles[0].ID)
+	assert.Equal(t, "bus-3", vehicles[1].ID)
+}
+
+// TestHandleListVehicles_IncludesInactive pins that the endpoint still lists
+// deactivated vehicles, which it has always done — the admin page's
+// active-only filter must not leak into the API.
+func TestHandleListVehicles_IncludesInactive(t *testing.T) {
+	store := newMockVehicleStore()
+	now := time.Now()
+	store.vehicles["bus-1"] = &VehicleResponse{ID: "bus-1", Label: "Bus 1", Active: true, CreatedAt: now, UpdatedAt: now}
+	store.vehicles["bus-2"] = &VehicleResponse{ID: "bus-2", Label: "Bus 2", Active: false, CreatedAt: now, UpdatedAt: now}
+
+	handler := handleListVehicles(store)
+	req := httptest.NewRequest("GET", "/api/v1/admin/vehicles", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, store.gotIncludeInactive, "the API must ask for deactivated vehicles too")
+	var vehicles []VehicleResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&vehicles))
+	assert.Len(t, vehicles, 2)
+}
+
+// TestHandleListVehicles_StillReturnsBareArray guards the response shape:
+// adding paging deliberately did NOT wrap the body in an object the way the
+// trips and location-history endpoints do, because existing clients and the
+// documented schema index into a bare array. If someone wraps it later, this
+// fails loudly.
+func TestHandleListVehicles_StillReturnsBareArray(t *testing.T) {
+	store := newMockVehicleStore()
+	now := time.Now()
+	store.vehicles["bus-1"] = &VehicleResponse{ID: "bus-1", Label: "Bus 1", Active: true, CreatedAt: now, UpdatedAt: now}
+
+	handler := handleListVehicles(store)
+	req := httptest.NewRequest("GET", "/api/v1/admin/vehicles", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var vehicles []VehicleResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &vehicles), "response must unmarshal into a bare array")
+	require.Len(t, vehicles, 1)
+	assert.Equal(t, "bus-1", vehicles[0].ID)
 }
 
 func TestHandleListVehicles_StoreError(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var files embed.FS
 type appStore interface {
 	UserFetcher
 	UserLister
+	UserPager
 	UserGetter
 	UserCreator
 	UserUpdater
@@ -30,6 +31,7 @@ type appStore interface {
 	UserPasswordUpdater
 	UserRoleCounter
 	VehicleManager
+	VehiclePager
 	VehicleInfoUpdater
 	VehicleActivator
 	VehicleCreator

--- a/route_wiring_test.go
+++ b/route_wiring_test.go
@@ -24,6 +24,9 @@ func (n *noopStore) GetUserByEmail(_ context.Context, _ string) (*User, error) {
 func (n *noopStore) ListUsers(_ context.Context) ([]UserResponse, error) {
 	return make([]UserResponse, 0), nil
 }
+func (n *noopStore) ListUsersPage(_ context.Context, _, _ int32) ([]UserResponse, error) {
+	return make([]UserResponse, 0), nil
+}
 func (n *noopStore) GetUser(_ context.Context, _ int64) (*UserResponse, error) {
 	return nil, nil
 }
@@ -37,6 +40,9 @@ func (n *noopStore) DeleteUser(_ context.Context, _ int64) error {
 	return nil
 }
 func (n *noopStore) ListVehicles(_ context.Context) ([]VehicleResponse, error) {
+	return make([]VehicleResponse, 0), nil
+}
+func (n *noopStore) ListVehiclesPage(_ context.Context, _ bool, _, _ int32) ([]VehicleResponse, error) {
 	return make([]VehicleResponse, 0), nil
 }
 func (n *noopStore) GetVehicle(_ context.Context, _ string) (*VehicleResponse, error) {

--- a/store_users_test.go
+++ b/store_users_test.go
@@ -314,3 +314,85 @@ func TestStore_UpdateUserPassword_NotFound(t *testing.T) {
 	err := store.UpdateUserPassword(context.Background(), 999999999, "somepassword")
 	assert.ErrorIs(t, err, ErrUserNotFound)
 }
+
+// TestStore_ListUsersPage covers the paged listing: limit is honoured and
+// consecutive pages tile the table exactly, with no user skipped or repeated
+// across the page boundary. The five users seeded here are the newest rows,
+// so they occupy the first five positions of a created_at DESC listing
+// whatever else the table holds.
+func TestStore_ListUsersPage(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	emails := []string{
+		"paged-1@example.com",
+		"paged-2@example.com",
+		"paged-3@example.com",
+		"paged-4@example.com",
+		"paged-5@example.com",
+	}
+	cleanupTestUsers(t, store, emails...)
+	t.Cleanup(func() { cleanupTestUsers(t, store, emails...) })
+
+	seeded := make(map[string]bool, len(emails))
+	for i, email := range emails {
+		_, err := store.CreateUser(ctx, fmt.Sprintf("Paged %d", i+1), email, "securepass", "driver")
+		require.NoError(t, err)
+		seeded[email] = true
+	}
+
+	first, err := store.ListUsersPage(ctx, 3, 0)
+	require.NoError(t, err)
+	require.Len(t, first, 3, "limit must cap the page")
+
+	second, err := store.ListUsersPage(ctx, 3, 3)
+	require.NoError(t, err)
+	require.NotEmpty(t, second)
+
+	seen := make(map[string]int, len(emails))
+	found := 0
+	for _, page := range [][]UserResponse{first, second} {
+		for _, u := range page {
+			if seeded[u.Email] {
+				seen[u.Email]++
+				found++
+			}
+		}
+	}
+	assert.Equal(t, len(emails), found, "all seeded users must land in the first two pages")
+	for _, email := range emails {
+		assert.Equal(t, 1, seen[email], "user %s must appear on exactly one page", email)
+	}
+
+	past, err := store.ListUsersPage(ctx, 3, 1_000_000)
+	require.NoError(t, err)
+	assert.NotNil(t, past, "an offset past the end should be [], not nil")
+	assert.Empty(t, past)
+}
+
+// TestStore_ListUsers_SafetyBound verifies the unpaged listing stops at the
+// query's 1000-row LIMIT rather than marshalling an unbounded table. The
+// rows are seeded with one generate_series insert to keep this fast.
+func TestStore_ListUsers_SafetyBound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	deleteBoundUsers := func() {
+		_, err := store.pool.Exec(ctx, "DELETE FROM users WHERE email LIKE 'bound-%@example.com'")
+		require.NoError(t, err)
+	}
+	deleteBoundUsers()
+	t.Cleanup(deleteBoundUsers)
+
+	// A syntactically valid bcrypt hash; these rows are never logged in as.
+	const hash = "$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi"
+	_, err := store.pool.Exec(ctx,
+		`INSERT INTO users (name, email, password_hash, role)
+		 SELECT 'Bound ' || g, 'bound-' || g || '@example.com', $1, 'driver'
+		 FROM generate_series(1, 1001) AS g`, hash)
+	require.NoError(t, err)
+
+	users, err := store.ListUsers(ctx)
+	require.NoError(t, err)
+	assert.Len(t, users, 1000, "ListUsers must stop at its 1000-row safety bound")
+}

--- a/store_vehicles.go
+++ b/store_vehicles.go
@@ -28,6 +28,15 @@ type VehicleManager interface {
 	DeactivateVehicle(ctx context.Context, id string) error
 }
 
+// VehiclePager lists vehicles one page at a time, for the paginated admin
+// vehicle list and the vehicles API endpoint. Callers that need the whole
+// fleet in a single call — the dashboard's label map, the assignment and
+// trip-filter dropdowns, the live map — keep using
+// VehicleManager.ListVehicles, which pagination would silently truncate.
+type VehiclePager interface {
+	ListVehiclesPage(ctx context.Context, includeInactive bool, limit, offset int32) ([]VehicleResponse, error)
+}
+
 // VehicleInfoUpdater updates a vehicle's label/agency tag without touching
 // its active flag (unlike VehicleManager.UpsertVehicle, which reactivates).
 type VehicleInfoUpdater interface {
@@ -46,7 +55,9 @@ type VehicleCreator interface {
 	CreateVehicle(ctx context.Context, id, label, agencyTag string) (created bool, err error)
 }
 
-// ListVehicles returns all vehicles ordered by creation time.
+// ListVehicles returns vehicles ordered by creation time, capped at the
+// query's 1000-row safety bound. Callers that page through the fleet use
+// ListVehiclesPage instead.
 func (s *Store) ListVehicles(ctx context.Context) ([]VehicleResponse, error) {
 	rows, err := s.queries.ListVehicles(ctx)
 	if err != nil {
@@ -59,6 +70,36 @@ func (s *Store) ListVehicles(ctx context.Context) ([]VehicleResponse, error) {
 	}
 	return vehicles, nil
 }
+
+// ListVehiclesPage returns one page of vehicles in the same order as
+// ListVehicles. includeInactive=false filters deactivated vehicles out in
+// SQL rather than after the fetch, so a page of the admin list holds a full
+// page of rows.
+func (s *Store) ListVehiclesPage(ctx context.Context, includeInactive bool, limit, offset int32) ([]VehicleResponse, error) {
+	if !includeInactive {
+		rows, err := s.queries.ListActiveVehiclesPage(ctx, db.ListActiveVehiclesPageParams{Limit: limit, Offset: offset})
+		if err != nil {
+			return nil, fmt.Errorf("list active vehicles page: %w", err)
+		}
+		vehicles := make([]VehicleResponse, 0, len(rows))
+		for _, row := range rows {
+			vehicles = append(vehicles, toVehicleResponse(row.ID, row.Label, row.AgencyTag, row.Active, row.CreatedAt, row.UpdatedAt))
+		}
+		return vehicles, nil
+	}
+
+	rows, err := s.queries.ListVehiclesPage(ctx, db.ListVehiclesPageParams{Limit: limit, Offset: offset})
+	if err != nil {
+		return nil, fmt.Errorf("list vehicles page: %w", err)
+	}
+	vehicles := make([]VehicleResponse, 0, len(rows))
+	for _, row := range rows {
+		vehicles = append(vehicles, toVehicleResponse(row.ID, row.Label, row.AgencyTag, row.Active, row.CreatedAt, row.UpdatedAt))
+	}
+	return vehicles, nil
+}
+
+var _ VehiclePager = (*Store)(nil)
 
 // GetVehicle returns a single vehicle by ID.
 func (s *Store) GetVehicle(ctx context.Context, id string) (*VehicleResponse, error) {

--- a/store_vehicles_test.go
+++ b/store_vehicles_test.go
@@ -322,3 +322,95 @@ func TestCountActiveVehiclesAndTrips(t *testing.T) {
 	_, err = store.CountActiveTrips(context.Background())
 	require.NoError(t, err) // exact value covered by trip tests; here just exercises the query
 }
+
+// TestStore_ListVehiclesPage covers the paged listing: limit and offset are
+// honoured, consecutive pages tile the table exactly (the id tiebreaker in
+// the ORDER BY keeps LIMIT/OFFSET from skipping or repeating a row), and an
+// offset past the end is an empty page rather than an error.
+func TestStore_ListVehiclesPage(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+	ctx := context.Background()
+
+	ids := []string{"page-a", "page-b", "page-c", "page-d", "page-e"}
+	for _, id := range ids {
+		_, err := store.UpsertVehicle(ctx, id, "Label "+id, "agency")
+		require.NoError(t, err)
+	}
+
+	first, err := store.ListVehiclesPage(ctx, true, 3, 0)
+	require.NoError(t, err)
+	require.Len(t, first, 3)
+
+	second, err := store.ListVehiclesPage(ctx, true, 3, 3)
+	require.NoError(t, err)
+	require.Len(t, second, 2)
+
+	seen := make(map[string]int, len(ids))
+	for _, page := range [][]VehicleResponse{first, second} {
+		for _, v := range page {
+			seen[v.ID]++
+		}
+	}
+	assert.Len(t, seen, len(ids), "the two pages together must cover every vehicle")
+	for _, id := range ids {
+		assert.Equal(t, 1, seen[id], "vehicle %s must appear on exactly one page", id)
+	}
+
+	past, err := store.ListVehiclesPage(ctx, true, 3, 100)
+	require.NoError(t, err)
+	assert.NotNil(t, past, "an offset past the end should be [], not nil")
+	assert.Empty(t, past)
+}
+
+func TestStore_ListVehiclesPage_Empty(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+
+	vehicles, err := store.ListVehiclesPage(context.Background(), true, 50, 0)
+	require.NoError(t, err)
+	assert.NotNil(t, vehicles, "empty page should be [], not nil")
+	assert.Empty(t, vehicles)
+}
+
+// TestStore_ListVehiclesPage_ExcludesInactive verifies includeInactive=false
+// filters deactivated vehicles out in SQL. The admin list hides them by
+// default, and filtering after the fetch would shrink pages below the page
+// size instead of returning a full page of active vehicles.
+func TestStore_ListVehiclesPage_ExcludesInactive(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+	ctx := context.Background()
+
+	_, err := store.UpsertVehicle(ctx, "page-active", "Active Bus", "agency")
+	require.NoError(t, err)
+	_, err = store.UpsertVehicle(ctx, "page-retired", "Retired Bus", "agency")
+	require.NoError(t, err)
+	require.NoError(t, store.DeactivateVehicle(ctx, "page-retired"))
+
+	activeOnly, err := store.ListVehiclesPage(ctx, false, 50, 0)
+	require.NoError(t, err)
+	require.Len(t, activeOnly, 1)
+	assert.Equal(t, "page-active", activeOnly[0].ID)
+
+	all, err := store.ListVehiclesPage(ctx, true, 50, 0)
+	require.NoError(t, err)
+	assert.Len(t, all, 2, "includeInactive must return deactivated vehicles too")
+}
+
+// TestStore_ListVehicles_SafetyBound verifies the unpaged listing stops at
+// the query's 1000-row LIMIT rather than marshalling an unbounded table.
+// The rows are seeded with one generate_series insert to keep this fast.
+func TestStore_ListVehicles_SafetyBound(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+	ctx := context.Background()
+
+	_, err := store.pool.Exec(ctx,
+		`INSERT INTO vehicles (id, label) SELECT 'bound-' || g, 'Bound ' || g FROM generate_series(1, 1001) AS g`)
+	require.NoError(t, err)
+
+	vehicles, err := store.ListVehicles(ctx)
+	require.NoError(t, err)
+	assert.Len(t, vehicles, 1000, "ListVehicles must stop at its 1000-row safety bound")
+}

--- a/user_handlers.go
+++ b/user_handlers.go
@@ -24,9 +24,17 @@ type UpdateUserRequest struct {
 	Role  string `json:"role"`
 }
 
-func handleListUsers(store UserLister) http.HandlerFunc {
+// handleListUsers returns one page of users, newest first, bounded by the
+// limit/offset query params. The response stays a bare JSON array rather
+// than a paging envelope so existing clients keep working.
+func handleListUsers(store UserPager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		users, err := store.ListUsers(r.Context())
+		limit, offset, ok := parseListPageParams(w, r)
+		if !ok {
+			return
+		}
+
+		users, err := store.ListUsersPage(r.Context(), int32(limit), int32(offset))
 		if err != nil {
 			slog.Error("failed to list users", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})

--- a/user_handlers_test.go
+++ b/user_handlers_test.go
@@ -18,13 +18,22 @@ import (
 
 // --- Mock stores ---
 
-type mockUserLister struct {
+type mockUserPager struct {
 	users []UserResponse
 	err   error
+
+	// Recorded by ListUsersPage so paging tests can assert what the handler
+	// asked the store for.
+	gotLimit  int32
+	gotOffset int32
 }
 
-func (m *mockUserLister) ListUsers(ctx context.Context) ([]UserResponse, error) {
-	return m.users, m.err
+func (m *mockUserPager) ListUsersPage(_ context.Context, limit, offset int32) ([]UserResponse, error) {
+	m.gotLimit, m.gotOffset = limit, offset
+	if m.err != nil {
+		return nil, m.err
+	}
+	return pageSlice(m.users, limit, offset), nil
 }
 
 type mockUserGetter struct {
@@ -86,7 +95,7 @@ func newSampleUser() *UserResponse {
 // --- List Users ---
 
 func TestHandleListUsers_Empty(t *testing.T) {
-	handler := handleListUsers(&mockUserLister{users: make([]UserResponse, 0)})
+	handler := handleListUsers(&mockUserPager{users: make([]UserResponse, 0)})
 	req := httptest.NewRequest("GET", "/api/v1/admin/users", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)
@@ -105,7 +114,7 @@ func TestHandleListUsers_WithUsers(t *testing.T) {
 		{ID: 1, Name: "Alice", Email: "alice@example.com", Role: "admin"},
 		{ID: 2, Name: "Bob", Email: "bob@example.com", Role: "driver"},
 	}
-	handler := handleListUsers(&mockUserLister{users: users})
+	handler := handleListUsers(&mockUserPager{users: users})
 	req := httptest.NewRequest("GET", "/api/v1/admin/users", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)
@@ -120,11 +129,94 @@ func TestHandleListUsers_WithUsers(t *testing.T) {
 	assert.Equal(t, "Bob", result[1].Name)
 }
 
+// TestHandleListUsers_PagingParams covers the limit/offset contract on the
+// users endpoint: the defaults, the values that reach the store, and the
+// boundary pair at exactly the maximum and one past it. The shared parsing
+// is exercised exhaustively in TestHandleListVehicles_PagingParams; this
+// table pins that this endpoint is wired to the same rules.
+func TestHandleListUsers_PagingParams(t *testing.T) {
+	const limitError = "limit must be between 1 and 200"
+	offsetError := fmt.Sprintf("offset must be between 0 and %d", maxListOffset)
+
+	tests := []struct {
+		name       string
+		query      string
+		wantStatus int
+		wantError  string
+		wantLimit  int32
+		wantOffset int32
+	}{
+		{name: "absent params use the defaults", query: "", wantStatus: http.StatusOK, wantLimit: defaultListLimit},
+		{name: "explicit limit and offset", query: "?limit=10&offset=20", wantStatus: http.StatusOK, wantLimit: 10, wantOffset: 20},
+		{name: "limit at the maximum", query: "?limit=200", wantStatus: http.StatusOK, wantLimit: maxListLimit},
+		{name: "limit one past the maximum", query: "?limit=201", wantStatus: http.StatusBadRequest, wantError: limitError},
+		{name: "limit zero", query: "?limit=0", wantStatus: http.StatusBadRequest, wantError: limitError},
+		{name: "limit non-numeric", query: "?limit=abc", wantStatus: http.StatusBadRequest, wantError: limitError},
+		{name: "offset negative", query: "?offset=-1", wantStatus: http.StatusBadRequest, wantError: offsetError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &mockUserPager{users: make([]UserResponse, 0)}
+			handler := handleListUsers(store)
+			req := httptest.NewRequest("GET", "/api/v1/admin/users"+tt.query, nil)
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code)
+			if tt.wantStatus != http.StatusOK {
+				assert.Equal(t, tt.wantError, decodeErrorResponse(t, w))
+				return
+			}
+			assert.Equal(t, tt.wantLimit, store.gotLimit, "limit passed to the store")
+			assert.Equal(t, tt.wantOffset, store.gotOffset, "offset passed to the store")
+		})
+	}
+}
+
+// TestHandleListUsers_PagesResults verifies limit/offset actually narrow the
+// response rather than only being validated.
+func TestHandleListUsers_PagesResults(t *testing.T) {
+	users := []UserResponse{
+		{ID: 1, Name: "Alice", Email: "alice@example.com", Role: "admin"},
+		{ID: 2, Name: "Bob", Email: "bob@example.com", Role: "driver"},
+		{ID: 3, Name: "Carol", Email: "carol@example.com", Role: "driver"},
+	}
+	handler := handleListUsers(&mockUserPager{users: users})
+	req := httptest.NewRequest("GET", "/api/v1/admin/users?limit=2&offset=1", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var result []UserResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&result))
+	require.Len(t, result, 2)
+	assert.Equal(t, "Bob", result[0].Name)
+	assert.Equal(t, "Carol", result[1].Name)
+}
+
+// TestHandleListUsers_StillReturnsBareArray guards the response shape:
+// paging deliberately did NOT wrap the body in an object, because existing
+// clients and the documented schema index into a bare array.
+func TestHandleListUsers_StillReturnsBareArray(t *testing.T) {
+	users := []UserResponse{{ID: 1, Name: "Alice", Email: "alice@example.com", Role: "admin"}}
+	handler := handleListUsers(&mockUserPager{users: users})
+	req := httptest.NewRequest("GET", "/api/v1/admin/users", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var result []UserResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result), "response must unmarshal into a bare array")
+	require.Len(t, result, 1)
+	assert.Equal(t, "Alice", result[0].Name)
+}
+
 func TestHandleListUsers_NoPasswordInResponse(t *testing.T) {
 	users := []UserResponse{
 		{ID: 1, Name: "Alice", Email: "alice@example.com", Role: "admin"},
 	}
-	handler := handleListUsers(&mockUserLister{users: users})
+	handler := handleListUsers(&mockUserPager{users: users})
 	req := httptest.NewRequest("GET", "/api/v1/admin/users", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)
@@ -135,7 +227,7 @@ func TestHandleListUsers_NoPasswordInResponse(t *testing.T) {
 }
 
 func TestHandleListUsers_DBError(t *testing.T) {
-	handler := handleListUsers(&mockUserLister{err: fmt.Errorf("database down")})
+	handler := handleListUsers(&mockUserPager{err: fmt.Errorf("database down")})
 	req := httptest.NewRequest("GET", "/api/v1/admin/users", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)

--- a/user_store.go
+++ b/user_store.go
@@ -31,6 +31,13 @@ type UserLister interface {
 	ListUsers(ctx context.Context) ([]UserResponse, error)
 }
 
+// UserPager lists users one page at a time, for the paginated admin user
+// list and the users API endpoint. UserLister.ListUsers stays the call for
+// anything that needs every user in one go.
+type UserPager interface {
+	ListUsersPage(ctx context.Context, limit, offset int32) ([]UserResponse, error)
+}
+
 type UserGetter interface {
 	GetUser(ctx context.Context, id int64) (*UserResponse, error)
 }
@@ -65,6 +72,8 @@ type UserRoleCounter interface {
 	CountActiveUsersByRole(ctx context.Context, role string) (int, error)
 }
 
+// ListUsers returns users newest-first, capped at the query's 1000-row
+// safety bound. Callers that page through the list use ListUsersPage.
 func (s *Store) ListUsers(ctx context.Context) ([]UserResponse, error) {
 	rows, err := s.queries.ListUsers(ctx)
 	if err != nil {
@@ -85,6 +94,30 @@ func (s *Store) ListUsers(ctx context.Context) ([]UserResponse, error) {
 	}
 	return users, nil
 }
+
+// ListUsersPage returns one page of users in the same order as ListUsers.
+func (s *Store) ListUsersPage(ctx context.Context, limit, offset int32) ([]UserResponse, error) {
+	rows, err := s.queries.ListUsersPage(ctx, db.ListUsersPageParams{Limit: limit, Offset: offset})
+	if err != nil {
+		return nil, fmt.Errorf("list users page: %w", err)
+	}
+
+	users := make([]UserResponse, 0, len(rows))
+	for _, row := range rows {
+		users = append(users, UserResponse{
+			ID:        row.ID,
+			Name:      row.Name,
+			Email:     row.Email,
+			Role:      row.Role,
+			Active:    row.Active,
+			CreatedAt: row.CreatedAt.Time,
+			UpdatedAt: row.UpdatedAt.Time,
+		})
+	}
+	return users, nil
+}
+
+var _ UserPager = (*Store)(nil)
 
 func (s *Store) GetUser(ctx context.Context, id int64) (*UserResponse, error) {
 	row, err := s.queries.GetUserByID(ctx, id)

--- a/web/templates/layout/pagination.html
+++ b/web/templates/layout/pagination.html
@@ -1,0 +1,17 @@
+{{define "pagination"}}
+{{if or (gt .PageNum 1) .HasMore}}
+<div class="flex items-center justify-between border-t border-slate-200/60 px-5 py-4 text-xs font-semibold text-slate-500">
+  <div>
+    {{if gt .PageNum 1}}
+    <a href="{{.PrevURL}}" class="text-sky-600 hover:text-sky-800">&larr; Previous</a>
+    {{end}}
+  </div>
+  <div>Page {{.PageNum}}</div>
+  <div>
+    {{if .HasMore}}
+    <a href="{{.NextURL}}" class="text-sky-600 hover:text-sky-800">Next &rarr;</a>
+    {{end}}
+  </div>
+</div>
+{{end}}
+{{end}}

--- a/web/templates/views/trips.html
+++ b/web/templates/views/trips.html
@@ -72,21 +72,7 @@
         </tbody>
       </table>
     </div>
-    {{if or (gt .PageNum 1) .HasMore}}
-    <div class="flex items-center justify-between border-t border-slate-200/60 px-5 py-4 text-xs font-semibold text-slate-500">
-      <div>
-        {{if gt .PageNum 1}}
-        <a href="{{.PrevURL}}" class="text-sky-600 hover:text-sky-800">&larr; Previous</a>
-        {{end}}
-      </div>
-      <div>Page {{.PageNum}}</div>
-      <div>
-        {{if .HasMore}}
-        <a href="{{.NextURL}}" class="text-sky-600 hover:text-sky-800">Next &rarr;</a>
-        {{end}}
-      </div>
-    </div>
-    {{end}}
+    {{template "pagination" .}}
   </div>
 </div>
 {{end}}

--- a/web/templates/views/users.html
+++ b/web/templates/views/users.html
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-between border-b border-slate-200/60 px-5 py-4">
       <div>
         <h3 class="display-font text-lg font-bold text-slate-900">All Users</h3>
-        <p class="mt-0.5 text-xs text-slate-400">{{len .Users}} accounts</p>
+        <p class="mt-0.5 text-xs text-slate-400">{{len .Users}} accounts on this page</p>
       </div>
       <a href="/admin/users/new" class="inline-flex items-center justify-center rounded-2xl bg-ink px-4 py-2 text-xs font-semibold text-white transition hover:bg-slate-800">New user</a>
     </div>
@@ -69,6 +69,7 @@
         </tbody>
       </table>
     </div>
+    {{template "pagination" .}}
   </div>
 </div>
 {{end}}

--- a/web/templates/views/vehicles.html
+++ b/web/templates/views/vehicles.html
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-between border-b border-slate-200/60 px-5 py-4">
       <div>
         <h3 class="display-font text-lg font-bold text-slate-900">All Vehicles</h3>
-        <p class="mt-0.5 text-xs text-slate-400">{{len .Vehicles}} {{if .IncludeInactive}}shown{{else}}active{{end}} in fleet</p>
+        <p class="mt-0.5 text-xs text-slate-400">{{len .Vehicles}} {{if .IncludeInactive}}shown{{else}}active{{end}} on this page</p>
       </div>
       <div class="flex items-center gap-3">
         {{if .IncludeInactive}}
@@ -74,6 +74,7 @@
         </tbody>
       </table>
     </div>
+    {{template "pagination" .}}
   </div>
 </div>
 {{end}}


### PR DESCRIPTION

### Summary
`ListVehicles` and `ListUsers` (`db/query.sql:17,54`) have no `LIMIT` — the full table, marshalled to JSON, on every request. Every `:many` query added since `ListVehiclesByUser` carries `LIMIT 1000` under a `-- safety bound; not pagination` comment; these two predate that convention. Separately, #92 built pagination for `/admin/trips` (`tripsPageSize`, `HasMore` via `limit+1`, `tripsPageURL`), and `/admin/vehicles` and `/admin/users` never got it.
This adds the safety bound to both queries, adds paged variants, wires `limit`/`offset` into both JSON endpoints, and paginates both admin pages using #92's helpers.
### Approach: added methods, not changed signatures
Four call sites legitimately need the whole list — the dashboard's vehicle-label map (`admin_page_handlers.go:305`), the assignment dropdown (`:841`), the trips filter dropdown (`:1233`), and the live map (`admin_live_handlers.go:47`). Forcing `limit`/`offset` onto `ListVehicles` would silently truncate all four, with no natural test to catch it.
So `ListVehicles`/`ListUsers` keep their signature and gain a safety bound, and the paginating callers use new `ListVehiclesPage`/`ListUsersPage` behind narrow `VehiclePager`/`UserPager` interfaces. The existing `TestStore_ListVehicles`/`TestStore_ListUsers` pass unchanged, which is the proof the signatures held. No existing test fake needed a rewrite.
Manually verified with 200 vehicles and 200 users seeded: a vehicle that sits on page 4 of the paginated admin list still resolves its label on the dashboard and in `/api/v1/admin/vehicles/live`.
### Compatibility
**Both endpoints keep their bare-array response.** Wrapping them with `has_more` — which is what `location_history_handlers.go` and `handleListTrips` both do, so the bare array is the outlier here, not the convention — would break existing consumers and #81's documented schema. I chose compatibility over consistency deliberately, and `TestHandleListVehicles_StillReturnsBareArray` (plus the users equivalent) pins that choice so it can't be undone by accident. Happy to do the wrap as a follow-up if breaking the shape is acceptable.
Both endpoints previously returned every row and now default to 50, so a client that read the whole table in one call now needs `?limit=`/`?offset=`. That is the intended change, but it is a behaviour change worth calling out.
### Behaviour changes worth calling out
- `/admin/vehicles` rows are now ordered newest-first (the store's order) instead of being sorted by id within the page. Sorting a single page by id would make the page boundaries look arbitrary, since the slices themselves are cut in `created_at` order.
- `ListVehicles`/`ListUsers` now truncate at 1000 rows. That is the point of a safety bound, and it matches the three existing bounded queries, but the dashboard, dropdowns and live map will stop at 1000 rows on a fleet that large.
- The `include_inactive` filter moved from Go into SQL (`ListActiveVehiclesPage`). Filtering after the fetch would have shrunk a page below the page size as deactivated rows were dropped; filtering in SQL keeps every page a full page.
- `?limit=`/`?offset=` are bounded at 1–200 and 0–2147483647, matching `maxTripListLimit`. The offset ceiling exists because the paged queries take an `int32` offset; without it a larger value wraps negative and Postgres turns a bad request into a 500.
### Shared pagination vocabulary
`tripsPageSize`/`maxTripsPage` are now `adminPageSize`/`maxAdminPage`, and the `?page=` parsing all three pages need is `adminPageNumber`. Three list pages with the same page size shouldn't carry three copies of the same constant. The prev/next markup moved to `web/templates/layout/pagination.html` and is shared by all three views. Trips' rendered behaviour is unchanged.
The JSON endpoints define their own `defaultListLimit`/`maxListLimit` mirroring `defaultTripListLimit`/`maxTripListLimit`; `handleListTrips` keeps its own copy of the parsing rather than putting an unrelated handler in this diff. Folding it into `parseListPageParams` is a clean follow-up.
### Not included
- **No migration.** This PR needs none.
- The users page's per-user assignment lookup is an N+1, but `admin_page_handlers.go:615-619` documents it as an intentional tradeoff at admin scale, and I have no evidence the scale assumption changed. Left alone. Paginating the page bounds it as a side effect — from once per user in the table to at most `adminPageSize` per request — and `TestUsersPage_AssignmentQueriesBoundedByPageSize` pins that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pagination to admin vehicle, user, and trip lists, with Previous/Next navigation.
  - Added pagination support to vehicle and user API list responses using `limit` and `offset` parameters.
  - Added filtering for inactive vehicles while paging.
  - Added safeguards against excessively large list requests and clearer current-page counts.

- **Bug Fixes**
  - Improved list ordering for consistent results across pages.
  - Invalid pagination parameters are now rejected with an appropriate error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->