### PR TITLE
docs: production deployment guide and operator manual; fix the Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: Build Docker image
+        run: docker build -t vehicle-positions:ci .
+
       - name: Verify committed Tailwind CSS is current
         if: runner.os == 'Linux'
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN go mod download
 COPY migrations ./migrations
 COPY db ./db
 COPY web ./web
+COPY rider ./rider
 COPY *.go ./
 RUN CGO_ENABLED=0 go build -o /vehicle-positions .
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Quick-start instructions for running the server locally with Docker Compose,
 plus API sanity checks and troubleshooting, live in
 [`docs/development.md`](docs/development.md).
 
+For production — Postgres, reverse proxy and TLS, systemd, backups, monitoring
+and APK distribution — see [`docs/deployment.md`](docs/deployment.md).
+
 ### Admin web UI
 
 The server also ships a server-rendered admin web UI at `/admin` — sign in,

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ of location history), user CRUD, vehicle assignments, and trip history. It's
 built into the same binary and enabled by default; set
 `ADMIN_UI_ENABLED=false` to disable it entirely (the route returns 404).
 
+Day-to-day instructions for operators — onboarding drivers, managing vehicles,
+watching the feed — are in [`docs/operator-manual.md`](docs/operator-manual.md).
+
 **Note for operators upgrading from an earlier version:** the admin UI used to
 not exist, so there's nothing to opt into — this is a new default-on surface.
 If you don't want it exposed, set `ADMIN_UI_ENABLED=false` before deploying.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ unparseable value logs and falls back to its default.
 | `RIDER_MODE_ENABLED` | `false` | Enable rider routes, engine and feed merge. |
 | `GTFS_STATIC_URL` | — (required when enabled; exit 1 if missing) | GTFS zip URL or path. |
 | `GTFS_STATIC_REFRESH` | `24h` | Re-download and rebuild the index. Failure keeps the old index and logs. |
-| `TRUSTED_GTFS_RT_URLS` | empty | Comma-separated external VehiclePositions feed URLs. The server's own driver-reported positions are always a trusted source; with no external feed, a trip no driver is reporting has corroboration `unavailable`. |
+| `TRUSTED_GTFS_RT_URLS` | empty | Comma-separated external VehiclePositions feed URLs. The server's own driver-reported positions are always a trusted source when the driver entered the GTFS trip id (matching is by trip id, so a route-only driver report doesn't count); with no external feed, a trip no driver is reporting that way has corroboration `unavailable`. |
 | `TRUSTED_FEED_POLL` | `30s` | Poll interval; sends `If-None-Match` / `If-Modified-Since` when the server gave `ETag` / `Last-Modified`. |
 | `TRUSTED_FEED_MAX_AGE` | `5m` | Trusted entities older than this are dropped from the snapshot. |
 | `RIDER_JWT_TTL` | `8760h` | Rider token lifetime. |
@@ -126,7 +126,9 @@ distinguishable by construction: their id — and their `vehicle.id`, so that tw
 service dates of one trip are two vehicles — is `rider:<trip_id>:<start_date>`,
 and their vehicle label is `Rider-reported`. A rider-reported position is always
 snapped to the route shape, never a raw GPS fix, and a trip the trusted feed
-already reports is never published from rider data.
+already reports is never published from rider data — for the server's own
+driver reports, that requires the driver to have entered the GTFS trip id, not
+just a route.
 
 The iOS SDK that talks to this API lives in `ios/VehiclePositionsKit`. For the
 full design — verification rules, ride state machine, reputation tiers and

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -115,8 +115,11 @@ disabled. Turn it on only if you intend to accept positions from riders' phones.
 | `RIDER_POINT_MAX_AGE` | `90s` | A ride whose latest accepted point is older than this stops contributing to the feed. |
 | `RIDER_POINT_RETENTION` | `168h` | `ride_points` rows older than this are deleted hourly. |
 
-Every rider-mode value above must be positive; a zero or negative one is
-rejected with a warning and the default is used. The README's
+Every rider-mode value above except `RIDER_SCHEDULE_EARLY` and
+`RIDER_SCHEDULE_LATE` must be positive: a zero or negative one is rejected with
+a warning and the default is used instead. The two schedule windows are taken as
+given, so setting either to `0s` narrows the adherence window rather than
+falling back. The README's
 [Rider mode](../README.md#rider-mode-crowdsourced-positions) section documents
 the API and the verification model.
 
@@ -139,6 +142,11 @@ The `Dockerfile` is multi-stage (`golang:1.25-alpine` builds a static binary,
 `alpine:3.21` runs it), exposes port 8080, and has `vehicle-positions` as its
 entrypoint. Tagging with the commit SHA rather than `latest` is what makes a
 rollback possible: you can always start the previous tag again.
+
+The repository's development `docker-compose.yml` builds this same image through
+its `build: .` line, which is why the production file below refers to a tag you
+built yourself instead: an explicit tag is what lets you roll back to the
+previous build, and it keeps the image pinned when you edit the compose file.
 
 ### 4.2 The environment file
 
@@ -383,16 +391,25 @@ Take a compressed custom-format dump; it restores selectively and compresses
 well.
 
 ```bash
+# pg_dump runs as the postgres user, so the directory must be writable by it.
 sudo mkdir -p /var/backups/vehicle-positions
+sudo chown postgres:postgres /var/backups/vehicle-positions
+sudo chmod 0700 /var/backups/vehicle-positions
+
 sudo -u postgres pg_dump -Fc vehicle_positions \
   -f /var/backups/vehicle-positions/vehicle_positions-$(date +%F).dump
 ```
 
-For the Docker Compose deployment, run it inside the database container:
+For the Docker Compose deployment, run `pg_dump` inside the database container
+and pipe the result out. The dump goes to stdout here, and the `>` of a plain
+redirect would be opened by your own shell before `sudo` ever runs — so write
+the file through `sudo tee` (or back it up somewhere your user can already
+write):
 
 ```bash
+sudo mkdir -p /var/backups/vehicle-positions
 docker compose exec -T db pg_dump -U vehicle_positions -Fc vehicle_positions \
-  > /var/backups/vehicle-positions/vehicle_positions-$(date +%F).dump
+  | sudo tee /var/backups/vehicle-positions/vehicle_positions-$(date +%F).dump >/dev/null
 ```
 
 Automate it with a systemd timer. Two files:
@@ -424,7 +441,7 @@ WantedBy=timers.target
 ```
 
 ```bash
-sudo chown postgres:postgres /var/backups/vehicle-positions
+# The unit runs as postgres, into the directory you chowned above.
 sudo systemctl daemon-reload
 sudo systemctl enable --now vehicle-positions-backup.timer
 sudo systemctl start vehicle-positions-backup.service   # prove it works now
@@ -615,8 +632,19 @@ docker compose logs -f server                      # option A
 Every request logs `{"msg":"request","method":...,"path":...,"status":...,"duration_ms":...}`.
 Startup logs `starting server` with the port, `seeded tracker` with the count of
 vehicles restored from the database, and `location retention enabled` when
-retention is on. Because the format is JSON, `journalctl -u vehicle-positions -o cat | jq
-'select(.level=="ERROR")'` is a usable triage command.
+retention is on. Because the format is JSON, this is a usable triage command:
+
+```bash
+sudo journalctl -u vehicle-positions -o cat \
+  | jq 'select(.level=="ERROR" or .level=="WARN")'
+```
+
+Watch both levels, not just `ERROR`. Several failures that matter are logged at
+`WARN`: `readiness check failed` (the database did not answer),
+`failed to seed tracker from database` (the feed started empty after a restart),
+`rider: GTFS refresh failed, keeping the previous index` and
+`rider: trusted feed poll failed, keeping the previous vehicles` (rider mode is
+running on stale data). `location retention prune failed` is logged at `ERROR`.
 
 ### What to alert on
 
@@ -626,8 +654,10 @@ retention is on. Because the format is JSON, `journalctl -u vehicle-positions -o
   the failure that no process-level check catches: the server is healthy, the
   feed is just empty because no phone is reporting.
 - `last_update` older than your `STALENESS_THRESHOLD` during service hours.
-- Log lines at `ERROR`, particularly `location retention prune failed` and
-  `readiness check failed`.
+- Log lines at `ERROR` or `WARN` — `location retention prune failed` is an
+  `ERROR`, while `readiness check failed` is a `WARN`. If you would rather not
+  alert on log levels at all, key the database alert off the `/ready` probe
+  above; it covers the same failure and is easier to reason about.
 - Certificate expiry, if you are not relying on certbot's own renewal timer.
 
 ## 10. Upgrading

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,834 @@
+# Production Deployment Guide
+
+## 1. Who this is for, and what you get
+
+This guide is for the person who will run the Vehicle Tracker for a transit
+agency: an IT administrator or a technically inclined operations manager. It
+assumes you can use a Linux shell and `sudo`, and that you have never seen this
+codebase before. For running the project on a laptop while developing it, read
+[`development.md`](development.md) instead.
+
+What you are deploying is one Go binary plus one PostgreSQL database. The
+binary ingests location reports from the Android driver app, keeps the current
+position of every active vehicle in memory, and publishes a standard GTFS
+Realtime **Vehicle Positions** feed at `GET /gtfs-rt/vehicle-positions`. The
+same binary serves a browser admin UI at `/admin` (sign-in, dashboard, live
+fleet map, vehicle and user management, trip history) and a JSON API under
+`/api/v1/`. Database migrations and the admin UI's templates and CSS are
+compiled into the binary, so there is nothing else to install or copy to the
+server.
+
+Run **one** instance of the server against a database. Current vehicle
+positions, rider-mode sessions and the rate limiters all live in the process's
+memory, so a second instance would answer with a different view of the fleet.
+On startup the server reloads recent positions from the database
+(`GetRecentLocations`), so a restart is not a data loss event — it just costs a
+few seconds of feed continuity.
+
+## 2. Sizing and prerequisites
+
+| Requirement | What you need |
+|---|---|
+| Host | A Linux server with a public IP. 1 vCPU and 1 GB RAM comfortably serves a fleet of tens of vehicles; the process holds one small record per active vehicle in memory. |
+| Disk | Sized for `location_points`, the only table that grows quickly. Fifty vehicles reporting every 10 seconds over a 16-hour service day is roughly 105 million rows a year (see the README's [Data Retention & Privacy](../README.md#31-server-go) notes). Turn on retention (section 6) and this stops mattering. |
+| PostgreSQL | 15 or newer. The project's own stack runs `postgres:17-alpine` (`docker-compose.yml`), so 17 is the best-tested choice for a new install. It may run on the same host or a managed service. |
+| DNS + TLS | A hostname (`tracker.example.org` throughout this guide) pointing at the host, and a certificate. Section 7 uses Let's Encrypt. |
+| Build tooling | Either Docker (option A) **or** Go 1.25 or newer (option B, `go.mod` declares `go 1.25.0`). There is no published container image — agencies build from this repository. |
+| Ports | 80 and 443 open to the internet. Port 8080 (the app) and 5432 (PostgreSQL) must **not** be reachable from the internet. |
+
+The GTFS-RT feed endpoint is unauthenticated: anyone who can reach the server
+can read the current positions of your fleet. That is normally what you want (a
+public realtime feed), but it means the reverse proxy is the only thing between
+the world and everything else the binary serves, so do not skip section 7.
+
+## 3. Configuration reference
+
+Every setting is an environment variable. There is no configuration file.
+
+Rules that apply to the whole table:
+
+- Durations use Go's `time.ParseDuration` syntax: `30s`, `5m`, `24h`, `2160h`.
+  There is no "days" unit.
+- An unset or empty variable takes the default. A value that cannot be parsed
+  is **ignored**, logged as a warning, and the default is used instead — so
+  check the logs after a change rather than assuming it took effect.
+- Booleans accept anything Go's `strconv.ParseBool` accepts: `true`, `false`,
+  `1`, `0`, `t`, `f`, `TRUE`, `FALSE`.
+
+### Core
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PORT` | `8080` | TCP port the HTTP server listens on. It binds every interface; there is no loopback-only mode, so keep the port off the internet with a firewall or a Docker port binding (sections 4, 5 and 7). |
+| `DATABASE_URL` | `postgres://postgres:postgres@localhost:5432/vehicle_positions?sslmode=disable` | PostgreSQL connection string. The default is a development convenience — always set it explicitly in production. |
+| `JWT_SECRET` | — (required) | HMAC-SHA256 key that signs every driver, admin and rider token. The server logs an error and exits 1 if it is unset or shorter than 32 bytes. Generate with `openssl rand -hex 32`. |
+| `STALENESS_THRESHOLD` | `5m` | How long a vehicle stays in the feed after its last report, and the window used to reseed the tracker at startup. Must be positive — a value of `0s` crashes the server at startup. |
+| `READ_TIMEOUT` | `15s` | HTTP server read timeout. |
+| `WRITE_TIMEOUT` | `15s` | HTTP server write timeout. |
+| `IDLE_TIMEOUT` | `60s` | HTTP keep-alive idle timeout. |
+
+### Admin UI and proxying
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ADMIN_UI_ENABLED` | `true` | Serves the browser admin UI at `/admin`. Set to `false` to run the JSON API only; the `/admin` routes then return 404. **This is on by default**, so decide before you expose the host. |
+| `ADMIN_BOOTSTRAP_EMAIL` | unset | Email of the first admin account. Takes effect only when `ADMIN_BOOTSTRAP_PASSWORD` is also set. |
+| `ADMIN_BOOTSTRAP_PASSWORD` | unset | Password for that account, 8 characters minimum. The account is created only when the `users` table holds zero admins, so the pair is a no-op on every later boot. On that first boot, a password shorter than 8 characters aborts startup rather than creating a weak account. |
+| `TRUST_PROXY_HEADERS` | `false` | Read the client IP from the last `X-Forwarded-For` hop and the scheme from `X-Forwarded-Proto`. Set to `true` **only** behind a reverse proxy you control (section 7). |
+
+See the README's [Admin web UI](../README.md#admin-web-ui) section for the
+sign-in behaviour, including the one limitation worth knowing up front:
+deactivating a user or changing their password blocks new logins immediately
+but does not revoke tokens already issued — those stay valid for up to 24
+hours.
+
+### Location retention (driver data)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `LOCATION_RETENTION_PERIOD` | `0` | How long to keep rows in `location_points`, measured from server receipt time. `0` (the default) keeps them forever. |
+| `LOCATION_PRUNE_INTERVAL` | `1h` | How often the pruner sweeps. The first sweep runs one full interval after startup, not at boot. |
+| `LOCATION_PRUNE_BATCH_SIZE` | `10000` | Rows deleted per statement, each batch in its own transaction, so a large backlog does not stall location ingest. |
+
+Deletion is permanent — there is no archive step. The README's
+[retention notes](../README.md#31-server-go) cover the privacy reasoning and
+the operator caveats in full.
+
+### Rider mode (crowdsourced positions)
+
+Rider mode is off by default and adds nothing to the driver-reported feed when
+disabled. Turn it on only if you intend to accept positions from riders' phones.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RIDER_MODE_ENABLED` | `false` | Enable the rider routes, verification engine and feed merge. |
+| `GTFS_STATIC_URL` | — (required when rider mode is on) | GTFS static zip, as an `http(s)://` URL or a local file path. The server exits 1 if rider mode is enabled without one. |
+| `GTFS_STATIC_REFRESH` | `24h` | How often the schedule is re-downloaded. A failed refresh keeps the previous index and logs. |
+| `TRUSTED_GTFS_RT_URLS` | empty | Comma-separated external VehiclePositions feeds used to corroborate riders. This server's own driver-reported positions are always trusted, so this is optional. |
+| `TRUSTED_FEED_POLL` | `30s` | Poll interval for those feeds. |
+| `TRUSTED_FEED_MAX_AGE` | `5m` | Trusted entities older than this are dropped. |
+| `RIDER_JWT_TTL` | `8760h` | Lifetime of an anonymous rider token (one year). |
+| `RIDER_MAX_SHAPE_DISTANCE` | `60` | Metres from the route shape (plus the fix's reported accuracy) for a point to match. |
+| `RIDER_MAX_SPEED` | `35` | Metres per second; a higher implied along-shape speed is treated as implausible. |
+| `RIDER_SCHEDULE_EARLY` | `15m` | How early a trip may be running and still match. |
+| `RIDER_SCHEDULE_LATE` | `90m` | How late a trip may be running and still match. |
+| `RIDER_POINT_MAX_AGE` | `90s` | A ride whose latest accepted point is older than this stops contributing to the feed. |
+| `RIDER_POINT_RETENTION` | `168h` | `ride_points` rows older than this are deleted hourly. |
+
+Every rider-mode value above must be positive; a zero or negative one is
+rejected with a warning and the default is used. The README's
+[Rider mode](../README.md#rider-mode-crowdsourced-positions) section documents
+the API and the verification model.
+
+## 4. Option A — Docker Compose on one host
+
+The `docker-compose.yml` in the repository root is the **development** stack: it
+publishes PostgreSQL on port 5432 and uses the password `postgres`. Do not
+deploy it as-is. Build an image from the repository and run the file below
+instead.
+
+### 4.1 Build a pinned image
+
+```bash
+git clone https://github.com/OneBusAway/vehicle-positions.git
+cd vehicle-positions
+docker build -t vehicle-positions:$(git rev-parse --short HEAD) .
+```
+
+The `Dockerfile` is multi-stage (`golang:1.25-alpine` builds a static binary,
+`alpine:3.21` runs it), exposes port 8080, and has `vehicle-positions` as its
+entrypoint. Tagging with the commit SHA rather than `latest` is what makes a
+rollback possible: you can always start the previous tag again.
+
+### 4.2 The environment file
+
+```bash
+mkdir -p /srv/vehicle-positions
+cd /srv/vehicle-positions
+umask 077
+cat > .env <<EOF
+JWT_SECRET=$(openssl rand -hex 32)
+POSTGRES_PASSWORD=$(openssl rand -hex 24)
+ADMIN_BOOTSTRAP_EMAIL=ops@example.org
+ADMIN_BOOTSTRAP_PASSWORD=$(openssl rand -hex 12)
+EOF
+chmod 600 .env
+cat .env   # copy the bootstrap password somewhere safe, you need it once
+```
+
+`chmod 600` matters: `JWT_SECRET` is the key that signs admin tokens, so anyone
+who can read this file can mint an administrator session for your server.
+
+### 4.3 `compose.yaml`
+
+Save this next to the `.env` file as `/srv/vehicle-positions/compose.yaml`,
+replacing `<SHA>` with the tag you built.
+
+```yaml
+services:
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: vehicle_positions
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: vehicle_positions
+    # No `ports:` on purpose. The database is reachable from the server
+    # container over the compose network and from nowhere else.
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U vehicle_positions"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  server:
+    image: vehicle-positions:<SHA>
+    restart: unless-stopped
+    # Bound to loopback: nginx on the host reaches it, the internet does not.
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      PORT: "8080"
+      DATABASE_URL: "postgres://vehicle_positions:${POSTGRES_PASSWORD}@db:5432/vehicle_positions?sslmode=disable"
+      JWT_SECRET: "${JWT_SECRET:?JWT_SECRET must be set; the server requires 32+ bytes}"
+      STALENESS_THRESHOLD: "5m"
+      TRUST_PROXY_HEADERS: "true"
+      ADMIN_UI_ENABLED: "true"
+      LOCATION_RETENTION_PERIOD: "2160h"
+      LOCATION_PRUNE_INTERVAL: "1h"
+      # First boot only. Delete these two lines and re-run `docker compose up -d`
+      # once you have signed in and confirmed the account works.
+      ADMIN_BOOTSTRAP_EMAIL: "${ADMIN_BOOTSTRAP_EMAIL}"
+      ADMIN_BOOTSTRAP_PASSWORD: "${ADMIN_BOOTSTRAP_PASSWORD}"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  pgdata:
+```
+
+Start it:
+
+```bash
+docker compose up -d
+docker compose logs -f server
+```
+
+The server creates its schema on the first boot, so there is no migration step
+to run. `TRUST_PROXY_HEADERS: "true"` is correct here only because section 7
+puts nginx in front; if you have not done that yet, leave it `"false"`.
+
+### 4.4 After the first sign-in
+
+Remove `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` from
+`compose.yaml` and the matching lines from `.env`, then `docker compose up -d`
+to apply. They are harmless if left (the bootstrap is skipped once an admin
+exists) but they keep a working admin password in plain text on disk for no
+further benefit.
+
+## 5. Option B — systemd and a native binary
+
+Use this when you already run PostgreSQL on the host and would rather not add
+Docker.
+
+### 5.1 Build and install the binary
+
+```bash
+git clone https://github.com/OneBusAway/vehicle-positions.git
+cd vehicle-positions
+CGO_ENABLED=0 go build -o vehicle-positions .
+sudo install -o root -g root -m 0755 vehicle-positions /usr/local/bin/vehicle-positions
+/usr/local/bin/vehicle-positions --help 2>/dev/null; echo "installed"
+```
+
+The binary embeds the migrations, HTML templates and CSS, so this single file is
+the entire application. You can build it on a build host and copy it to the
+server, as long as both are the same OS and architecture.
+
+### 5.2 Create the service account
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin vehicle-positions
+```
+
+### 5.3 The environment file
+
+```bash
+sudo touch /etc/vehicle-positions.env
+sudo chown root:vehicle-positions /etc/vehicle-positions.env
+sudo chmod 0640 /etc/vehicle-positions.env
+sudo tee /etc/vehicle-positions.env >/dev/null <<'EOF'
+PORT=8080
+DATABASE_URL=postgres://vehicle_positions:CHANGE_ME@127.0.0.1:5432/vehicle_positions?sslmode=disable
+JWT_SECRET=CHANGE_ME
+STALENESS_THRESHOLD=5m
+TRUST_PROXY_HEADERS=true
+ADMIN_UI_ENABLED=true
+LOCATION_RETENTION_PERIOD=2160h
+LOCATION_PRUNE_INTERVAL=1h
+# First boot only — delete both lines after you have signed in.
+ADMIN_BOOTSTRAP_EMAIL=ops@example.org
+ADMIN_BOOTSTRAP_PASSWORD=CHANGE_ME
+EOF
+```
+
+Then replace each `CHANGE_ME` (`openssl rand -hex 32` for `JWT_SECRET`). Two
+things to know about this file:
+
+- systemd's `EnvironmentFile` is **not** a shell script. Write
+  `JWT_SECRET=abc123`, not `export JWT_SECRET=...`, and do not expect
+  `$(openssl rand -hex 32)` to be evaluated — paste the generated value in.
+- `0640 root:vehicle-positions` keeps it readable by the service and root only.
+  It holds both the database password and the token-signing key.
+
+### 5.4 The unit file
+
+```ini
+# /etc/systemd/system/vehicle-positions.service
+[Unit]
+Description=OneBusAway Vehicle Tracker
+Documentation=https://github.com/OneBusAway/vehicle-positions
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=vehicle-positions
+Group=vehicle-positions
+EnvironmentFile=/etc/vehicle-positions.env
+ExecStart=/usr/local/bin/vehicle-positions
+Restart=on-failure
+RestartSec=5s
+KillSignal=SIGTERM
+# The server drains in-flight requests for up to 10s on SIGTERM.
+TimeoutStopSec=30s
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+LockPersonality=yes
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`ProtectSystem=strict` makes the whole filesystem read-only for this service.
+That is fine because the server writes nothing to disk — it logs to stdout and
+stores everything else in PostgreSQL. If you enable rider mode with a *local*
+GTFS zip, give `GTFS_STATIC_URL` an absolute path to a file the service can
+read; a URL needs no filesystem access at all.
+
+`After=postgresql.service` only orders startup when PostgreSQL runs on this
+same host. If the database is remote, drop it — the server exits 1 when it
+cannot reach the database, and `Restart=on-failure` will retry every 5 seconds
+until it can.
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now vehicle-positions
+sudo systemctl status vehicle-positions
+sudo journalctl -u vehicle-positions -f
+```
+
+### 5.5 Keep port 8080 private
+
+The server binds every interface. With no reverse proxy in front of it, that
+means the admin UI is on the internet over plain HTTP. Block the port at the
+firewall and let nginx reach it over loopback:
+
+```bash
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw deny 8080/tcp
+sudo ufw enable
+```
+
+## 6. Database
+
+### 6.1 Create the role and database
+
+For option B (option A's compose file does this for you):
+
+```bash
+sudo -u postgres createuser --pwprompt vehicle_positions
+sudo -u postgres createdb --owner vehicle_positions vehicle_positions
+```
+
+Put the password you chose into `DATABASE_URL`. Use `sslmode=disable` only for
+a database on the same host reached over loopback; for a database on another
+machine use `sslmode=require`, or `sslmode=verify-full` with a CA you trust.
+
+### 6.2 Migrations
+
+There is no separate migration command and no `migrate` subcommand. The server
+runs every pending migration itself at startup, from a copy of `migrations/`
+compiled into the binary, before it starts listening. A failed migration is a
+startup failure: the process logs `could not run migrations` and exits 1
+without serving traffic. This means a deploy is just "restart the new binary",
+and it also means you should take a backup before upgrading (section 10).
+
+### 6.3 Backups
+
+Take a compressed custom-format dump; it restores selectively and compresses
+well.
+
+```bash
+sudo mkdir -p /var/backups/vehicle-positions
+sudo -u postgres pg_dump -Fc vehicle_positions \
+  -f /var/backups/vehicle-positions/vehicle_positions-$(date +%F).dump
+```
+
+For the Docker Compose deployment, run it inside the database container:
+
+```bash
+docker compose exec -T db pg_dump -U vehicle_positions -Fc vehicle_positions \
+  > /var/backups/vehicle-positions/vehicle_positions-$(date +%F).dump
+```
+
+Automate it with a systemd timer. Two files:
+
+```ini
+# /etc/systemd/system/vehicle-positions-backup.service
+[Unit]
+Description=Back up the vehicle-positions database
+After=postgresql.service
+
+[Service]
+Type=oneshot
+User=postgres
+ExecStart=/bin/sh -c 'pg_dump -Fc vehicle_positions -f /var/backups/vehicle-positions/vehicle_positions-$(date +%%F).dump'
+ExecStartPost=/usr/bin/find /var/backups/vehicle-positions -name "vehicle_positions-*.dump" -mtime +30 -delete
+```
+
+```ini
+# /etc/systemd/system/vehicle-positions-backup.timer
+[Unit]
+Description=Nightly vehicle-positions database backup
+
+[Timer]
+OnCalendar=*-*-* 02:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+```bash
+sudo chown postgres:postgres /var/backups/vehicle-positions
+sudo systemctl daemon-reload
+sudo systemctl enable --now vehicle-positions-backup.timer
+sudo systemctl start vehicle-positions-backup.service   # prove it works now
+```
+
+`%%F` is doubled because systemd itself uses `%` for specifiers. Copy the dumps
+off the host — a backup on the same disk as the database is not a backup.
+
+### 6.4 Restore
+
+Stop the server first so nothing writes while the schema is being replaced.
+
+```bash
+sudo systemctl stop vehicle-positions          # or: docker compose stop server
+sudo -u postgres pg_restore --clean --if-exists \
+  -d vehicle_positions /var/backups/vehicle-positions/vehicle_positions-2026-09-01.dump
+sudo systemctl start vehicle-positions         # or: docker compose start server
+```
+
+### 6.5 Retention
+
+`location_points` is a per-driver GPS trace and the fastest-growing table in the
+system, so decide how long you intend to keep it before you go live. A good
+starting point is 90 days, swept hourly:
+
+```
+LOCATION_RETENTION_PERIOD=2160h
+LOCATION_PRUNE_INTERVAL=1h
+```
+
+Retention is off by default, deletion is permanent, and the period is measured
+from when the server received the point rather than the timestamp the phone
+reported — the README's [retention notes](../README.md#31-server-go) explain
+each of those and the privacy reasoning behind them. Pick a period consistent
+with local law and your agency's driver-privacy policy, and export anything you
+want to keep before you turn it on.
+
+## 7. Reverse proxy and TLS
+
+Terminate TLS in nginx and forward to the server on loopback.
+
+### 7.1 Get a certificate
+
+```bash
+sudo apt install nginx certbot
+sudo mkdir -p /var/www/html
+sudo certbot certonly --webroot -w /var/www/html -d tracker.example.org
+```
+
+Certbot installs its own renewal timer; confirm it with
+`systemctl list-timers | grep certbot` and test with
+`sudo certbot renew --dry-run`.
+
+### 7.2 The nginx site
+
+```nginx
+# /etc/nginx/sites-available/vehicle-positions
+server {
+    listen 80;
+    listen [::]:80;
+    server_name tracker.example.org;
+
+    # Leave this reachable over HTTP so certificate renewals keep working.
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;                 # nginx 1.25.1+; older builds: `listen 443 ssl http2;`
+    server_name tracker.example.org;
+
+    ssl_certificate     /etc/letsencrypt/live/tracker.example.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/tracker.example.org/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
+    # Location reports are a few hundred bytes; the location endpoint itself
+    # caps bodies at 1 MiB. This stops oversized uploads at the proxy first.
+    client_max_body_size 2m;
+
+    access_log /var/log/nginx/vehicle-positions.access.log;
+    error_log  /var/log/nginx/vehicle-positions.error.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+}
+```
+
+```bash
+sudo ln -s /etc/nginx/sites-available/vehicle-positions /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+### 7.3 Then, and only then, set `TRUST_PROXY_HEADERS=true`
+
+With the proxy in place, set `TRUST_PROXY_HEADERS=true` and restart the server.
+It changes two things: the admin login rate limiter buckets by the real client
+IP instead of nginx's, and the admin session cookie is marked `Secure` because
+the server can now tell the request arrived over HTTPS.
+
+Leave it `false` whenever the server can be reached directly. A client can send
+any `X-Forwarded-For` it likes, so trusting the header without a proxy in front
+lets an attacker spoof their IP and escape the login rate limiter. The server
+reads the **rightmost** hop of `X-Forwarded-For`, which is exactly the value
+`$proxy_add_x_forwarded_for` appends — nginx's own observation of who connected
+— so a client-supplied header cannot displace it. The README's
+[admin UI section](../README.md#admin-web-ui) states the same rule.
+
+## 8. First boot checklist
+
+```bash
+# 1. Liveness: the process is up and serving.
+curl https://tracker.example.org/health
+# {"status":"ok"}
+
+# 2. Readiness: it can reach the database. 503 with {"status":"degraded"} if not.
+curl -i https://tracker.example.org/ready
+# HTTP/2 200 ... {"status":"ok"}
+
+# 3. The feed answers, with no vehicles yet.
+curl 'https://tracker.example.org/gtfs-rt/vehicle-positions?format=json'
+```
+
+4. Open `https://tracker.example.org/admin/login` and sign in with
+   `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD`. Change that password
+   from the admin UI once you are in.
+
+5. Remove `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` from the
+   environment file and restart. They are only read when the `users` table has
+   no admin, so keeping them buys nothing and leaves a valid password on disk.
+
+6. In the admin UI, create your first vehicle (**Vehicles → New**), then a
+   driver user (**Users → New**), then assign the vehicle to that driver from
+   the user's page. The assignment is what makes the vehicle appear in the
+   driver app's vehicle picker (`GET /api/v1/vehicles` lists a driver's active
+   assigned vehicles).
+
+7. Hand that driver's email and password to a phone running the Android app,
+   with `https://tracker.example.org` as the server URL, and watch the vehicle
+   appear on **Map**.
+
+## 9. Monitoring
+
+| Check | What it tells you |
+|---|---|
+| `GET /health` | The process is alive and serving HTTP. Always `{"status":"ok"}`; it touches nothing else. Use it as the liveness probe. |
+| `GET /ready` | The database answered a ping within 2 seconds. `200 {"status":"ok"}` or `503 {"status":"degraded"}`. Use it as the readiness probe and alert on it. |
+| `GET /api/v1/admin/status` | Requires an admin bearer token. Returns `status`, `uptime_seconds`, `active_vehicles`, `total_vehicles_tracked` and `last_update`. This is the one that tells you whether data is actually flowing. |
+| `/admin/dashboard` and `/admin/map` | The human version of the same picture: active vehicles, recent trips, live positions. |
+
+Fetching the status endpoint from a script:
+
+```bash
+TOKEN=$(curl -s -X POST https://tracker.example.org/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"ops@example.org","password":"..."}' | jq -r .token)
+
+curl -s https://tracker.example.org/api/v1/admin/status \
+  -H "Authorization: Bearer $TOKEN" | jq .
+# {"status":"ok","uptime_seconds":3600,"active_vehicles":12,...}
+```
+
+### Logs
+
+The server writes structured JSON to stdout, one object per line — under
+systemd that goes to the journal, under Compose to the container log.
+
+```bash
+sudo journalctl -u vehicle-positions -f            # option B
+docker compose logs -f server                      # option A
+```
+
+Every request logs `{"msg":"request","method":...,"path":...,"status":...,"duration_ms":...}`.
+Startup logs `starting server` with the port, `seeded tracker` with the count of
+vehicles restored from the database, and `location retention enabled` when
+retention is on. Because the format is JSON, `journalctl -u vehicle-positions -o cat | jq
+'select(.level=="ERROR")'` is a usable triage command.
+
+### What to alert on
+
+- `/ready` returning 503 for more than a minute — the database is unreachable,
+  and location reports are being lost, not queued.
+- `active_vehicles` at 0 during service hours while buses are running. This is
+  the failure that no process-level check catches: the server is healthy, the
+  feed is just empty because no phone is reporting.
+- `last_update` older than your `STALENESS_THRESHOLD` during service hours.
+- Log lines at `ERROR`, particularly `location retention prune failed` and
+  `readiness check failed`.
+- Certificate expiry, if you are not relying on certbot's own renewal timer.
+
+## 10. Upgrading
+
+Take a backup first (section 6.3); migrations run automatically and are not
+reversed automatically.
+
+Docker Compose:
+
+```bash
+cd /path/to/checkout && git pull
+docker build -t vehicle-positions:$(git rev-parse --short HEAD) .
+# edit the image tag in /srv/vehicle-positions/compose.yaml
+cd /srv/vehicle-positions && docker compose up -d
+docker compose logs -f server
+```
+
+systemd:
+
+```bash
+cd /path/to/checkout && git pull
+CGO_ENABLED=0 go build -o vehicle-positions .
+sudo install -o root -g root -m 0755 vehicle-positions /usr/local/bin/vehicle-positions
+sudo systemctl restart vehicle-positions
+sudo journalctl -u vehicle-positions -n 50
+```
+
+What a restart costs: pending migrations apply before the server listens, so a
+schema change shows up as a slightly longer startup. The in-memory tracker is
+reseeded from the database using `STALENESS_THRESHOLD`, so recently active
+vehicles reappear in the feed immediately. Rider-mode rides are held in memory
+only and do not survive a restart — every active ride is ended and filed as the
+new process starts.
+
+Read the release notes for new default-on surfaces before you upgrade. The
+admin UI is the example the README calls out: it did not exist in earlier
+versions and it is **on by default**, so an upgrade exposes `/admin` unless you
+set `ADMIN_UI_ENABLED=false` first.
+
+To roll back, start the previous image tag (Compose) or reinstall the previous
+binary (systemd). If the newer version applied a migration, restore the pre-
+upgrade dump as well.
+
+## 11. Connecting the feed to OneBusAway
+
+The feed is a standard GTFS Realtime `FeedMessage` containing
+`VehiclePosition` entities, served as protobuf:
+
+```
+https://tracker.example.org/gtfs-rt/vehicle-positions
+```
+
+Point your OneBusAway instance's vehicle-positions realtime source at that URL.
+OneBusAway consumes GTFS-RT Vehicle Positions natively — no changes to OBA are
+required, and any other GTFS-RT-compliant consumer works the same way (see the
+README's [How This Connects to OneBusAway](../README.md#8-how-this-connects-to-onebusaway)).
+
+Two query parameters help when you are checking the feed by hand:
+
+```bash
+# Human-readable JSON instead of protobuf — for eyeballing, not for OBA.
+curl 'https://tracker.example.org/gtfs-rt/vehicle-positions?format=json' | jq .
+
+# Pick one half of the feed: driver, rider, or all (the default).
+curl 'https://tracker.example.org/gtfs-rt/vehicle-positions?format=json&source=driver' | jq '.entity | length'
+```
+
+`source` accepts exactly `driver`, `rider` and `all`; anything else returns
+`400 {"error":"invalid source"}`. With rider mode off, `driver` and `all` are
+identical. Rider-derived entities are always distinguishable: their id is
+`rider:<trip_id>:<start_date>` and their vehicle label is `Rider-reported`, so
+you can feed OBA `?source=driver` if you want agency-reported positions only.
+
+A driver-reported entity's id and `vehicle.id` are the `vehicle_id` the app
+reported — the vehicle the driver picked, which you created in the admin UI —
+and its `trip.trip_id` and `trip.route_id` are whatever the app sent with the
+fix. For OBA to match them to your schedule, those must be the ids from the
+same GTFS static feed OBA is using.
+
+## 12. Distributing the Android app
+
+The driver app lives in [`android/`](../android/) and takes the server URL on
+its **login screen**, stored per device. One APK therefore works for every
+agency and every server — there is nothing to rebuild per deployment.
+
+### 12.1 Build a release APK
+
+```bash
+cd android
+./gradlew :app:assembleRelease
+ls app/build/outputs/apk/release/app-release-unsigned.apk
+```
+
+JDK 17 is what CI uses (`.github/workflows/android.yml`), and the Gradle build
+targets Java 17, so build with a JDK 17 toolchain. The output is
+**unsigned**: `android/app/build/outputs/apk/release/app-release-unsigned.apk`.
+`android/app/build.gradle.kts` enables minification for the release build type
+but defines no `signingConfig`, so signing is the agency's job. Android will not
+install an unsigned APK.
+
+### 12.2 Create a signing key
+
+Do this once, and keep the keystore forever: an update can only install over an
+existing app if it is signed with the *same* key. Lose it and every driver has
+to uninstall and reinstall.
+
+```bash
+keytool -genkeypair -v \
+  -keystore ~/vehicle-tracker-release.jks \
+  -alias vehicle-tracker \
+  -keyalg RSA -keysize 4096 -validity 10000
+```
+
+Back the `.jks` file up somewhere separate from the build machine, and treat the
+passwords like the server's `JWT_SECRET`.
+
+### 12.3 Sign the APK
+
+`zipalign` and `apksigner` ship with the Android SDK build-tools (adjust the
+version to match what you have installed under `$ANDROID_HOME/build-tools/`):
+
+```bash
+export BT="$ANDROID_HOME/build-tools/36.0.0"
+
+"$BT/zipalign" -p -f 4 \
+  app/build/outputs/apk/release/app-release-unsigned.apk \
+  app-release-aligned.apk
+
+"$BT/apksigner" sign \
+  --ks ~/vehicle-tracker-release.jks \
+  --ks-key-alias vehicle-tracker \
+  --out app-release.apk \
+  app-release-aligned.apk
+
+"$BT/apksigner" verify --print-certs app-release.apk
+```
+
+Align before signing, not after: rewriting the archive afterwards invalidates
+the signature.
+
+### 12.4 Or let Gradle sign it
+
+If you build releases often, add a signing config that is used only when the
+keystore is available, so the repository's CI (which has no keystore) keeps
+building as it does today. In `android/app/build.gradle.kts`:
+
+```kotlin
+android {
+    val keystorePath = System.getenv("ANDROID_KEYSTORE")
+
+    signingConfigs {
+        if (keystorePath != null) {
+            create("release") {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            signingConfig = signingConfigs.findByName("release")
+        }
+    }
+}
+```
+
+With the four `ANDROID_*` variables exported, `./gradlew :app:assembleRelease`
+writes a signed `app-release.apk` to the same directory; without them the build
+still produces `app-release-unsigned.apk`. Never commit the keystore or its
+passwords — pass them through the environment or a secrets store. Verify the
+result with `apksigner verify --print-certs` before you hand the APK out.
+
+### 12.5 Get it onto driver phones
+
+Most agencies deploying this have no Play Store presence, so sideload:
+
+- **Over USB**, for phones you control:
+
+  ```bash
+  adb install -r app-release.apk
+  ```
+
+  `-r` reinstalls over an existing copy, keeping the driver's stored login.
+
+- **From a download link**, for phones you do not: host the APK on your own
+  HTTPS site (`https://tracker.example.org` is fine if you can serve a static
+  file from nginx) and send drivers the link. On Android 8 and newer, the phone
+  will prompt to allow the *downloading app* — Chrome, or the file manager — to
+  install unknown apps; the driver grants it once under
+  **Settings → Apps → Special app access → Install unknown apps**.
+
+Bump `versionCode` in `android/app/build.gradle.kts` for every build you hand
+out (it is `1` today). Android refuses to install an APK whose `versionCode` is
+lower than the installed one, and identical codes make it impossible to tell
+which build a driver is running when you are debugging a report from the field.
+
+Then tell drivers three things: the server URL, their email, and their password.
+The app's [smoke-test walkthrough](android-smoke-test.md) is a useful script for
+verifying a new build end to end before you distribute it.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -151,7 +151,7 @@ previous build, and it keeps the image pinned when you edit the compose file.
 ### 4.2 The environment file
 
 ```bash
-mkdir -p /srv/vehicle-positions
+sudo mkdir -p /srv/vehicle-positions
 cd /srv/vehicle-positions
 umask 077
 cat > .env <<EOF
@@ -249,7 +249,7 @@ git clone https://github.com/OneBusAway/vehicle-positions.git
 cd vehicle-positions
 CGO_ENABLED=0 go build -o vehicle-positions .
 sudo install -o root -g root -m 0755 vehicle-positions /usr/local/bin/vehicle-positions
-/usr/local/bin/vehicle-positions --help 2>/dev/null; echo "installed"
+ls -l /usr/local/bin/vehicle-positions
 ```
 
 The binary embeds the migrations, HTML templates and CSS, so this single file is
@@ -742,6 +742,14 @@ same GTFS static feed OBA is using.
 The driver app lives in [`android/`](../android/) and takes the server URL on
 its **login screen**, stored per device. One APK therefore works for every
 agency and every server — there is nothing to rebuild per deployment.
+
+**Version skew:** this app sends `route_id` and `start_date` on every location
+report, so it requires a server built from this repository at or after the
+commit that added those fields to `POST /api/v1/locations`. Against an older
+server, every location report is rejected with `400` as an unknown field: the
+app logs the failure and drops the report, but the driver still sees the
+green "connected" banner, since the app has no way to tell a rejected report
+from a slow one. Upgrade the server before distributing this APK.
 
 ### 12.1 Build a release APK
 

--- a/docs/operator-manual.md
+++ b/docs/operator-manual.md
@@ -1,0 +1,524 @@
+# Operator Manual
+
+This manual is for the person who runs the service day to day: an operations
+manager or dispatcher at a transit agency. You do not need to write code, use a
+terminal, or log into a server. Everything here happens in a web browser or on a
+driver's phone.
+
+If you are the person who has to *install* the software, read
+[`deployment.md`](deployment.md) instead — it covers servers, databases,
+certificates and the settings named in this manual. Where something is a
+settings change rather than a click, this manual says so and points you at your
+IT contact.
+
+Throughout, **bold** text is exactly what you will see on the screen.
+
+---
+
+## 1. What the system does
+
+Drivers carry an Android phone running the Vehicle Tracker app. When a driver
+starts a trip, the phone sends its location to your server every few seconds.
+The server keeps the current position of every vehicle and publishes it as a
+standard GTFS Realtime **Vehicle Positions** feed — the same format OneBusAway
+and other rider apps already understand. You manage the fleet, the accounts and
+the assignments from a web page at `/admin` on the same server.
+
+```
+  ┌──────────────────┐      ┌──────────────────┐      ┌──────────────────┐
+  │  Driver's phone  │      │   Your server    │      │  OneBusAway or   │
+  │                  │─────▶│                  │─────▶│  any GTFS-RT     │
+  │  Vehicle Tracker │  GPS │  Admin UI /admin │ Feed │  rider app       │
+  │  app, on a trip  │      │  + GTFS-RT feed  │      │                  │
+  └──────────────────┘      └──────────────────┘      └──────────────────┘
+```
+
+Two things are worth knowing up front:
+
+- A vehicle appears in the feed only while a phone is reporting for it. When
+  reports stop, the vehicle drops out of the feed after the **staleness
+  threshold** (5 minutes unless your IT contact changed it).
+- Positions are not stored on the phone when the network is down. Fixes taken
+  during an outage are lost, not sent later.
+
+---
+
+## 2. Signing in
+
+1. In a browser, go to `https://your-server/admin`.
+2. You land on the sign-in page, headed **Transit Tracker** / **Fleet
+   operations sign in**.
+3. Enter your **Email** and **Password** and click **Sign in**.
+
+The very first admin account is created during installation, from the
+`ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` settings — see
+[`deployment.md` §4.4](deployment.md#44-after-the-first-sign-in). If nobody has
+signed in yet, ask your IT contact for those credentials. After you sign in,
+create a real account for yourself and every other person who needs one
+(section 5).
+
+**If sign-in fails.** A wrong password, an unknown email address, and a
+deactivated account all show the same message, **Invalid email or password.** —
+this is deliberate, so an outsider cannot learn which email addresses exist. If
+you see **Too many attempts, try again shortly.**, wait a minute: the server
+allows only a handful of sign-in attempts per email address and per network
+address in any one minute, and then makes you pause.
+
+**Changing your own password.** There is no separate profile page. Go to
+**Users**, click **Edit** on your own row, type a new password into **New
+password (leave blank to keep current)**, and click **Save changes**. Passwords
+must be at least 8 characters.
+
+Once signed in, the left sidebar takes you to **Live Map**, **Dashboard**,
+**Vehicles**, **Users** and **Trips**. **Sign out** is at the top right of every
+page.
+
+---
+
+## 3. Dashboard
+
+**Dashboard** is the one-screen health check. Four numbers across the top:
+
+| Card | What it counts |
+|---|---|
+| **Active Fleet** | Vehicles you have registered and not deactivated. It does not mean they are moving. |
+| **Active Now** | Vehicles that have reported a position within the staleness threshold. These are the ones in the feed right now. |
+| **Drivers** | Accounts with the driver role that are not deactivated. |
+| **Active Trips** | Trips that have been started and not yet ended. |
+
+Below them is a thin strip with two more:
+
+| Field | What it means |
+|---|---|
+| **Feed last updated** | How long ago *any* vehicle last reported — "just now", "7 min ago", "2 h ago", or **never** if nothing has ever reported. |
+| **Staleness threshold** | How long a vehicle may go without reporting before it drops out of the feed and out of **Active Now**. Default 5 min; changing it is a server setting (`STALENESS_THRESHOLD`), not a UI control. |
+
+The **Recent Activity** table lists the ten most recently reporting vehicles
+with their **Vehicle** label, **Route** (the route of their current trip, or a
+dash if they have none) and **Last Update**. **View all →** goes to the vehicle
+list. When nothing has reported lately it says **No vehicles have reported
+recently.**
+
+The healthy picture during service hours is: **Active Now** roughly equal to the
+number of buses you expect out, **Active Trips** matching it, and **Feed last
+updated** saying "just now".
+
+---
+
+## 4. Vehicles
+
+**Vehicles** lists every vehicle under the heading **All Vehicles**, with
+columns **ID**, **Label**, **Agency tag**, **Status**, **Last seen**, **Driver**
+and **Actions**. By default only active vehicles are shown; **Show deactivated**
+adds the deactivated ones and turns into **Hide deactivated**. Long lists are
+paged with **← Previous** / **Next →** at the bottom.
+
+### Add a vehicle
+
+1. Click **New vehicle**.
+2. Fill in **Vehicle ID**. This is the permanent identifier that goes into the
+   feed, so use the id your agency already uses for the bus — a fleet number,
+   for example.
+   - Allowed characters: letters, digits, dots, hyphens and underscores.
+   - Maximum 50 characters.
+   - No spaces, no accented letters, no slashes. If you use anything else the
+     form comes back with **vehicle id must contain only alphanumeric
+     characters, dots, hyphens, and underscores**.
+   - Ids must be unique. Reusing one gives **vehicle id already exists**.
+3. Fill in **Label** — the human name shown in the admin screens and on the map
+   ("Bus 12", "Minibus 7").
+4. Fill in **Agency tag** if you run more than one operator or depot through one
+   server. It is a free-text grouping label; leave it blank if you do not need
+   it.
+5. Click **Create vehicle**. You return to the list with **Vehicle created.**
+
+### Edit a vehicle
+
+Click **Edit** on the row. You can change **Label** and **Agency tag** and click
+**Save changes**. **Vehicle ID** is greyed out and cannot be changed — it is
+baked into the feed and into every location record already stored. If a vehicle
+genuinely needs a different id, create a new one and deactivate the old one.
+
+### Deactivate and reactivate
+
+There is no delete button, by design. Use **Deactivate** on the row; a
+confirmation asks **Deactivate this vehicle?** The vehicle disappears from the
+default list, can no longer be assigned to a driver, and stops being offered to
+drivers in the app. Its history is kept. To bring it back, click **Show
+deactivated**, then **Activate** on the row (**Reactivate this vehicle?**).
+
+Deactivating does not stop a trip that is already running.
+
+### Export location history
+
+The **CSV** link on each row downloads that vehicle's recent location points as
+a spreadsheet file named `<vehicle-id>_locations.csv`. It contains the last
+**24 hours**, up to **1,000 points**, with one row per position:
+
+| Column | Meaning |
+|---|---|
+| `timestamp` | When the phone recorded the fix (Unix seconds). |
+| `latitude`, `longitude` | Where it was. |
+| `bearing` | Direction of travel in degrees, if the phone reported one. |
+| `speed` | Metres per second, if the phone reported one. |
+| `accuracy` | The phone's own estimate of how far off the fix may be, in metres. |
+| `trip_id` | The GTFS trip id the driver entered, if any. |
+| `received_at` | When your server received the point. |
+
+Empty cells mean the phone did not supply that value. For anything older or
+larger than that — a full month of one vehicle, for instance — ask your IT
+contact; it is a database query, not a button.
+
+---
+
+## 5. Drivers and admins
+
+**Users** lists every account under **All Users**, with **Name**, **Email**,
+**Role**, **Status**, **Vehicles** (how many are assigned) and **Actions**.
+
+There are exactly two roles:
+
+| Role | Can do |
+|---|---|
+| **Driver** | Sign in to the Android app, see their assigned vehicles, start and end trips, report locations. Cannot open `/admin` at all. |
+| **Admin** | Everything in the admin web UI: vehicles, users, assignments, map, trips, CSV export. |
+
+### Create an account
+
+1. Click **New user**.
+2. Fill in **Name**, **Email** and **Password**. The password must be at least
+   8 characters, or you get **password must be at least 8 characters**.
+3. Choose **Role** — **Driver** or **Admin**. New accounts default to
+   **Driver**.
+4. Click **Create user**. A duplicate address gives **email already exists**.
+
+Give the driver their email address and password in person or by whatever
+channel your agency uses; there is no invitation email and no self-service
+password reset.
+
+### Reset a password
+
+1. **Users** → **Edit** on the row.
+2. Type the new password into **New password (leave blank to keep current)**.
+   Leave the field empty if you only want to change the name, email or role.
+3. Click **Save changes**.
+
+### Deactivate an account
+
+Click **Deactivate** on the row and confirm **Deactivate this user?** The person
+can no longer sign in — to the admin UI or the app. **Activate** puts them back.
+
+**Important:** deactivating blocks *new* sign-ins immediately, but it does not
+cut off a session that is already open. A phone or browser that signed in
+earlier keeps working until its session expires, which can be up to 24 hours.
+Changing someone's password has the same limit. If you need someone locked out
+right now — a phone was stolen, a driver was dismissed — deactivate the account
+*and* tell your IT contact — signing everyone out at once is a server-side
+change (rotating the token-signing key and restarting), not something the admin
+UI can do.
+
+### The last-admin protection
+
+The system will not let you lock everyone out of the admin UI. If exactly one
+active admin account is left:
+
+- Deactivating it is refused with **cannot deactivate the last active admin**
+  (shown as a plain error page — use your browser's Back button).
+- Changing its **Role** from **Admin** to **Driver** is refused with **cannot
+  demote the last active admin**, shown on the form.
+
+Create the second admin first, then make the change. Keeping at least two admin
+accounts is good practice anyway.
+
+---
+
+## 6. Assigning vehicles to drivers
+
+A driver can only start a trip on a vehicle assigned to them. Assignments live
+on the user's edit page.
+
+1. **Users** → **Edit** on the driver's row.
+2. Scroll to **Assigned vehicles**. It shows what they have now, or **No
+   vehicles assigned.**
+3. Pick a vehicle from the dropdown and click **Assign**. You get **Vehicle
+   assigned.** Only active vehicles appear in the dropdown; if there are none,
+   you see **No active vehicles available to assign.**
+4. To take one away, click **Remove** beside it and confirm **Remove this
+   vehicle assignment?** You get **Vehicle unassigned.**
+
+A driver may hold several assignments — useful when the same person drives
+whichever bus is free — and a vehicle may be assigned to several drivers.
+
+If a driver tries to start a trip on a vehicle that is not assigned to them, the
+server refuses (`403 driver is not assigned to this vehicle`) and the app shows
+**You are not assigned to this vehicle.** Note the one thing this does *not*
+cover: the assignment is checked when a trip is started, not on each individual
+location report. In normal use that is the same thing, because the app only
+reports while a trip is running.
+
+---
+
+## 7. Onboarding a driver
+
+Do this once per driver, with the driver and their phone in front of you. It
+takes about ten minutes. Before you start, make sure the driver has an account
+(section 5) and at least one assigned vehicle (section 6).
+
+**On your side, first:**
+
+1. Get the app file (an APK) from your IT contact, along with the exact server
+   web address the drivers should use. Both come out of
+   [`deployment.md` §12](deployment.md#12-distributing-the-android-app).
+2. Have the driver's email address, their password, and the **route id** they
+   will be driving ready.
+
+**On the driver's phone:**
+
+1. Install the app. The driver will have to allow installation from your source
+   the first time; your IT contact's distribution instructions cover this.
+2. Open **Vehicle Tracker**. The first screen is **Driver Login**.
+3. Enter the **Server URL** you were given. It is stored on the phone, so the
+   driver only ever types it once. Enter **Email** and **Password**, then tap
+   **Log In**.
+   - **Invalid email or password.** means the account or password is wrong, or
+     the account is deactivated.
+   - **Could not reach the server. Check your connection.** means the phone
+     cannot reach the server — check the network and the server URL.
+4. Next is **Select a Vehicle**, listing exactly the vehicles you assigned. If
+   there is only one, the app skips this screen and selects it automatically. If
+   it says **No vehicles are assigned to you.**, go back to section 6.
+5. Next is **Start a Trip**:
+   - **Route ID** — required. Type the route id exactly as it appears in the
+     `route_id` column of your agency's GTFS `routes.txt`. This is often *not*
+     the number painted on the bus. If your published route "12" has the GTFS
+     `route_id` `RT-012`, the driver must type `RT-012`. Get this wrong and the
+     vehicle still shows up in the feed, but OneBusAway cannot match it to a
+     route, so riders will not see it on the route they are waiting for.
+   - **GTFS Trip ID (optional)** — leave it blank unless your agency works from
+     a schedule and knows the exact `trip_id` for this run. A route id alone is
+     enough for the feed. Filling it in lets OneBusAway tie the bus to a
+     specific scheduled trip.
+   - **Recent routes** — after the first few trips, the last route ids used on
+     that phone appear as buttons here. Tapping one fills in **Route ID**. This
+     is what most drivers will use day to day.
+   - Tap **Start Trip**.
+6. The permission prompts appear next, once per phone. Work through them with
+   the driver — this is the step drivers get wrong on their own:
+   - Location: choose the **precise** option. If only approximate location is
+     granted, the app warns **Approximate Location Only** and offers **Grant
+     Precise Location**; take it.
+   - Background location: the app shows **Keep Tracking in the Background**.
+     Tap **Continue**, then choose **"Allow all the time"** on the Android
+     screen that appears. Anything less — or tapping **Not Now** — and tracking
+     stops the moment the screen locks.
+   - Notifications: allow them. If they are refused the app says so and carries
+     on, but the driver loses the ongoing tracking notification.
+   - Battery: the app shows **Prevent Battery Optimization**. Tap **Continue**
+     and allow it. This is what keeps long trips reporting reliably.
+   - If the phone's location services are switched off entirely, the app says
+     **Turn On Location Services** and will not start until they are on.
+7. Tracking starts. The screen fills with a large status banner, plus **Route
+   …**, **Trip duration: …** and **Location updates sent: …**, and an **End
+   Trip** button. A notification, **OBA Tracker is active**, stays in the status
+   bar for the whole trip.
+
+**What the status banner means.** The banner is green when all is well and red
+when something needs attention:
+
+| Banner | Colour | What is happening | What the driver should do |
+|---|---|---|---|
+| **Tracking – Connected** | green | Fixes are reaching the server. | Nothing. |
+| **No connection** | red | The phone cannot reach the server. Positions taken now are dropped, not queued. | Keep driving; it goes green again by itself when signal returns. |
+| **GPS unavailable** | red | The phone is not producing location fixes. | Check that location services are still on and the phone has a view of the sky. |
+| **Check device clock** | red | The server has rejected several reports because the phone's clock is wrong. | Turn on automatic date and time in Android settings. |
+| **Session expired – log in again** | red | The phone's sign-in has expired. Sign-ins last 24 hours, so this normally appears on a phone that has been running since the previous day. | Tap **Log in** on the same screen and sign in again with the same email and password. |
+
+**Ending a trip.** Tap **End Trip** and confirm **End this trip?** ("This will
+stop location tracking and mark the trip as complete."). Tracking stops, the
+notification disappears, and the vehicle drops out of the feed once its last
+report ages past the staleness threshold. If the server cannot be reached at
+that moment the app offers **Could not end trip** with **Retry** and **End
+Locally** — **End Locally** stops the phone but leaves the trip showing as
+**Active** on your **Trips** page, so ask the driver to reopen the app and end
+it properly when they are back on the network.
+
+Teach every driver the same three habits: start the trip before pulling out,
+check the banner is green, and end the trip when the run finishes.
+
+---
+
+## 8. Watching the fleet
+
+### Live Map
+
+**Live Map** shows every vehicle that has reported within the staleness
+threshold, refreshing about every 10 seconds on its own. It shows
+driver-reported vehicles only.
+
+- The overlay at the top left counts **Active** vehicles and how many distinct
+  **Routes** they are on.
+- Clicking a bus marker opens a card with **Route**, **Driver**, **Speed** and
+  **Updated** ("how long ago").
+- **Fleet Status** on the right lists the same vehicles as rows.
+- If nothing is reporting you get the banner **No vehicles to show right now.**
+  and **No vehicles reporting.** in the sidebar.
+
+### Trips and trails
+
+**Trips** is the history, headed **Trip History**. Each row shows **Trip**,
+**Vehicle**, **Driver**, **Route**, **GTFS trip**, **Start**, **End**,
+**Status** and **Duration**. Filter with the status dropdown (**All statuses**,
+**Active**, **Completed**), the vehicle dropdown (**All vehicles**), and the
+search box ("Search driver, route, trip id") — then click **Apply**.
+
+Click **View trail** on any trip to open the map on that trip alone: the route
+actually driven as a line, with a **Start** and an **End** marker, and the
+sidebar replaced by **Trip Detail** showing driver, route, status and times.
+This is the tool for answering "where did this bus actually go?".
+
+### The feed itself
+
+Hand this address to whoever runs your OneBusAway instance, or to any other
+GTFS-Realtime consumer:
+
+```
+https://your-server/gtfs-rt/vehicle-positions
+```
+
+That is the whole integration. OneBusAway reads GTFS-RT Vehicle Positions
+natively; see [`deployment.md` §11](deployment.md#11-connecting-the-feed-to-onebusaway)
+for the details your IT contact needs.
+
+To check the feed with your own eyes, open the same address with `?format=json`
+on the end:
+
+```
+https://your-server/gtfs-rt/vehicle-positions?format=json
+```
+
+The browser shows a readable list instead of the machine format. Each vehicle
+appears once, with its position, its `vehicleId`, and the `routeId` and
+`startDate` its driver entered (plus `tripId` if the driver typed a GTFS trip
+id). An empty list means no vehicle has reported inside the staleness window.
+
+---
+
+## 9. Daily operations checklist
+
+**Before service**
+
+1. Open **Dashboard**. Confirm **Active Fleet** matches the number of buses you
+   expect to be available and **Drivers** matches your roster.
+2. Check **Trips** filtered to **Active**. It should be empty. Anything left
+   over is yesterday's trip that was never ended — see section 12.
+3. As the first buses pull out, confirm **Active Now** and **Active Trips**
+   start climbing and **Feed last updated** says "just now".
+
+**During service**
+
+1. Keep **Live Map** open. Every bus that should be out should be a marker.
+2. A bus that vanishes from the map has stopped reporting for longer than the
+   staleness threshold — call the driver before assuming a fault.
+3. Spot-check the feed with `?format=json` if a rider or OneBusAway reports
+   something missing.
+
+**After service**
+
+1. **Trips** → **Completed**: every run of the day should be there, with a
+   sensible **Duration**.
+2. **Trips** → **Active**: should be empty. Every trip still listed as
+   **Active** is a driver who did not tap **End Trip**. Ask them to reopen the
+   app and end it; the app remembers the trip and will take them straight back
+   to the tracking screen.
+3. **Dashboard**: **Active Trips** back to 0, **Active Now** back to 0 a few
+   minutes after the last bus.
+
+---
+
+## 10. Rider mode (optional)
+
+Rider mode is an optional extra where ordinary riders' phones, running a
+separate anonymous rider app, help fill in positions for trips no driver phone
+is covering. The server checks each reported position against your GTFS
+schedule and route shape, and only publishes one when it is convincing. It is
+**off** unless your IT contact deliberately turned it on, and when it is off it
+changes nothing at all about the driver-reported feed.
+
+It has no screens in the admin UI. Two addresses report on it, and both answer
+with raw data meant for a technical reader rather than a page:
+
+- `https://your-server/api/v1/admin/rider/status` — whether it is enabled, plus
+  schedule and live-ride counts. When rider mode is off it simply answers
+  `{"enabled":false}`, which is the quickest way to tell.
+- `https://your-server/api/v1/admin/rider/rides` — recent rider rides, newest
+  first.
+
+Both require an admin account, so while you are signed in to the admin UI you
+can open them in the same browser. If the answer means nothing to you, that is
+expected — hand it to your IT contact. The settings behind it are in
+[`deployment.md` §3](deployment.md#3-configuration-reference) and the README's
+rider-mode section.
+
+What you *can* see for yourself is the effect on the feed. Rider-derived
+vehicles are labelled **Rider-reported** and their ids look like
+`rider:<trip id>:<date>`, so they are never confused with your own buses. They
+never appear on the **Live Map**, which shows driver-reported vehicles only.
+A trip your own drivers are already reporting is never published from rider
+data. If your OneBusAway instance should receive agency positions only, your IT
+contact can point it at the feed address with `?source=driver` on the end.
+
+---
+
+## 11. Data retention and privacy
+
+**What is stored.** For every location report: the vehicle, the position
+(latitude, longitude, and where available bearing, speed and accuracy), the
+time the phone recorded it, the time the server received it, and the trip it
+belonged to. For every trip: the driver, the vehicle, the route id, the
+optional GTFS trip id, and the start and end times. For every account: name,
+email address, role and a scrambled form of the password — never the password
+itself.
+
+Taken together this is a **per-driver movement history**, and it should be
+treated like one. Anyone with an admin account can see any vehicle's positions:
+the **Live Map**, the trip trails, and the **CSV** export on the vehicle list.
+Drivers can see none of it — the app has no history screen, and driver accounts
+cannot open `/admin`. So the real access control here is how many admin
+accounts you hand out. Keep the number small, and deactivate accounts when
+people change jobs.
+
+**How long it is kept.** Location history is kept **forever** unless your agency
+turns on retention. Turning it on is a server setting
+(`LOCATION_RETENTION_PERIOD`), not a control in the admin UI — ask your IT
+contact, and see [`deployment.md` §6.5](deployment.md#65-retention) and the
+README's retention notes. Three things to know before you ask for it:
+
+- Deletion is permanent. There is no archive and no undo. Export anything you
+  need to keep first.
+- The clock runs from when the server received the point, not from the time the
+  phone claimed — so a phone with a wrong clock cannot dodge the rule.
+- Pick a period consistent with local law and your own driver-privacy policy.
+  Ninety days is a common starting point.
+
+Trip records and accounts are not deleted by retention; only the location
+points are.
+
+---
+
+## 12. Troubleshooting
+
+| Symptom | Likely cause | What to do |
+|---|---|---|
+| Driver sees **You are not assigned to this vehicle.** when tapping **Start Trip** | The vehicle is not assigned to that driver, or the assignment was removed. | **Users** → **Edit** the driver → **Assigned vehicles** → pick the vehicle → **Assign**. Then have them tap **Start Trip** again. |
+| Driver sees **You already have an active trip.** | An earlier trip was never ended — usually **End Locally** after a network problem, or the app was reinstalled. | Have the driver reopen the app; it returns to the tracking screen for the old trip, where **End Trip** ends it. Confirm on **Trips** → **Active** that it is gone. If the app no longer knows about the trip, ask your IT contact — there is no button in the admin UI to end another person's trip. |
+| Driver sees **No vehicles are assigned to you.** | No active vehicle is assigned to that account. | Check the vehicle is not deactivated (**Vehicles** → **Show deactivated**), then assign it (section 6). |
+| One vehicle missing from the feed and the map, others fine | That phone has stopped reporting for longer than the staleness threshold: no signal, app closed, trip never started, phone battery dead, or Android killed the app in the background. | Ask the driver what the status banner says. **No connection** is a coverage problem and clears itself. If the app is not on the tracking screen at all, the trip was never started or was ended. If it keeps dying when the screen locks, the background-location permission is not **"Allow all the time"** — redo step 6 of section 7. |
+| Feed completely empty during service hours | Nothing is reporting, or the server lost its database. | Check **Dashboard**: if **Feed last updated** says **never** or a long time, and **Active Trips** is 0, it is the phones — start with two or three drivers. If **Active Trips** is healthy but nothing is in the feed, contact IT: see the monitoring checks in [`deployment.md` §9](deployment.md#9-monitoring). |
+| Driver phone shows **Session expired – log in again** | The 24-hour sign-in expired. | Have the driver tap **Log in** on that screen and sign in again. If you have since deactivated the account, sign-in is refused — which is the intended outcome. |
+| A driver or admin cannot sign in and insists the password is right | The account is deactivated. Deactivation is deliberately indistinguishable from a wrong password on the sign-in screen. | **Users** → find the row → if **Status** reads **Deactivated**, click **Activate** and confirm **Reactivate this user?** |
+| Someone you deactivated is still reporting, or their phone still works | Deactivation blocks new sign-ins; it does not end a session already in progress, and that session can last up to 24 hours. | Confirm the row shows **Deactivated** on **Users** — that is enough to stop them signing in again. If they must be cut off this minute, tell your IT contact; only a server-side change ends live sessions. |
+| Driver phone shows **Check device clock** | The phone's clock is wrong, so the server is rejecting its reports. | On the phone, turn on automatic date and time in Android settings, then restart the app. The banner goes green once reports are accepted again. |
+| Vehicles show on your **Live Map** but not in OneBusAway | Almost always the route id. The driver typed the public route number instead of the GTFS `route_id`, so OBA cannot match it to a route. | Check **Trips** → the **Route** column against your GTFS `routes.txt`. Correct it with the driver (section 7, step 5) and have them end and restart the trip. If the ids are right, check with IT that OBA is pointed at the feed address and using the same GTFS static file. |
+| **Deactivate** on a user returns a plain page saying **cannot deactivate the last active admin** | It is the only active admin account left. | Use your browser's Back button, create or reactivate another admin, then try again. |
+| Vehicle form rejects an id | The id has spaces or other characters, or is over 50 characters, or already exists. | Use only letters, digits, dots, hyphens and underscores; keep it to at most 50 characters; check **Show deactivated** in case the id belongs to a deactivated vehicle. |
+| `/admin` returns "not found" | The admin UI was switched off at install time (`ADMIN_UI_ENABLED=false`). | Ask your IT contact to enable it — see [`deployment.md` §3](deployment.md#3-configuration-reference). |

--- a/docs/operator-manual.md
+++ b/docs/operator-manual.md
@@ -467,8 +467,11 @@ vehicles are labelled **Rider-reported** and their ids look like
 `rider:<trip id>:<date>`, so they are never confused with your own buses. They
 never appear on the **Live Map**, which shows driver-reported vehicles only.
 A trip your own drivers are already reporting is never published from rider
-data. If your OneBusAway instance should receive agency positions only, your IT
-contact can point it at the feed address with `?source=driver` on the end.
+data — but only when the driver picked the specific scheduled trip, not just a
+route. If a driver only entered a route, the server has no scheduled trip to
+match against, so rider coverage for that trip is not suppressed. If your
+OneBusAway instance should receive agency positions only, your IT contact can
+point it at the feed address with `?source=driver` on the end.
 
 ---
 

--- a/docs/operator-manual.md
+++ b/docs/operator-manual.md
@@ -90,7 +90,7 @@ Below them is a thin strip with two more:
 
 | Field | What it means |
 |---|---|
-| **Feed last updated** | How long ago *any* vehicle last reported — "just now", "7 min ago", "2 h ago", or **never** if nothing has ever reported. |
+| **Feed last updated** | How long ago *any* vehicle the server is still tracking last reported — "just now", "3 min ago". It is **never** whenever the server is tracking no vehicles at all, which in practice means nothing has reported for roughly the last 5 to 10 minutes: the server forgets a vehicle once it passes the staleness threshold. **never** is also what you see after a restart if nothing has reported in the last few minutes. Treat it as "recently" or "not recently", not as a long-term record. |
 | **Staleness threshold** | How long a vehicle may go without reporting before it drops out of the feed and out of **Active Now**. Default 5 min; changing it is a server setting (`STALENESS_THRESHOLD`), not a UI control. |
 
 The **Recent Activity** table lists the ten most recently reporting vehicles
@@ -397,9 +397,10 @@ https://your-server/gtfs-rt/vehicle-positions?format=json
 ```
 
 The browser shows a readable list instead of the machine format. Each vehicle
-appears once, with its position, its `vehicleId`, and the `routeId` and
-`startDate` its driver entered (plus `tripId` if the driver typed a GTFS trip
-id). An empty list means no vehicle has reported inside the staleness window.
+appears once under an `id` — the **Vehicle ID** you gave it on the vehicle form
+— with its position, and with the `routeId` and `startDate` its driver entered
+(plus `tripId` if the driver typed a GTFS trip id). An empty list means no
+vehicle has reported inside the staleness window.
 
 ---
 
@@ -411,8 +412,10 @@ id). An empty list means no vehicle has reported inside the staleness window.
    expect to be available and **Drivers** matches your roster.
 2. Check **Trips** filtered to **Active**. It should be empty. Anything left
    over is yesterday's trip that was never ended — see section 12.
-3. As the first buses pull out, confirm **Active Now** and **Active Trips**
-   start climbing and **Feed last updated** says "just now".
+3. Before the first bus reports, **Feed last updated** will read **never** and
+   **Active Now** will be 0. That is normal, not a fault.
+4. As the first buses pull out, confirm **Active Now** and **Active Trips**
+   start climbing and **Feed last updated** changes to "just now".
 
 **During service**
 
@@ -513,7 +516,7 @@ points are.
 | Driver sees **You already have an active trip.** | An earlier trip was never ended — usually **End Locally** after a network problem, or the app was reinstalled. | Have the driver reopen the app; it returns to the tracking screen for the old trip, where **End Trip** ends it. Confirm on **Trips** → **Active** that it is gone. If the app no longer knows about the trip, ask your IT contact — there is no button in the admin UI to end another person's trip. |
 | Driver sees **No vehicles are assigned to you.** | No active vehicle is assigned to that account. | Check the vehicle is not deactivated (**Vehicles** → **Show deactivated**), then assign it (section 6). |
 | One vehicle missing from the feed and the map, others fine | That phone has stopped reporting for longer than the staleness threshold: no signal, app closed, trip never started, phone battery dead, or Android killed the app in the background. | Ask the driver what the status banner says. **No connection** is a coverage problem and clears itself. If the app is not on the tracking screen at all, the trip was never started or was ended. If it keeps dying when the screen locks, the background-location permission is not **"Allow all the time"** — redo step 6 of section 7. |
-| Feed completely empty during service hours | Nothing is reporting, or the server lost its database. | Check **Dashboard**: if **Feed last updated** says **never** or a long time, and **Active Trips** is 0, it is the phones — start with two or three drivers. If **Active Trips** is healthy but nothing is in the feed, contact IT: see the monitoring checks in [`deployment.md` §9](deployment.md#9-monitoring). |
+| Feed completely empty during service hours | Nothing is reporting, or the server lost its database. | Check **Dashboard**: if **Feed last updated** says **never** (nothing has reported for several minutes) and **Active Trips** is 0, it is the phones — start with two or three drivers. If **Active Trips** is healthy but nothing is in the feed, contact IT: see the monitoring checks in [`deployment.md` §9](deployment.md#9-monitoring). |
 | Driver phone shows **Session expired – log in again** | The 24-hour sign-in expired. | Have the driver tap **Log in** on that screen and sign in again. If you have since deactivated the account, sign-in is refused — which is the intended outcome. |
 | A driver or admin cannot sign in and insists the password is right | The account is deactivated. Deactivation is deliberately indistinguishable from a wrong password on the sign-in screen. | **Users** → find the row → if **Status** reads **Deactivated**, click **Activate** and confirm **Reactivate this user?** |
 | Someone you deactivated is still reporting, or their phone still works | Deactivation blocks new sign-ins; it does not end a session already in progress, and that session can last up to 24 hours. | Confirm the row shows **Deactivated** on **Users** — that is enough to stop them signing in again. If they must be cut off this minute, tell your IT contact; only a server-side change ends live sessions. |


### PR DESCRIPTION
## Summary

Fourth PR in the stack: the two documentation deliverables the README's Milestone 5 promised and the repo never got.

- **`docs/deployment.md`** — production deployment guide for agency IT: sizing, a complete configuration reference (every environment variable the server reads, with its real default), Docker Compose on one host, systemd + native binary (full unit file), PostgreSQL setup and `pg_dump` backups on a timer, nginx reverse proxy with TLS and the `TRUST_PROXY_HEADERS` reasoning, first-boot checklist, monitoring (`/health`, `/ready`, admin status, JSON logs and which messages are WARN vs ERROR), upgrades, connecting the feed to OneBusAway, and building/signing/sideloading the Android APK.
- **`docs/operator-manual.md`** — for the operations manager who never opens a terminal: signing in, the dashboard, vehicles, drivers and admins (including password reset and the last-admin rule), assignments, onboarding a driver step by step, watching the fleet, a daily checklist, rider mode, retention and privacy, and a symptom → cause → fix troubleshooting table. Every screen, button and message is named as the UI renders it.
- README links both guides from Getting Started.

**Also fixes a real bug found while verifying the guide, and adds the CI guard that would have caught it:** the `Dockerfile` never copied the `rider/` package, so `docker build` (and therefore `make up` / `docker compose up`) has failed since rider mode landed. One line: `COPY rider ./rider`. Nothing in CI built the image, which is why it went unnoticed; the `ci` workflow now runs `docker build` after the tests.

Every claim in both documents was checked against the source; the review found and fixed four inaccuracies before this PR was opened.

The deployment guide also warns about version skew: the Android APK from the previous PR requires a server that includes the `route_id`/`start_date` change, and against an older server every report is rejected while the app still shows its green banner. The operator manual and README now say that driver/rider de-duplication only applies when the driver entered the GTFS trip id.

## Product gaps surfaced while writing the manual (not fixed here)

- There is no admin UI or API way to end **another** user's stuck `active` trip. A driver whose phone loses its trip state cannot start a new trip until someone clears the row in the database. The manual escalates this to IT.
- Deactivating a user neither ends a running trip nor revokes the phone's token (up to 24 h).
- Driver and rider reports are matched by trip id only, so a route-only driver report never suppresses rider estimates for that trip. A route-level check needs its own design.

## Test plan

- [x] `go test ./...` unchanged and green
- [x] `docker build .` now succeeds (verified before and after the Dockerfile fix)
- [x] `./gradlew :app:assembleRelease` confirmed the unsigned APK path named in §12
- [ ] Have someone unfamiliar with the codebase follow `docs/deployment.md` on a fresh VM
