### PR TITLE
Docs/configuration reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
 
 Quick-start instructions for running the server locally with Docker Compose,
 plus API sanity checks and troubleshooting, live in
-[`docs/development.md`](docs/development.md).
+[`docs/development.md`](docs/development.md). Every environment variable the
+server reads, with its default and what a bad value does, is in
+[`docs/configuration.md`](docs/configuration.md).
 
 ### Admin web UI
 
@@ -85,6 +87,9 @@ unparseable value logs and falls back to its default.
 | `RIDER_SCHEDULE_EARLY` / `RIDER_SCHEDULE_LATE` | `15m` / `90m` | Schedule-adherence window. |
 | `RIDER_POINT_MAX_AGE` | `90s` | A ride whose latest accepted point (of any outcome) is older than this stops contributing to the feed. The position published for it is always its latest *matched* point. |
 | `RIDER_POINT_RETENTION` | `168h` | `ride_points` rows older than this are deleted hourly. |
+
+These settings also appear, alongside every other variable the server reads, in
+[`docs/configuration.md`](docs/configuration.md).
 
 Rider mode shares `JWT_SECRET` with the rest of the API, but rider tokens carry
 `role: "rider"` and are accepted only on the rider routes — a rider token is
@@ -302,6 +307,9 @@ The server can delete location points once they pass a configured age:
 |`LOCATION_RETENTION_PERIOD`|`0`    |How long to keep location points. `0` disables pruning|
 |`LOCATION_PRUNE_INTERVAL`  |`1h`   |How often the pruner runs                             |
 |`LOCATION_PRUNE_BATCH_SIZE`|`10000`|Maximum rows deleted per statement                    |
+
+These settings also appear, alongside every other variable the server reads, in
+[`docs/configuration.md`](docs/configuration.md).
 
 Notes for operators:
 

--- a/config_doc_test.go
+++ b/config_doc_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const configDocPath = "docs/configuration.md"
+
+// configDocVariablePattern matches the first cell of a reference table row: a
+// single backticked SHOUTY_NAME and nothing else. Requiring the whole cell to
+// be the name keeps prose that happens to mention a variable from counting as
+// documentation of it.
+var configDocVariablePattern = regexp.MustCompile("^`([A-Z][A-Z0-9_]*)`$")
+
+// TestConfigDoc_AllVariablesDocumented and TestConfigDoc_NoStaleVariables are
+// the two halves of the same guard: a variable added to the code without a
+// table row fails, and so does a row for a variable nothing reads any more.
+// One direction alone rots — a reference can be complete and wrong.
+func TestConfigDoc_AllVariablesDocumented(t *testing.T) {
+	inSource := envVarsReadInSource(t)
+	documented := documentedVariables(t)
+
+	for _, name := range sortedNames(inSource) {
+		assert.Contains(t, documented, name,
+			"%s is read by the server but has no row in %s", name, configDocPath)
+	}
+}
+
+func TestConfigDoc_NoStaleVariables(t *testing.T) {
+	inSource := envVarsReadInSource(t)
+	documented := documentedVariables(t)
+
+	for _, name := range sortedNames(documented) {
+		assert.Contains(t, inSource, name,
+			"%s has a row in %s but is not read anywhere in the module", name, configDocPath)
+	}
+}
+
+// TestConfigDoc_ParsesVariables keeps the two comparisons above from passing
+// vacuously: either extractor silently returning nothing would make every
+// Contains assertion above run zero times.
+func TestConfigDoc_ParsesVariables(t *testing.T) {
+	inSource := envVarsReadInSource(t)
+	require.NotEmpty(t, inSource, "the AST walk found no environment variables; the extractor is broken")
+
+	documented := documentedVariables(t)
+	require.NotEmpty(t, documented, "no variables parsed out of %s; the table format may have changed", configDocPath)
+}
+
+// TestConfigDoc_ExcludesTestOnlyVariables pins the walk's exclusion of _test.go
+// files. Variables that exist only to drive tests — WRITE_FIXTURE today — are
+// not operator-facing configuration and must not be required in the reference.
+// If the walk stopped skipping test files this set would be empty, because
+// every test-file variable would also appear in the production set.
+func TestConfigDoc_ExcludesTestOnlyVariables(t *testing.T) {
+	inSource := envVarsReadInSource(t)
+	inTests := envVarsReadInTests(t)
+
+	testOnly := make(map[string]struct{})
+	for name := range inTests {
+		if _, production := inSource[name]; !production {
+			testOnly[name] = struct{}{}
+		}
+	}
+	require.NotEmpty(t, testOnly, "no test-only variables found; the walk may no longer be skipping _test.go files")
+
+	documented := documentedVariables(t)
+	for _, name := range sortedNames(testOnly) {
+		assert.NotContains(t, documented, name,
+			"%s is read only by tests and should not be in %s", name, configDocPath)
+	}
+}
+
+// envVarsReadInSource returns every environment variable name the module reads
+// outside of tests.
+func envVarsReadInSource(t *testing.T) map[string]struct{} {
+	t.Helper()
+	return envVarsInFiles(parseModule(t, false))
+}
+
+// envVarsReadInTests is envVarsReadInSource for _test.go files only.
+func envVarsReadInTests(t *testing.T) map[string]struct{} {
+	t.Helper()
+	return envVarsInFiles(parseModule(t, true))
+}
+
+// parseModule parses every .go file in this module, either the test files or
+// the production ones. Nested modules (maglev/ has its own go.mod) and testdata
+// directories are skipped for the same reason the Go toolchain skips them:
+// their contents are not part of this module's build.
+func parseModule(t *testing.T, testFiles bool) []*ast.File {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	var files []*ast.File
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path == "." {
+				return nil
+			}
+			name := d.Name()
+			if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") || name == "testdata" {
+				return filepath.SkipDir
+			}
+			if _, statErr := os.Stat(filepath.Join(path, "go.mod")); statErr == nil {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") != testFiles {
+			return nil
+		}
+		parsed, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		files = append(files, parsed)
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "no Go files parsed; the walk root is wrong")
+	return files
+}
+
+// envVarsInFiles collects the string literal passed as the first argument to
+// any function that reads the environment.
+func envVarsInFiles(files []*ast.File) map[string]struct{} {
+	readers := envReaderNames(files)
+	names := make(map[string]struct{})
+	for _, file := range files {
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || !isEnvRead(call, readers) || len(call.Args) == 0 {
+				return true
+			}
+			lit, ok := call.Args[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			if name, err := strconv.Unquote(lit.Value); err == nil {
+				names[name] = struct{}{}
+			}
+			return true
+		})
+	}
+	return names
+}
+
+// envReaderNames discovers the module's env helpers rather than listing them,
+// so a helper added later is covered without touching this test. A function
+// qualifies when it forwards its own first string parameter to something that
+// already reads the environment, which resolves wrappers over wrappers —
+// envPositiveDurationOrDefault reaches os.Getenv only through
+// envDurationOrDefault — by iterating to a fixed point.
+func envReaderNames(files []*ast.File) map[string]struct{} {
+	readers := make(map[string]struct{})
+	for {
+		grew := false
+		for _, file := range files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv != nil || fn.Body == nil {
+					continue
+				}
+				if _, known := readers[fn.Name.Name]; known {
+					continue
+				}
+				key := firstStringParamName(fn)
+				if key == "" || !forwardsKey(fn.Body, key, readers) {
+					continue
+				}
+				readers[fn.Name.Name] = struct{}{}
+				grew = true
+			}
+		}
+		if !grew {
+			return readers
+		}
+	}
+}
+
+// firstStringParamName returns the name of the function's first parameter when
+// that parameter is a plain string, and "" otherwise.
+func firstStringParamName(fn *ast.FuncDecl) string {
+	if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+		return ""
+	}
+	first := fn.Type.Params.List[0]
+	if ident, ok := first.Type.(*ast.Ident); !ok || ident.Name != "string" {
+		return ""
+	}
+	if len(first.Names) == 0 {
+		return ""
+	}
+	return first.Names[0].Name
+}
+
+func forwardsKey(body *ast.BlockStmt, key string, readers map[string]struct{}) bool {
+	forwards := false
+	ast.Inspect(body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !isEnvRead(call, readers) || len(call.Args) == 0 {
+			return true
+		}
+		if ident, ok := call.Args[0].(*ast.Ident); ok && ident.Name == key {
+			forwards = true
+			return false
+		}
+		return true
+	})
+	return forwards
+}
+
+// isEnvRead reports whether the call reads the environment, either directly
+// through the os package or through one of the discovered helpers.
+func isEnvRead(call *ast.CallExpr, readers map[string]struct{}) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		pkg, ok := fn.X.(*ast.Ident)
+		return ok && pkg.Name == "os" && (fn.Sel.Name == "Getenv" || fn.Sel.Name == "LookupEnv")
+	case *ast.Ident:
+		_, known := readers[fn.Name]
+		return known
+	}
+	return false
+}
+
+// documentedVariables returns the variables named in the reference's tables.
+func documentedVariables(t *testing.T) map[string]struct{} {
+	t.Helper()
+
+	raw, err := os.ReadFile(configDocPath)
+	require.NoError(t, err)
+
+	documented := make(map[string]struct{})
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+		cells := strings.Split(strings.Trim(line, "|"), "|")
+		match := configDocVariablePattern.FindStringSubmatch(strings.TrimSpace(cells[0]))
+		if match == nil {
+			continue
+		}
+		documented[match[1]] = struct{}{}
+	}
+	return documented
+}
+
+// sortedNames keeps failure output stable across runs.
+func sortedNames(set map[string]struct{}) []string {
+	names := make([]string, 0, len(set))
+	for name := range set {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/config_doc_test.go
+++ b/config_doc_test.go
@@ -17,7 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const configDocPath = "docs/configuration.md"
+// configDocGlobs are the files a variable may be documented in. The guard
+// deliberately does not name one canonical file: the reference has lived in
+// docs/ and in the README at different times, and #102 adds a second one, so
+// pinning a path would make this test fail for a reason that has nothing to do
+// with whether the variable is documented.
+var configDocGlobs = []string{"README.md", "docs/*.md"}
 
 // configDocVariablePattern matches the first cell of a reference table row: a
 // single backticked SHOUTY_NAME and nothing else. Requiring the whole cell to
@@ -35,7 +40,7 @@ func TestConfigDoc_AllVariablesDocumented(t *testing.T) {
 
 	for _, name := range sortedNames(inSource) {
 		assert.Contains(t, documented, name,
-			"%s is read by the server but has no row in %s", name, configDocPath)
+			"%s is read by the server but has no reference-table row in %s", name, configDocGlobs)
 	}
 }
 
@@ -45,7 +50,7 @@ func TestConfigDoc_NoStaleVariables(t *testing.T) {
 
 	for _, name := range sortedNames(documented) {
 		assert.Contains(t, inSource, name,
-			"%s has a row in %s but is not read anywhere in the module", name, configDocPath)
+			"%s has a reference-table row in %s but is not read anywhere in the module", name, documented[name])
 	}
 }
 
@@ -57,7 +62,7 @@ func TestConfigDoc_ParsesVariables(t *testing.T) {
 	require.NotEmpty(t, inSource, "the AST walk found no environment variables; the extractor is broken")
 
 	documented := documentedVariables(t)
-	require.NotEmpty(t, documented, "no variables parsed out of %s; the table format may have changed", configDocPath)
+	require.NotEmpty(t, documented, "no variables parsed out of %s; the table format may have changed", configDocGlobs)
 }
 
 // TestConfigDoc_ExcludesTestOnlyVariables pins the walk's exclusion of _test.go
@@ -80,7 +85,7 @@ func TestConfigDoc_ExcludesTestOnlyVariables(t *testing.T) {
 	documented := documentedVariables(t)
 	for _, name := range sortedNames(testOnly) {
 		assert.NotContains(t, documented, name,
-			"%s is read only by tests and should not be in %s", name, configDocPath)
+			"%s is read only by tests and should not be in the operator reference", name)
 	}
 }
 
@@ -241,31 +246,62 @@ func isEnvRead(call *ast.CallExpr, readers map[string]struct{}) bool {
 	return false
 }
 
-// documentedVariables returns the variables named in the reference's tables.
-func documentedVariables(t *testing.T) map[string]struct{} {
+// documentedVariables returns every variable named in a reference table across
+// the operator-facing docs, mapped to the file it was found in so a failure can
+// name the file to edit.
+func documentedVariables(t *testing.T) map[string]string {
 	t.Helper()
 
-	raw, err := os.ReadFile(configDocPath)
-	require.NoError(t, err)
+	documented := make(map[string]string)
+	for _, path := range configDocFiles(t) {
+		raw, err := os.ReadFile(path)
+		require.NoError(t, err)
 
-	documented := make(map[string]struct{})
-	for _, line := range strings.Split(string(raw), "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "|") {
-			continue
+		for _, line := range strings.Split(string(raw), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "|") {
+				continue
+			}
+			cells := strings.Split(strings.Trim(line, "|"), "|")
+			match := configDocVariablePattern.FindStringSubmatch(strings.TrimSpace(cells[0]))
+			if match == nil {
+				continue
+			}
+			if _, seen := documented[match[1]]; !seen {
+				documented[match[1]] = path
+			}
 		}
-		cells := strings.Split(strings.Trim(line, "|"), "|")
-		match := configDocVariablePattern.FindStringSubmatch(strings.TrimSpace(cells[0]))
-		if match == nil {
-			continue
-		}
-		documented[match[1]] = struct{}{}
 	}
 	return documented
 }
 
-// sortedNames keeps failure output stable across runs.
-func sortedNames(set map[string]struct{}) []string {
+// configDocFiles expands configDocGlobs, skipping docs/superpowers — those are
+// design specs and implementation plans, not operator documentation, and a
+// variable named in a table there is not documented for the person deploying
+// this.
+func configDocFiles(t *testing.T) []string {
+	t.Helper()
+
+	var paths []string
+	for _, glob := range configDocGlobs {
+		matches, err := filepath.Glob(glob)
+		require.NoError(t, err)
+		for _, path := range matches {
+			if strings.HasPrefix(filepath.ToSlash(path), "docs/superpowers/") {
+				continue
+			}
+			paths = append(paths, path)
+		}
+	}
+	require.NotEmpty(t, paths, "no documentation files matched %s", configDocGlobs)
+	sort.Strings(paths)
+	return paths
+}
+
+// sortedNames keeps failure output stable across runs. It is generic over the
+// map's value type so it serves both the presence sets and the
+// variable-to-file map.
+func sortedNames[V any](set map[string]V) []string {
 	names := make([]string, 0, len(set))
 	for name := range set {
 		names = append(names, name)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,174 @@
+# Configuration reference
+
+Every environment variable the server reads, what it defaults to, and what
+happens when it is set wrong. This is the complete list — it is checked against
+the source by `TestConfigDoc_AllVariablesDocumented`, which fails the build if a
+variable is added to the code without a row here, or if a row here names a
+variable nothing reads any more.
+
+## How values are read
+
+The server is configured entirely through the process environment. There is no
+configuration file and no command-line flags.
+
+**Everything is read once, at startup.** Changing a variable requires a restart;
+nothing here is re-read per request.
+
+**An empty value means unset.** `PORT=""` is the same as not setting `PORT` at
+all — the default applies.
+
+**Durations** use Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration)
+syntax: `30s`, `5m`, `24h`, `2160h`. There is no day or week unit; 90 days is
+`2160h`.
+
+**Booleans** use Go's [`strconv.ParseBool`](https://pkg.go.dev/strconv#ParseBool),
+which accepts `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`,
+`false`, `False` — **and nothing else**. `yes`, `no`, `on` and `off` are *not*
+booleans here: they fail to parse, and a value that fails to parse falls back to
+the default. `ADMIN_UI_ENABLED=no` therefore leaves the admin UI **on**. Use
+`false`.
+
+A bad value fails in one of three ways, noted per variable below:
+
+| Failure mode | What happens |
+|---|---|
+| Warn and default | The value is ignored, the default is used, and a `WARN` line naming the key and the value is logged. Most variables behave this way. |
+| Refuse to start | The server logs an `ERROR` and exits with status 1. |
+| Panic | The process crashes with a stack trace. Only `STALENESS_THRESHOLD` does this. |
+
+### Under Docker Compose
+
+[`docker-compose.yml`](../docker-compose.yml) passes only the variables listed
+in its `environment:` block into the container — today `PORT`, `DATABASE_URL`,
+`STALENESS_THRESHOLD`, `JWT_SECRET` and `RIDER_MODE_ENABLED`. Exporting any
+other variable in your shell has **no effect** on a Compose-run server; add it
+to that block (or an `env_file`) instead. Compose itself refuses to start
+without `JWT_SECRET`; the 32-byte minimum is the server's own check.
+
+## Core server
+
+| Variable | Default | Status | Purpose |
+|---|---|---|---|
+| `PORT` | `8080` | Optional | TCP port to listen on. The server binds `:$PORT`. |
+| `DATABASE_URL` | `postgres://postgres:postgres@localhost:5432/vehicle_positions?sslmode=disable` | Recommended in production | PostgreSQL connection string, used for both the connection pool and the migrations run at startup. A database that cannot be reached, or a migration that fails, **refuses to start**. |
+| `JWT_SECRET` | — | **Required** | HMAC-SHA256 signing key for driver, admin and rider tokens. The server **refuses to start** when it is unset or shorter than 32 bytes. |
+| `STALENESS_THRESHOLD` | `5m` | Optional | How long a vehicle stays in the GTFS-RT feed after its last report. Also the window used to seed the tracker from the database at startup, and what the admin UI calls a stale vehicle. Unparseable: warn and default. **A value that parses to zero or a negative duration panics** — the tracker rejects a non-positive window rather than dropping every vehicle. |
+| `READ_TIMEOUT` | `15s` | Optional | `http.Server.ReadTimeout` — the deadline for reading an entire request, headers and body. Warn and default. |
+| `WRITE_TIMEOUT` | `15s` | Optional | `http.Server.WriteTimeout` — the deadline for writing the response. Warn and default. |
+| `IDLE_TIMEOUT` | `60s` | Optional | `http.Server.IdleTimeout` — how long a keep-alive connection may sit idle. Warn and default. |
+
+`STALENESS_THRESHOLD` is not the same as the ±5 minute skew check applied to the
+`timestamp` in a location report; that one is request validation and is not
+configurable.
+
+## Admin UI and first-admin bootstrap
+
+| Variable | Default | Status | Purpose |
+|---|---|---|---|
+| `ADMIN_UI_ENABLED` | `true` | Optional | Serve the admin web UI at `/admin`. Set to `false` to unregister those routes entirely — they then return 404. Unparseable: warn and default, so the UI stays on. |
+| `ADMIN_BOOTSTRAP_EMAIL` | — | Recommended on a new deployment | Email address for the initial admin account. |
+| `ADMIN_BOOTSTRAP_PASSWORD` | — | Recommended on a new deployment | Password for that account; minimum 8 characters. A shorter one **refuses to start**. |
+
+Bootstrap runs only when **both** variables are set and non-empty, and only when
+the `users` table holds zero admins — it is a no-op on every later boot, and
+changing the values afterwards does not change an account that already exists.
+Once an admin exists, both variables can be removed.
+
+## Security and proxying
+
+| Variable | Default | Status | Purpose |
+|---|---|---|---|
+| `TRUST_PROXY_HEADERS` | `false` | Required behind a reverse proxy | Trust `X-Forwarded-For` and `X-Forwarded-Proto`. Controls which address the per-IP rate limiters bucket on, whether the admin session cookie is marked `Secure`, and the client IP recorded for rider requests. Unparseable: warn and default. |
+
+## Location retention
+
+Off by default: location history is kept forever until an agency opts in. The
+operational notes — that deletion is permanent, that retention is measured from
+server receipt time, and that the first pass runs one interval after startup —
+are under *Data Retention & Privacy* in the [README](../README.md).
+
+| Variable | Default | Status | Purpose |
+|---|---|---|---|
+| `LOCATION_RETENTION_PERIOD` | `0` | Optional | How long to keep rows in `location_points`. **`0` means keep forever**, not "keep nothing" — it disables pruning. Any other value enables it. A negative duration logs an `ERROR` and leaves retention **off**; the server still starts. |
+| `LOCATION_PRUNE_INTERVAL` | `1h` | Optional | How often the pruner sweeps. Read **only when `LOCATION_RETENTION_PERIOD` is non-zero.** A value that parses to zero or a negative duration disables retention entirely rather than falling back to `1h`. |
+| `LOCATION_PRUNE_BATCH_SIZE` | `10000` | Optional | Maximum rows deleted per statement, each batch in its own transaction. Read **only when `LOCATION_RETENTION_PERIOD` is non-zero.** Must be a positive 32-bit integer; anything else warns and defaults. |
+
+An interval longer than the retention period is allowed — points then outlive
+the period by up to one interval, and the server logs a `WARN` saying so.
+
+## Rider mode
+
+Off by default. The narrative introduction — what rider mode does, the API, and
+how rider tokens differ from driver and admin tokens — is in the
+[Rider mode section of the README](../README.md#rider-mode-crowdsourced-positions),
+which carries the same defaults in the context they are read.
+
+| Variable | Default | Status | Purpose |
+|---|---|---|---|
+| `RIDER_MODE_ENABLED` | `false` | Optional | Register the rider routes, start the engine, and merge rider positions into the feed. When off, rider routes are not registered at all. Unparseable: warn and default. |
+| `GTFS_STATIC_URL` | — | **Required when rider mode is on** | GTFS static zip to verify rider reports against — an `http(s)://` URL or a local file path. The server **refuses to start** if rider mode is on and this is missing, or if the feed cannot be downloaded or parsed at startup. Ignored when rider mode is off. |
+| `GTFS_STATIC_REFRESH` | `24h` | Optional | How often to re-download the zip and rebuild the index. A failed refresh keeps the previous index and logs. Must be positive; zero, negative or unparseable warns and defaults. |
+| `TRUSTED_GTFS_RT_URLS` | empty | Optional | Comma-separated external GTFS-RT VehiclePositions feeds used to corroborate rider reports. Surrounding spaces and empty entries are dropped, so a trailing comma is not a feed. URLs are not validated at startup: an unreachable one fails per poll, is recorded in the feed health, and leaves that feed's last-known entities in place. The server's own driver-reported positions are always trusted; with no external feed, a trip no driver reports has corroboration `unavailable`. |
+| `TRUSTED_FEED_POLL` | `30s` | Optional | How often each trusted feed is polled. Must be positive; zero, negative or unparseable warns and defaults. |
+| `TRUSTED_FEED_MAX_AGE` | `5m` | Optional | Trusted entities older than this are dropped from the snapshot. Must be positive; zero, negative or unparseable warns and defaults. |
+| `RIDER_JWT_TTL` | `8760h` | Optional | Rider token lifetime (one year by default). Must be positive; zero, negative or unparseable warns and defaults. |
+| `RIDER_POINT_RETENTION` | `168h` | Optional | `ride_points` rows older than this are deleted. The sweep runs hourly and that interval is not configurable. Must be positive; zero, negative or unparseable warns and defaults. |
+| `RIDER_MAX_SHAPE_DISTANCE` | `60` | Optional | Metres from the trip shape — plus the reported accuracy — within which a point still matches. Must be positive; zero, negative, `NaN`, `Inf` or unparseable warns and defaults. |
+| `RIDER_MAX_SPEED` | `35` | Optional | Metres per second; an implied along-shape speed above this is treated as implausible. Must be positive; zero, negative, `NaN`, `Inf` or unparseable warns and defaults. |
+| `RIDER_SCHEDULE_EARLY` | `15m` | Optional | How far ahead of schedule a trip may run and still be matched. Unparseable warns and defaults; unlike the durations above, zero and negative values are accepted, since this is a tolerance window rather than an interval. |
+| `RIDER_SCHEDULE_LATE` | `90m` | Optional | How far behind schedule a trip may run and still be matched. Same handling as `RIDER_SCHEDULE_EARLY`. |
+| `RIDER_POINT_MAX_AGE` | `90s` | Optional | A ride whose latest accepted point is older than this stops contributing to the feed. Must be positive; zero, negative or unparseable warns and defaults. |
+
+Rider mode shares `JWT_SECRET` with the rest of the API. Rider tokens carry
+`role: "rider"` and are rejected on the driver and admin APIs, and vice versa.
+
+## Settings that change the security posture
+
+The defaults are chosen for a first local run, not for every deployment. These
+five are worth a deliberate decision before going to production.
+
+**`JWT_SECRET` is the whole authentication system.** Anyone holding it can mint
+a token for any driver, rider or admin. Generate it with `openssl rand -hex 32`,
+keep it out of version control, and note that rotating it invalidates every
+issued token at once — every driver app and rider app has to sign in again.
+
+**`ADMIN_UI_ENABLED` defaults to `true`.** An operator upgrading from a version
+that predates the admin UI newly serves `/admin/login` on the same port as the
+API, without opting in. If that surface should not be reachable, set it to
+`false` before deploying — and remember that `no` is not a boolean, so it would
+leave the UI on.
+
+**`TRUST_PROXY_HEADERS` has no safe universal default.** Both directions are
+wrong somewhere:
+
+- Left `false` behind a reverse proxy, every request appears to come from the
+  proxy's address, so the per-IP login rate limiter buckets the whole internet
+  as one client — a handful of failed logins locks out every real operator, and
+  the session cookie is not marked `Secure` because the server cannot see that
+  the original request was HTTPS.
+- Set `true` when the server is directly reachable, any client can send its own
+  `X-Forwarded-For` and choose which bucket its login attempts land in, which
+  defeats the rate limiter entirely.
+
+Set it to `true` if and only if the server sits behind a proxy that overwrites
+those headers itself.
+
+**`ADMIN_BOOTSTRAP_PASSWORD` is a password in the process environment.** It
+persists in shell history and is readable from the process listing and from
+`docker inspect`. Prefer generating it (`openssl rand -hex 16`), and unset both
+bootstrap variables once the account exists — they have no further effect, and
+the server does not need them again.
+
+**`LOCATION_RETENTION_PERIOD` defaults to keeping driver GPS traces forever.**
+`location_points` is a per-driver movement history, and the default of `0` never
+deletes any of it. Agencies should pick a period consistent with local law and
+their own driver-privacy policy rather than inheriting the default.
+
+## Related documentation
+
+- [`docs/development.md`](development.md) — local setup, the variables a
+  development run needs, and troubleshooting
+- [README — Rider mode](../README.md#rider-mode-crowdsourced-positions) — what
+  rider mode does, with the same defaults in context
+- [README](../README.md), under *Data Retention & Privacy* — the operator
+  notes behind the retention settings

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,6 +2,8 @@
 
 This guide is for contributors who want to run, verify, and iterate on the current Go server in this repository.
 
+The environment variables below are the ones a development run needs. For the complete list — every variable the server reads, its default, and what happens when it is set wrong — see [configuration.md](configuration.md).
+
 ## Scope
 
 The current implementation focuses on:


### PR DESCRIPTION
### Summary
`main` reads 27 environment variables. Rider mode's 13 are documented in the README, retention's 3 landed with #93, and the rest live in `docs/development.md` as prose inside a dev-setup narrative — except `READ_TIMEOUT`, `WRITE_TIMEOUT`, `IDLE_TIMEOUT` and `TRUST_PROXY_HEADERS`, which are documented nowhere. An operator deploying this has no single place to learn what they can configure, and `TRUST_PROXY_HEADERS` in particular is security-relevant: left `false` behind a reverse proxy, per-IP rate limiting keys off the proxy's address and throttles every client as one, and the admin session cookie is not marked `Secure`. This adds `docs/configuration.md` as the complete reference — every variable, its default, whether it is required, and what happens when it is set wrong — plus a test that keeps it true.
### What the verification pass turned up
Every default and failure mode in the reference was read back against its call site rather than copied from the existing docs. Four things that were not written down anywhere:
- **`STALENESS_THRESHOLD` must be positive.** `envDurationOrDefault` happily parses `0s` or `-1m`, and `NewTracker` (`tracker.go:33`) panics on a non-positive window. That is the only variable in the system whose bad value crashes the process rather than warning and defaulting, or exiting cleanly.
- **`no` is not a boolean.** `envBoolOrDefault` uses `strconv.ParseBool`, which rejects `yes`/`no`/`on`/`off`, and an unparseable value falls back to the default. So `ADMIN_UI_ENABLED=no` leaves the admin UI **on** — the opposite of what the operator who typed it intended. Same for `TRUST_PROXY_HEADERS=yes`.
- **`LOCATION_PRUNE_INTERVAL=0` disables retention entirely** rather than falling back to `1h`: it reaches `NewLocationPruner`, which rejects a non-positive interval, and `main.go` logs and carries on with pruning off. `LOCATION_PRUNE_BATCH_SIZE=0`, by contrast, warns and defaults — the two neighbouring variables fail differently.
- **Docker Compose forwards only five variables** (`PORT`, `DATABASE_URL`, `STALENESS_THRESHOLD`, `JWT_SECRET`, `RIDER_MODE_ENABLED`). Exporting anything else in your shell has no effect on a Compose-run server, which makes "`TRUST_PROXY_HEADERS=true` didn't work" a plausible support question.
Two claims elsewhere were checked and are correct as written: `GTFS_STATIC_URL` is required only when `RIDER_MODE_ENABLED=true` and exits 1 when missing, and `ADMIN_BOOTSTRAP_*` apply only when the `users` table holds zero admins. `LOCATION_RETENTION_PERIOD=0` means keep forever, and the reference says so in bold, because it is the one default here that reads backwards.
### The guard
`config_doc_test.go` walks the module with `go/ast`, collects every string literal passed to something that reads the environment, and compares that set against the variables named in the reference — **in both directions**, so a new undocumented variable fails the build and so does a documented one that has been removed.
The helper names are **discovered, not listed**. A function qualifies as an env reader when it forwards its own first string parameter to something that already reads the environment, iterated to a fixed point. That finds `os.Getenv`, the four `env*OrDefault` helpers in `main.go`, and `rider_wiring.go`'s own `envFloatOrDefault` plus its two wrappers over `envDurationOrDefault` — and will find a helper added later without anyone having to remember to update this test. A hardcoded list would have missed the rider wrappers and under-reported silently, which is worse than no guard.
`TestConfigDoc_ParsesVariables` requires both extracted sets to be non-empty, so neither comparison can pass vacuously if an extractor silently returns nothing. Nested modules and `testdata` are skipped for the same reason the Go toolchain skips them; `_test.go` files are excluded so test-only variables are not treated as operator-facing configuration, and `TestConfigDoc_ExcludesTestOnlyVariables` pins that by deriving the test-only set and requiring it non-empty — if the walk stopped skipping test files, that set would be empty and the test would fail.
**Verified non-vacuous by mutation**, all three restored afterwards:
| Mutation | Result |
|---|---|
| `os.Getenv("BOGUS_VAR")` added to `proxy.go` | `TestConfigDoc_AllVariablesDocumented` fails: *BOGUS_VAR is read by the server but has no row in docs/configuration.md* |
| A `REMOVED_VAR` row added to the reference | `TestConfigDoc_NoStaleVariables` fails: *REMOVED_VAR has a row in docs/configuration.md but is not read anywhere in the module* |
| Reference stripped of its table rows | `TestConfigDoc_ParsesVariables` fails: *no variables parsed out of docs/configuration.md* |
The guard needs no database.
### What this does not change
No behaviour. No new variables, no changed defaults, no new validation, no migration, no route changes — this documents what exists.
The rider table and the retention table stay where they are, in the sections whose context they belong to. Relocating them into a central file would make those sections worse to read, so the reference is the complete index and the two existing tables gain a one-line pointer to it.
**That is a real tradeoff, not an oversight:** a handful of defaults are now stated in two places and can drift apart. I chose duplication over churning recently-written docs. The guard compares variable *names*, so it catches a variable that disappears from the code but not a default that disagrees between the README and the reference. A follow-up could extend it to compare default values across both tables and close that gap.
`FEED_AUTH_ENABLED` (#97) is deliberately absent — it has not merged into `main`, and documenting a variable nothing reads would fail this PR's own guard. It needs a row here when #97 lands, which is exactly the signal the guard exists to give.
### Test plan
- [x] `go fmt ./...`, `go vet ./...`, `go build ./...`, `go test ./...`, `go mod tidy` — all clean, `go.mod`/`go.sum` unchanged
- [x] Every documented default and failure mode read back against its call site
- [x] Guard proven to fail in both directions, and non-vacuously, by mutation
- [x] Test-only variables (`WRITE_FIXTURE`) correctly excluded
- [x] Branched off latest `upstream/main`; re-checked for new variables before opening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive configuration reference covering server environment variables, defaults, parsing, startup behavior, and related security settings.
  - Linked configuration guidance from the README and Development Guide.
- **Tests**
  - Added automated checks to ensure environment variables read by the server remain accurately documented and that stale or test-only entries are identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->