### PR TITLE
Search and filter the admin vehicle and user lists

### DIFF
--- a/admin_page_handlers.go
+++ b/admin_page_handlers.go
@@ -432,13 +432,20 @@ type vehicleRow struct {
 	Driver    string
 }
 
-// vehiclesPageURL builds an /admin/vehicles link preserving the inactive
-// filter with page set to the given page number, for the prev/next
-// pagination links.
-func vehiclesPageURL(includeInactive bool, page int) string {
+// vehiclesPageURL builds an /admin/vehicles link preserving the current
+// filter values with page set to the given page number, for the prev/next
+// pagination links and the show/hide-deactivated toggle. Every filter has to
+// be threaded through, or page 2 of a search silently shows unfiltered rows.
+func vehiclesPageURL(f VehicleFilter, page int) string {
 	v := url.Values{}
-	if includeInactive {
+	if f.IncludeInactive {
 		v.Set("include_inactive", "1")
+	}
+	if f.AgencyTag != "" {
+		v.Set("agency_tag", f.AgencyTag)
+	}
+	if f.Q != "" {
+		v.Set("q", f.Q)
 	}
 	v.Set("page", strconv.Itoa(page))
 	return "/admin/vehicles?" + v.Encode()
@@ -452,10 +459,23 @@ func vehiclesPageURL(includeInactive bool, page int) string {
 func (ui *adminUI) vehiclesPage(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	query := r.URL.Query()
-	includeInactive := query.Get("include_inactive") == "1"
+
+	q := query.Get("q")
+	if err := validateListQuery(q); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	page := adminPageNumber(query)
 
-	vehicles, err := ui.vehiclePager.ListVehiclesPage(ctx, includeInactive, adminPageSize+1, int32(adminPageOffset(page)))
+	filter := VehicleFilter{
+		IncludeInactive: query.Get("include_inactive") == "1",
+		AgencyTag:       query.Get("agency_tag"),
+		Q:               q,
+		Limit:           adminPageSize + 1,
+		Offset:          int32(adminPageOffset(page)),
+	}
+
+	vehicles, err := ui.vehiclePager.ListVehiclesPage(ctx, filter)
 	if err != nil {
 		slog.Error("vehicles: list vehicles page", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -489,15 +509,23 @@ func (ui *adminUI) vehiclesPage(w http.ResponseWriter, r *http.Request) {
 		rows = append(rows, row)
 	}
 
+	// The show/hide-deactivated link flips only that one filter, so a search
+	// in progress survives the toggle.
+	toggled := filter
+	toggled.IncludeInactive = !filter.IncludeInactive
+
 	ui.renderAdmin(w, r, http.StatusOK, "vehicles.html", map[string]interface{}{
-		"Title":           "Vehicles",
-		"Page":            "vehicles",
-		"Vehicles":        rows,
-		"IncludeInactive": includeInactive,
-		"PageNum":         page,
-		"HasMore":         hasMore,
-		"PrevURL":         vehiclesPageURL(includeInactive, page-1),
-		"NextURL":         vehiclesPageURL(includeInactive, page+1),
+		"Title":             "Vehicles",
+		"Page":              "vehicles",
+		"Vehicles":          rows,
+		"IncludeInactive":   filter.IncludeInactive,
+		"AgencyTag":         filter.AgencyTag,
+		"Q":                 filter.Q,
+		"PageNum":           page,
+		"HasMore":           hasMore,
+		"PrevURL":           vehiclesPageURL(filter, page-1),
+		"NextURL":           vehiclesPageURL(filter, page+1),
+		"ToggleInactiveURL": vehiclesPageURL(toggled, 1),
 	})
 }
 
@@ -665,10 +693,21 @@ type userRow struct {
 	VehicleCount int
 }
 
-// usersPageURL builds an /admin/users link with page set to the given page
-// number, for the prev/next pagination links.
-func usersPageURL(page int) string {
+// usersPageURL builds an /admin/users link preserving the current filter
+// values with page set to the given page number, for the prev/next
+// pagination links and the active-only toggle. Every filter has to be
+// threaded through, or page 2 of a search silently shows unfiltered rows.
+func usersPageURL(f UserFilter, page int) string {
 	v := url.Values{}
+	if f.Role != "" {
+		v.Set("role", f.Role)
+	}
+	if f.Q != "" {
+		v.Set("q", f.Q)
+	}
+	if f.ActiveOnly {
+		v.Set("active", "1")
+	}
 	v.Set("page", strconv.Itoa(page))
 	return "/admin/users?" + v.Encode()
 }
@@ -682,9 +721,29 @@ func usersPageURL(page int) string {
 // lookups per request, whatever the table holds.
 func (ui *adminUI) usersPage(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	page := adminPageNumber(r.URL.Query())
+	query := r.URL.Query()
 
-	users, err := ui.userPager.ListUsersPage(ctx, adminPageSize+1, int32(adminPageOffset(page)))
+	q := query.Get("q")
+	if err := validateListQuery(q); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	role := query.Get("role")
+	if !validUserRoleFilter(role) {
+		http.Error(w, "role must be driver or admin", http.StatusBadRequest)
+		return
+	}
+	page := adminPageNumber(query)
+
+	filter := UserFilter{
+		Role:       role,
+		Q:          q,
+		ActiveOnly: query.Get("active") == "1",
+		Limit:      adminPageSize + 1,
+		Offset:     int32(adminPageOffset(page)),
+	}
+
+	users, err := ui.userPager.ListUsersPage(ctx, filter)
 	if err != nil {
 		slog.Error("users: list users page", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -713,14 +772,23 @@ func (ui *adminUI) usersPage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	// The active-only link flips only that one filter, so a search in
+	// progress survives the toggle.
+	toggled := filter
+	toggled.ActiveOnly = !filter.ActiveOnly
+
 	ui.renderAdmin(w, r, http.StatusOK, "users.html", map[string]interface{}{
-		"Title":   "Users",
-		"Page":    "users",
-		"Users":   rows,
-		"PageNum": page,
-		"HasMore": hasMore,
-		"PrevURL": usersPageURL(page - 1),
-		"NextURL": usersPageURL(page + 1),
+		"Title":           "Users",
+		"Page":            "users",
+		"Users":           rows,
+		"Role":            filter.Role,
+		"Q":               filter.Q,
+		"ActiveOnly":      filter.ActiveOnly,
+		"PageNum":         page,
+		"HasMore":         hasMore,
+		"PrevURL":         usersPageURL(filter, page-1),
+		"NextURL":         usersPageURL(filter, page+1),
+		"ToggleActiveURL": usersPageURL(toggled, 1),
 	})
 }
 

--- a/admin_page_handlers_test.go
+++ b/admin_page_handlers_test.go
@@ -348,6 +348,10 @@ func (erroringAdminStats) CountActiveTrips(_ context.Context) (int, error) {
 // database.
 type fakeVehicleStore struct {
 	vehicles map[string]*VehicleResponse
+
+	// Recorded by ListVehiclesPage so the page tests can assert which filter
+	// the handler built from the query string.
+	gotFilter VehicleFilter
 }
 
 func newFakeVehicleStore(vehicles ...VehicleResponse) *fakeVehicleStore {
@@ -369,8 +373,11 @@ func (f *fakeVehicleStore) ListVehicles(_ context.Context) ([]VehicleResponse, e
 
 // ListVehiclesPage orders by id so pages are deterministic; the real store
 // orders by created_at DESC with an id tiebreaker. Only the totality of the
-// order matters to the page handler.
-func (f *fakeVehicleStore) ListVehiclesPage(_ context.Context, includeInactive bool, limit, offset int32) ([]VehicleResponse, error) {
+// order matters to the page handler. Q and AgencyTag are recorded rather
+// than applied — matching them is the store's job, tested against Postgres.
+func (f *fakeVehicleStore) ListVehiclesPage(_ context.Context, filter VehicleFilter) ([]VehicleResponse, error) {
+	f.gotFilter = filter
+
 	ids := make([]string, 0, len(f.vehicles))
 	for id := range f.vehicles {
 		ids = append(ids, id)
@@ -380,12 +387,12 @@ func (f *fakeVehicleStore) ListVehiclesPage(_ context.Context, includeInactive b
 	all := make([]VehicleResponse, 0, len(ids))
 	for _, id := range ids {
 		v := f.vehicles[id]
-		if !includeInactive && !v.Active {
+		if !filter.IncludeInactive && !v.Active {
 			continue
 		}
 		all = append(all, *v)
 	}
-	return pageSlice(all, limit, offset), nil
+	return pageSlice(all, filter.Limit, filter.Offset), nil
 }
 
 func (f *fakeVehicleStore) GetVehicle(_ context.Context, id string) (*VehicleResponse, error) {
@@ -509,12 +516,20 @@ func TestVehiclesPageInactiveFilter(t *testing.T) {
 // UI and returns the rendered body, failing the test on a non-200.
 func getAdminPage(t *testing.T, mux *http.ServeMux, path string) string {
 	t.Helper()
+	w := requestAdminPage(t, mux, path)
+	require.Equal(t, http.StatusOK, w.Code)
+	return w.Body.String()
+}
+
+// requestAdminPage is getAdminPage without the 200 requirement, for the
+// tests that assert a rejected request's status and message.
+func requestAdminPage(t *testing.T, mux *http.ServeMux, path string) *httptest.ResponseRecorder {
+	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, path, nil)
 	req.AddCookie(cookieFor(t, "admin"))
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code)
-	return w.Body.String()
+	return w
 }
 
 // seedVehicles builds n active vehicles with zero-padded ids so a label like
@@ -757,6 +772,10 @@ type fakeUserStore struct {
 	users           map[int64]*UserResponse
 	nextID          int64
 	passwordUpdates map[int64]string
+
+	// Recorded by ListUsersPage so the page tests can assert which filter
+	// the handler built from the query string.
+	gotFilter UserFilter
 }
 
 func newFakeUserStore(users ...UserResponse) *fakeUserStore {
@@ -781,8 +800,12 @@ func (f *fakeUserStore) ListUsers(_ context.Context) ([]UserResponse, error) {
 }
 
 // ListUsersPage orders by id so pages are deterministic; the real store
-// orders by created_at DESC with an id tiebreaker.
-func (f *fakeUserStore) ListUsersPage(_ context.Context, limit, offset int32) ([]UserResponse, error) {
+// orders by created_at DESC with an id tiebreaker. Role, Q and ActiveOnly
+// are recorded rather than applied — matching them is the store's job,
+// tested against Postgres.
+func (f *fakeUserStore) ListUsersPage(_ context.Context, filter UserFilter) ([]UserResponse, error) {
+	f.gotFilter = filter
+
 	ids := make([]int64, 0, len(f.users))
 	for id := range f.users {
 		ids = append(ids, id)
@@ -793,7 +816,7 @@ func (f *fakeUserStore) ListUsersPage(_ context.Context, limit, offset int32) ([
 	for _, id := range ids {
 		all = append(all, *f.users[id])
 	}
-	return pageSlice(all, limit, offset), nil
+	return pageSlice(all, filter.Limit, filter.Offset), nil
 }
 
 func (f *fakeUserStore) GetUser(_ context.Context, id int64) (*UserResponse, error) {
@@ -1607,4 +1630,223 @@ func TestTripsPageVehicleSelectActiveOnly(t *testing.T) {
 	body := w.Body.String()
 	assert.Contains(t, body, "Active Bus")
 	assert.NotContains(t, body, "Retired Bus")
+}
+
+// TestVehiclesPageURL_PreservesFilters pins that every vehicle filter is
+// threaded into the prev/next links. Without this, page 2 of a search
+// silently drops the filter and shows unfiltered rows, and no other test
+// notices.
+func TestVehiclesPageURL_PreservesFilters(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter VehicleFilter
+		page   int
+		want   string
+	}{
+		{
+			name: "no filters",
+			page: 2,
+			want: "/admin/vehicles?page=2",
+		},
+		{
+			name:   "search term",
+			filter: VehicleFilter{Q: "bus-10"},
+			page:   3,
+			want:   "/admin/vehicles?page=3&q=bus-10",
+		},
+		{
+			name:   "agency tag",
+			filter: VehicleFilter{AgencyTag: "nairobi"},
+			page:   2,
+			want:   "/admin/vehicles?agency_tag=nairobi&page=2",
+		},
+		{
+			name:   "every filter at once",
+			filter: VehicleFilter{IncludeInactive: true, AgencyTag: "nairobi", Q: "bus 10"},
+			page:   4,
+			want:   "/admin/vehicles?agency_tag=nairobi&include_inactive=1&page=4&q=bus+10",
+		},
+		{
+			name:   "paging fields are not query params",
+			filter: VehicleFilter{Q: "bus", Limit: 25, Offset: 50},
+			page:   2,
+			want:   "/admin/vehicles?page=2&q=bus",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, vehiclesPageURL(tt.filter, tt.page))
+		})
+	}
+}
+
+// TestUsersPageURL_PreservesFilters pins that every user filter is threaded
+// into the prev/next links, for the same reason as the vehicle case above.
+func TestUsersPageURL_PreservesFilters(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter UserFilter
+		page   int
+		want   string
+	}{
+		{
+			name: "no filters",
+			page: 2,
+			want: "/admin/users?page=2",
+		},
+		{
+			name:   "search term",
+			filter: UserFilter{Q: "amina"},
+			page:   3,
+			want:   "/admin/users?page=3&q=amina",
+		},
+		{
+			name:   "role",
+			filter: UserFilter{Role: roleDriver},
+			page:   2,
+			want:   "/admin/users?page=2&role=driver",
+		},
+		{
+			name:   "every filter at once",
+			filter: UserFilter{Role: roleAdmin, Q: "carol n", ActiveOnly: true},
+			page:   4,
+			want:   "/admin/users?active=1&page=4&q=carol+n&role=admin",
+		},
+		{
+			name:   "paging fields are not query params",
+			filter: UserFilter{Q: "amina", Limit: 25, Offset: 50},
+			page:   2,
+			want:   "/admin/users?page=2&q=amina",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, usersPageURL(tt.filter, tt.page))
+		})
+	}
+}
+
+// TestVehiclesPage_Page2KeepsFilter renders page 2 of a filtered list and
+// asserts the store was asked for the same filter, with only the offset
+// moved on. The page-URL test above pins the links; this pins that a request
+// arriving on those links still filters.
+func TestVehiclesPage_Page2KeepsFilter(t *testing.T) {
+	ui := newTestAdminUI(t)
+	store := newFakeVehicleStore(seedVehicles(adminPageSize + 5)...)
+	wireFakeVehicleStore(ui, store)
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	body := getAdminPage(t, mux, "/admin/vehicles?q=bus&agency_tag=nairobi&include_inactive=1&page=2")
+
+	assert.Equal(t, "bus", store.gotFilter.Q, "q must survive to page 2")
+	assert.Equal(t, "nairobi", store.gotFilter.AgencyTag, "agency_tag must survive to page 2")
+	assert.True(t, store.gotFilter.IncludeInactive, "include_inactive must survive to page 2")
+	assert.Equal(t, int32(adminPageOffset(2)), store.gotFilter.Offset, "only the offset should move")
+	assert.Contains(t, body, `href="/admin/vehicles?agency_tag=nairobi&amp;include_inactive=1&amp;page=1&amp;q=bus"`,
+		"the previous link must carry every filter back")
+}
+
+// TestUsersPage_Page2KeepsFilter is the user-list counterpart to
+// TestVehiclesPage_Page2KeepsFilter.
+func TestUsersPage_Page2KeepsFilter(t *testing.T) {
+	ui := newTestAdminUI(t)
+	store := newFakeUserStore(seedUsers(adminPageSize + 5)...)
+	wireFakeUserStore(ui, store, newFakeAssignmentStore())
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	body := getAdminPage(t, mux, "/admin/users?q=driver&role=driver&active=1&page=2")
+
+	assert.Equal(t, "driver", store.gotFilter.Q, "q must survive to page 2")
+	assert.Equal(t, roleDriver, store.gotFilter.Role, "role must survive to page 2")
+	assert.True(t, store.gotFilter.ActiveOnly, "active must survive to page 2")
+	assert.Equal(t, int32(adminPageOffset(2)), store.gotFilter.Offset, "only the offset should move")
+	assert.Contains(t, body, `href="/admin/users?active=1&amp;page=1&amp;q=driver&amp;role=driver"`,
+		"the previous link must carry every filter back")
+}
+
+// TestVehiclesPage_FilterFormPrefills verifies the filter form renders the
+// current values, so an operator refining a search doesn't have to retype it,
+// and that the show/hide-deactivated toggle keeps the search in progress.
+func TestVehiclesPage_FilterFormPrefills(t *testing.T) {
+	ui := newTestAdminUI(t)
+	wireFakeVehicleStore(ui, newFakeVehicleStore(seedVehicles(3)...))
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	body := getAdminPage(t, mux, "/admin/vehicles?q=bus+10&agency_tag=nairobi")
+
+	assert.Contains(t, body, `name="q" placeholder="Search id or label" value="bus 10"`)
+	assert.Contains(t, body, `name="agency_tag" placeholder="Agency tag" value="nairobi"`)
+	// html/template escapes the "+" that url.Values uses for the space.
+	assert.Contains(t, body, `href="/admin/vehicles?agency_tag=nairobi&amp;include_inactive=1&amp;page=1&amp;q=bus&#43;10"`,
+		"the show-deactivated toggle must keep the search in progress")
+}
+
+// TestUsersPage_FilterFormPrefills is the user-list counterpart to
+// TestVehiclesPage_FilterFormPrefills, including the role select's
+// selected option.
+func TestUsersPage_FilterFormPrefills(t *testing.T) {
+	ui := newTestAdminUI(t)
+	wireFakeUserStore(ui, newFakeUserStore(seedUsers(3)...), newFakeAssignmentStore())
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	body := getAdminPage(t, mux, "/admin/users?q=amina&role=admin")
+
+	assert.Contains(t, body, `name="q" placeholder="Search name or email" value="amina"`)
+	assert.Contains(t, body, `<option value="admin" selected>Admin</option>`,
+		"the role select must show the active filter")
+	assert.Contains(t, body, `href="/admin/users?active=1&amp;page=1&amp;q=amina&amp;role=admin"`,
+		"the hide-deactivated toggle must keep the search in progress")
+}
+
+// TestVehiclesPage_RejectsOverlongQuery verifies the page enforces the same
+// length cap on q as the JSON endpoint, rather than passing an unbounded
+// search string through to Postgres.
+func TestVehiclesPage_RejectsOverlongQuery(t *testing.T) {
+	ui := newTestAdminUI(t)
+	wireFakeVehicleStore(ui, newFakeVehicleStore(seedVehicles(3)...))
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	w := requestAdminPage(t, mux, "/admin/vehicles?q="+strings.Repeat("a", maxFieldLength+1))
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), fmt.Sprintf("q must be at most %d characters", maxFieldLength))
+}
+
+// TestUsersPage_RejectsInvalidFilters verifies the user list rejects a role
+// it could never store and an over-long search string, rather than silently
+// ignoring either.
+func TestUsersPage_RejectsInvalidFilters(t *testing.T) {
+	ui := newTestAdminUI(t)
+	wireFakeUserStore(ui, newFakeUserStore(seedUsers(3)...), newFakeAssignmentStore())
+	mux := http.NewServeMux()
+	registerAdminUI(mux, ui)
+
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{name: "unknown role", query: "?role=superuser", want: "role must be driver or admin"},
+		{
+			name:  "q one past the maximum length",
+			query: "?q=" + strings.Repeat("a", maxFieldLength+1),
+			want:  fmt.Sprintf("q must be at most %d characters", maxFieldLength),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := requestAdminPage(t, mux, "/admin/users"+tt.query)
+
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), tt.want)
+		})
+	}
 }

--- a/auth.go
+++ b/auth.go
@@ -274,3 +274,9 @@ func requireRoles(secret []byte, allowCookie bool, roles ...string) func(http.Ha
 // <select> only ever submits one of these values, since form submissions
 // aren't trustworthy.
 func validUserRole(role string) bool { return slices.Contains(staffRoles, role) }
+
+// validUserRoleFilter reports whether role is a usable role *filter* value:
+// either empty, meaning "all roles", or a role a user may actually hold. It
+// mirrors validTripStatus and is shared by the users JSON endpoint and the
+// users admin page.
+func validUserRoleFilter(role string) bool { return role == "" || validUserRole(role) }

--- a/db/query.sql
+++ b/db/query.sql
@@ -23,12 +23,6 @@ FROM users
 ORDER BY created_at DESC, id DESC
 LIMIT 1000;
 
--- name: ListUsersPage :many
-SELECT id, name, email, role, active, created_at, updated_at
-FROM users
-ORDER BY created_at DESC, id DESC
-LIMIT $1 OFFSET $2;
-
 -- name: GetUserByID :one
 SELECT id, name, email, role, active, created_at, updated_at
 FROM users
@@ -69,22 +63,6 @@ SELECT id, label, agency_tag, active, created_at, updated_at
 FROM vehicles
 ORDER BY created_at DESC, id DESC
 LIMIT 1000;
-
--- name: ListVehiclesPage :many
-SELECT id, label, agency_tag, active, created_at, updated_at
-FROM vehicles
-ORDER BY created_at DESC, id DESC
-LIMIT $1 OFFSET $2;
-
--- name: ListActiveVehiclesPage :many
--- The admin vehicle list hides deactivated vehicles unless
--- ?include_inactive=1. Filtering here rather than after the fetch keeps
--- every page a full page.
-SELECT id, label, agency_tag, active, created_at, updated_at
-FROM vehicles
-WHERE active
-ORDER BY created_at DESC, id DESC
-LIMIT $1 OFFSET $2;
 
 -- name: GetVehicleByID :one
 SELECT id, label, agency_tag, active, created_at, updated_at

--- a/db/query.sql.go
+++ b/db/query.sql.go
@@ -830,58 +830,6 @@ func (q *Queries) ListActiveVehiclesByUser(ctx context.Context, userID int64) ([
 	return items, nil
 }
 
-const listActiveVehiclesPage = `-- name: ListActiveVehiclesPage :many
-SELECT id, label, agency_tag, active, created_at, updated_at
-FROM vehicles
-WHERE active
-ORDER BY created_at DESC, id DESC
-LIMIT $1 OFFSET $2
-`
-
-type ListActiveVehiclesPageParams struct {
-	Limit  int32
-	Offset int32
-}
-
-type ListActiveVehiclesPageRow struct {
-	ID        string
-	Label     string
-	AgencyTag string
-	Active    bool
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-}
-
-// The admin vehicle list hides deactivated vehicles unless
-// ?include_inactive=1. Filtering here rather than after the fetch keeps
-// every page a full page.
-func (q *Queries) ListActiveVehiclesPage(ctx context.Context, arg ListActiveVehiclesPageParams) ([]ListActiveVehiclesPageRow, error) {
-	rows, err := q.db.Query(ctx, listActiveVehiclesPage, arg.Limit, arg.Offset)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListActiveVehiclesPageRow
-	for rows.Next() {
-		var i ListActiveVehiclesPageRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.Label,
-			&i.AgencyTag,
-			&i.Active,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listRides = `-- name: ListRides :many
 SELECT id, rider_id, trip_id, start_date, route_id, vehicle_id, boarding_stop_id, destination_stop_id, status, state, corroborated, end_reason, points_total, points_matched, points_corroborated, points_contradicted, started_at, ended_at, updated_at FROM rides WHERE status = $1 ORDER BY started_at DESC, id DESC LIMIT $2 OFFSET $3
 `
@@ -1066,56 +1014,6 @@ func (q *Queries) ListUsersByVehicle(ctx context.Context, vehicleID string) ([]U
 	return items, nil
 }
 
-const listUsersPage = `-- name: ListUsersPage :many
-SELECT id, name, email, role, active, created_at, updated_at
-FROM users
-ORDER BY created_at DESC, id DESC
-LIMIT $1 OFFSET $2
-`
-
-type ListUsersPageParams struct {
-	Limit  int32
-	Offset int32
-}
-
-type ListUsersPageRow struct {
-	ID        int64
-	Name      string
-	Email     string
-	Role      string
-	Active    bool
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-}
-
-func (q *Queries) ListUsersPage(ctx context.Context, arg ListUsersPageParams) ([]ListUsersPageRow, error) {
-	rows, err := q.db.Query(ctx, listUsersPage, arg.Limit, arg.Offset)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListUsersPageRow
-	for rows.Next() {
-		var i ListUsersPageRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.Name,
-			&i.Email,
-			&i.Role,
-			&i.Active,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listVehicles = `-- name: ListVehicles :many
 SELECT id, label, agency_tag, active, created_at, updated_at
 FROM vehicles
@@ -1181,54 +1079,6 @@ func (q *Queries) ListVehiclesByUser(ctx context.Context, userID int64) ([]UserV
 	for rows.Next() {
 		var i UserVehicle
 		if err := rows.Scan(&i.UserID, &i.VehicleID, &i.CreatedAt); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listVehiclesPage = `-- name: ListVehiclesPage :many
-SELECT id, label, agency_tag, active, created_at, updated_at
-FROM vehicles
-ORDER BY created_at DESC, id DESC
-LIMIT $1 OFFSET $2
-`
-
-type ListVehiclesPageParams struct {
-	Limit  int32
-	Offset int32
-}
-
-type ListVehiclesPageRow struct {
-	ID        string
-	Label     string
-	AgencyTag string
-	Active    bool
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-}
-
-func (q *Queries) ListVehiclesPage(ctx context.Context, arg ListVehiclesPageParams) ([]ListVehiclesPageRow, error) {
-	rows, err := q.db.Query(ctx, listVehiclesPage, arg.Limit, arg.Offset)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListVehiclesPageRow
-	for rows.Next() {
-		var i ListVehiclesPageRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.Label,
-			&i.AgencyTag,
-			&i.Active,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/handlers.go
+++ b/handlers.go
@@ -400,6 +400,17 @@ func parseListPageParams(w http.ResponseWriter, r *http.Request) (limit, offset 
 	return limit, offset, true
 }
 
+// validateListQuery checks the free-text search param shared by the admin
+// list endpoints. An unbounded search string is a cheap way to make Postgres
+// do expensive substring work on an admin endpoint, so q is capped at the
+// same maxFieldLength the write paths already enforce.
+func validateListQuery(q string) error {
+	if len(q) > maxFieldLength {
+		return fmt.Errorf("q must be at most %d characters", maxFieldLength)
+	}
+	return nil
+}
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/handlers_vehicles.go
+++ b/handlers_vehicles.go
@@ -49,9 +49,10 @@ func (r *upsertVehicleRequest) validate() error {
 }
 
 // handleListVehicles returns one page of vehicles, newest first, bounded by
-// the limit/offset query params. Deactivated vehicles are included, as they
-// always have been. The response stays a bare JSON array rather than a
-// paging envelope so existing clients keep working.
+// the limit/offset query params and narrowed by the optional q and
+// agency_tag filters. Deactivated vehicles are included, as they always have
+// been. The response stays a bare JSON array rather than a paging envelope
+// so existing clients keep working.
 func handleListVehicles(store VehiclePager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		limit, offset, ok := parseListPageParams(w, r)
@@ -59,7 +60,20 @@ func handleListVehicles(store VehiclePager) http.HandlerFunc {
 			return
 		}
 
-		vehicles, err := store.ListVehiclesPage(r.Context(), true, int32(limit), int32(offset))
+		query := r.URL.Query()
+		q := query.Get("q")
+		if err := validateListQuery(q); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
+		vehicles, err := store.ListVehiclesPage(r.Context(), VehicleFilter{
+			IncludeInactive: true,
+			AgencyTag:       query.Get("agency_tag"),
+			Q:               q,
+			Limit:           int32(limit),
+			Offset:          int32(offset),
+		})
 		if err != nil {
 			slog.Error("failed to list vehicles", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list vehicles"})

--- a/handlers_vehicles_test.go
+++ b/handlers_vehicles_test.go
@@ -22,11 +22,9 @@ type mockVehicleStore struct {
 	vehicles map[string]*VehicleResponse
 	err      error
 
-	// Recorded by ListVehiclesPage so paging tests can assert what the
-	// handler asked the store for.
-	gotIncludeInactive bool
-	gotLimit           int32
-	gotOffset          int32
+	// Recorded by ListVehiclesPage so paging and filter tests can assert
+	// what the handler asked the store for.
+	gotFilter VehicleFilter
 }
 
 // pageSlice returns the limit/offset window of s, mirroring SQL LIMIT/OFFSET
@@ -60,9 +58,10 @@ func (m *mockVehicleStore) ListVehicles(_ context.Context) ([]VehicleResponse, e
 
 // ListVehiclesPage orders by id so pages are deterministic; the real store
 // orders by created_at DESC with an id tiebreaker. Only the totality of the
-// order matters to the handler.
-func (m *mockVehicleStore) ListVehiclesPage(_ context.Context, includeInactive bool, limit, offset int32) ([]VehicleResponse, error) {
-	m.gotIncludeInactive, m.gotLimit, m.gotOffset = includeInactive, limit, offset
+// order matters to the handler. Q and AgencyTag are recorded rather than
+// applied — matching them is the store's job, tested against Postgres.
+func (m *mockVehicleStore) ListVehiclesPage(_ context.Context, filter VehicleFilter) ([]VehicleResponse, error) {
+	m.gotFilter = filter
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -75,12 +74,12 @@ func (m *mockVehicleStore) ListVehiclesPage(_ context.Context, includeInactive b
 	all := make([]VehicleResponse, 0, len(ids))
 	for _, id := range ids {
 		v := m.vehicles[id]
-		if !includeInactive && !v.Active {
+		if !filter.IncludeInactive && !v.Active {
 			continue
 		}
 		all = append(all, *v)
 	}
-	return pageSlice(all, limit, offset), nil
+	return pageSlice(all, filter.Limit, filter.Offset), nil
 }
 
 func (m *mockVehicleStore) GetVehicle(_ context.Context, id string) (*VehicleResponse, error) {
@@ -218,8 +217,8 @@ func TestHandleListVehicles_PagingParams(t *testing.T) {
 				assert.Equal(t, tt.wantError, decodeErrorResponse(t, w))
 				return
 			}
-			assert.Equal(t, tt.wantLimit, store.gotLimit, "limit passed to the store")
-			assert.Equal(t, tt.wantOffset, store.gotOffset, "offset passed to the store")
+			assert.Equal(t, tt.wantLimit, store.gotFilter.Limit, "limit passed to the store")
+			assert.Equal(t, tt.wantOffset, store.gotFilter.Offset, "offset passed to the store")
 		})
 	}
 }
@@ -261,7 +260,7 @@ func TestHandleListVehicles_IncludesInactive(t *testing.T) {
 	handler(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	assert.True(t, store.gotIncludeInactive, "the API must ask for deactivated vehicles too")
+	assert.True(t, store.gotFilter.IncludeInactive, "the API must ask for deactivated vehicles too")
 	var vehicles []VehicleResponse
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&vehicles))
 	assert.Len(t, vehicles, 2)
@@ -698,4 +697,58 @@ func TestHandleDeactivateVehicle_InvalidID(t *testing.T) {
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err)
 	assert.Contains(t, resp["error"], "alphanumeric characters")
+}
+
+// TestHandleListVehicles_FilterParams is the validation table for the search
+// and agency filters. Every case asserts the filter the handler handed the
+// store, or the exact error message, so a case can't pass for the wrong
+// reason. The 255/256 pair is the boundary guard on q's length cap.
+func TestHandleListVehicles_FilterParams(t *testing.T) {
+	qError := fmt.Sprintf("q must be at most %d characters", maxFieldLength)
+
+	tests := []struct {
+		name       string
+		query      string
+		wantStatus int
+		wantError  string
+		wantQ      string
+		wantAgency string
+	}{
+		{name: "no filters", query: "", wantStatus: http.StatusOK},
+		{name: "search term", query: "?q=bus-10", wantStatus: http.StatusOK, wantQ: "bus-10"},
+		{name: "agency tag", query: "?agency_tag=nairobi", wantStatus: http.StatusOK, wantAgency: "nairobi"},
+		{name: "both filters", query: "?q=bus&agency_tag=nairobi", wantStatus: http.StatusOK, wantQ: "bus", wantAgency: "nairobi"},
+		{name: "empty q does not filter", query: "?q=", wantStatus: http.StatusOK},
+		{name: "wildcards reach the store verbatim", query: "?q=%25", wantStatus: http.StatusOK, wantQ: "%"},
+		{
+			name:       "q at the maximum length",
+			query:      "?q=" + strings.Repeat("a", maxFieldLength),
+			wantStatus: http.StatusOK,
+			wantQ:      strings.Repeat("a", maxFieldLength),
+		},
+		{
+			name:       "q one past the maximum length",
+			query:      "?q=" + strings.Repeat("a", maxFieldLength+1),
+			wantStatus: http.StatusBadRequest,
+			wantError:  qError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMockVehicleStore()
+			handler := handleListVehicles(store)
+			req := httptest.NewRequest("GET", "/api/v1/admin/vehicles"+tt.query, nil)
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code)
+			if tt.wantStatus != http.StatusOK {
+				assert.Equal(t, tt.wantError, decodeErrorResponse(t, w))
+				return
+			}
+			assert.Equal(t, tt.wantQ, store.gotFilter.Q, "q passed to the store")
+			assert.Equal(t, tt.wantAgency, store.gotFilter.AgencyTag, "agency_tag passed to the store")
+		})
+	}
 }

--- a/route_wiring_test.go
+++ b/route_wiring_test.go
@@ -24,7 +24,7 @@ func (n *noopStore) GetUserByEmail(_ context.Context, _ string) (*User, error) {
 func (n *noopStore) ListUsers(_ context.Context) ([]UserResponse, error) {
 	return make([]UserResponse, 0), nil
 }
-func (n *noopStore) ListUsersPage(_ context.Context, _, _ int32) ([]UserResponse, error) {
+func (n *noopStore) ListUsersPage(_ context.Context, _ UserFilter) ([]UserResponse, error) {
 	return make([]UserResponse, 0), nil
 }
 func (n *noopStore) GetUser(_ context.Context, _ int64) (*UserResponse, error) {
@@ -42,7 +42,7 @@ func (n *noopStore) DeleteUser(_ context.Context, _ int64) error {
 func (n *noopStore) ListVehicles(_ context.Context) ([]VehicleResponse, error) {
 	return make([]VehicleResponse, 0), nil
 }
-func (n *noopStore) ListVehiclesPage(_ context.Context, _ bool, _, _ int32) ([]VehicleResponse, error) {
+func (n *noopStore) ListVehiclesPage(_ context.Context, _ VehicleFilter) ([]VehicleResponse, error) {
 	return make([]VehicleResponse, 0), nil
 }
 func (n *noopStore) GetVehicle(_ context.Context, _ string) (*VehicleResponse, error) {

--- a/store.go
+++ b/store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/OneBusAway/vehicle-positions/db"
@@ -128,6 +129,16 @@ func (s *Store) GetRecentLocations(ctx context.Context, cutoff time.Time) ([]*Lo
 	}
 
 	return locations, nil
+}
+
+// likeSubstringPattern builds the ILIKE pattern that matches q as a literal
+// substring. LIKE metacharacters are escaped so a search for a literal % or _
+// (both legal in vehicle ids and GTFS ids) matches the literal text instead
+// of acting as a wildcard — without it, searching "bus_1" would also match
+// "bus-1", and searching "%" would return every row. Backslash is Postgres's
+// default LIKE escape character.
+func likeSubstringPattern(q string) string {
+	return "%" + strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(q) + "%"
 }
 
 // nullableFloat converts a pgtype.Float8 to a *float64 (nil when NULL).

--- a/store_test.go
+++ b/store_test.go
@@ -414,3 +414,29 @@ func TestStore_SaveLocation_ExplicitZeroOptionalFieldsPreserved(t *testing.T) {
 	require.NotNil(t, locs[0].Accuracy)
 	assert.Equal(t, 0.0, *locs[0].Accuracy)
 }
+
+// TestLikeSubstringPattern pins the escaping the free-text list filters rely
+// on: LIKE metacharacters must survive as literals, or a search for "bus_1"
+// silently matches "bus-1" and a search for "%" matches everything. The
+// mixed case guards the replacement order — the backslash rule has to run
+// before the escapes it would otherwise double.
+func TestLikeSubstringPattern(t *testing.T) {
+	tests := []struct {
+		name string
+		q    string
+		want string
+	}{
+		{"plain text", "bus", `%bus%`},
+		{"underscore is literal", "bus_1", `%bus\_1%`},
+		{"percent is literal", "50%", `%50\%%`},
+		{"backslash is escaped", `a\b`, `%a\\b%`},
+		{"mixed metacharacters", `a\_b`, `%a\\\_b%`},
+		{"empty", "", `%%`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, likeSubstringPattern(tt.q))
+		})
+	}
+}

--- a/store_trips.go
+++ b/store_trips.go
@@ -204,11 +204,7 @@ func (s *Store) ListTrips(ctx context.Context, f TripFilter) ([]TripSummary, err
 		conds = append(conds, "t.user_id = "+arg(f.UserID))
 	}
 	if f.Q != "" {
-		// Escape LIKE metacharacters so a search for a literal % or _
-		// (common in GTFS ids) matches the literal text instead of acting
-		// as a wildcard. Backslash is Postgres's default LIKE escape char.
-		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(f.Q)
-		p := arg("%" + escaped + "%")
+		p := arg(likeSubstringPattern(f.Q))
 		conds = append(conds, fmt.Sprintf("(u.name ILIKE %s OR t.route_id ILIKE %s OR t.gtfs_trip_id ILIKE %s)", p, p, p))
 	}
 	if len(conds) > 0 {

--- a/store_users_test.go
+++ b/store_users_test.go
@@ -341,11 +341,11 @@ func TestStore_ListUsersPage(t *testing.T) {
 		seeded[email] = true
 	}
 
-	first, err := store.ListUsersPage(ctx, 3, 0)
+	first, err := store.ListUsersPage(ctx, UserFilter{Limit: 3, Offset: 0})
 	require.NoError(t, err)
 	require.Len(t, first, 3, "limit must cap the page")
 
-	second, err := store.ListUsersPage(ctx, 3, 3)
+	second, err := store.ListUsersPage(ctx, UserFilter{Limit: 3, Offset: 3})
 	require.NoError(t, err)
 	require.NotEmpty(t, second)
 
@@ -364,7 +364,7 @@ func TestStore_ListUsersPage(t *testing.T) {
 		assert.Equal(t, 1, seen[email], "user %s must appear on exactly one page", email)
 	}
 
-	past, err := store.ListUsersPage(ctx, 3, 1_000_000)
+	past, err := store.ListUsersPage(ctx, UserFilter{Limit: 3, Offset: 1_000_000})
 	require.NoError(t, err)
 	assert.NotNil(t, past, "an offset past the end should be [], not nil")
 	assert.Empty(t, past)
@@ -395,4 +395,193 @@ func TestStore_ListUsers_SafetyBound(t *testing.T) {
 	users, err := store.ListUsers(ctx)
 	require.NoError(t, err)
 	assert.Len(t, users, 1000, "ListUsers must stop at its 1000-row safety bound")
+}
+
+// listUsersFilterEmails are the seeded accounts the filter tests below share.
+// They cover both roles and both active states so each test can assert on the
+// slice of them it cares about.
+var listUsersFilterEmails = []string{
+	"filter-amina@example.com",
+	"filter-brian@example.com",
+	"filter-admin@example.com",
+	"filter-retired@example.com",
+}
+
+// seedFilterUsers creates the shared filter fixtures and returns them by
+// email. The users table is not truncated between tests, so every assertion
+// below narrows to these rows rather than counting the whole table.
+func seedFilterUsers(t *testing.T, store *Store) map[string]*UserResponse {
+	t.Helper()
+	ctx := context.Background()
+	cleanupTestUsers(t, store, listUsersFilterEmails...)
+	t.Cleanup(func() { cleanupTestUsers(t, store, listUsersFilterEmails...) })
+
+	seed := []struct {
+		name, email, role string
+		deactivate        bool
+	}{
+		{"Amina Otieno", "filter-amina@example.com", "driver", false},
+		{"Brian Kimani", "filter-brian@example.com", "driver", false},
+		{"Carol Njoroge", "filter-admin@example.com", "admin", false},
+		{"Retired Driver", "filter-retired@example.com", "driver", true},
+	}
+
+	byEmail := make(map[string]*UserResponse, len(seed))
+	for _, s := range seed {
+		u, err := store.CreateUser(ctx, s.name, s.email, "securepass", s.role)
+		require.NoError(t, err)
+		if s.deactivate {
+			require.NoError(t, store.SetUserActive(ctx, u.ID, false))
+			u.Active = false
+		}
+		byEmail[s.email] = u
+	}
+	return byEmail
+}
+
+// seededSubset narrows a page of users to the rows this test seeded, keyed by
+// email. Other tests' users share the table, so a filter assertion has to
+// ignore them.
+func seededSubset(users []UserResponse) map[string]UserResponse {
+	got := make(map[string]UserResponse)
+	for _, u := range users {
+		for _, email := range listUsersFilterEmails {
+			if u.Email == email {
+				got[u.Email] = u
+			}
+		}
+	}
+	return got
+}
+
+// TestStore_ListUsersPage_EmptyFilterMatchesAll pins the behaviour every
+// existing caller relied on before filters existed: a filter carrying only
+// paging returns every user, deactivated ones included, exactly as the
+// unfiltered list always did.
+func TestStore_ListUsersPage_EmptyFilterMatchesAll(t *testing.T) {
+	store := newTestStore(t)
+	seedFilterUsers(t, store)
+
+	users, err := store.ListUsersPage(context.Background(), UserFilter{Limit: 1000})
+	require.NoError(t, err)
+
+	got := seededSubset(users)
+	assert.Len(t, got, len(listUsersFilterEmails), "a zero-value filter must not hide anyone")
+	assert.Contains(t, got, "filter-retired@example.com", "deactivated users were listed before and must still be")
+}
+
+// TestStore_ListUsersPage_FilterByQ covers the free-text search: it must
+// match on name as well as email, case-insensitively, since an admin looking
+// up a driver has one or the other to hand.
+func TestStore_ListUsersPage_FilterByQ(t *testing.T) {
+	store := newTestStore(t)
+	seedFilterUsers(t, store)
+	ctx := context.Background()
+
+	byName, err := store.ListUsersPage(ctx, UserFilter{Q: "amina", Limit: 1000})
+	require.NoError(t, err)
+	got := seededSubset(byName)
+	require.Len(t, got, 1, "q must match on name, case-insensitively")
+	assert.Contains(t, got, "filter-amina@example.com")
+
+	byEmail, err := store.ListUsersPage(ctx, UserFilter{Q: "filter-brian@", Limit: 1000})
+	require.NoError(t, err)
+	got = seededSubset(byEmail)
+	require.Len(t, got, 1, "q must match on email")
+	assert.Contains(t, got, "filter-brian@example.com")
+
+	none, err := store.ListUsersPage(ctx, UserFilter{Q: "filter-nobody@example.com", Limit: 1000})
+	require.NoError(t, err)
+	assert.NotNil(t, none, "no matches should be [], not nil")
+	assert.Empty(t, seededSubset(none))
+}
+
+// TestStore_ListUsersPage_FilterByRole checks the role filter selects one
+// role and excludes the other — in both directions, so a filter that
+// happened to ignore its argument could not pass.
+func TestStore_ListUsersPage_FilterByRole(t *testing.T) {
+	store := newTestStore(t)
+	seedFilterUsers(t, store)
+	ctx := context.Background()
+
+	drivers, err := store.ListUsersPage(ctx, UserFilter{Role: roleDriver, Q: "filter-", Limit: 1000})
+	require.NoError(t, err)
+	got := seededSubset(drivers)
+	assert.Len(t, got, 3, "the three seeded drivers, active and deactivated")
+	assert.NotContains(t, got, "filter-admin@example.com", "role=driver must exclude admins")
+
+	admins, err := store.ListUsersPage(ctx, UserFilter{Role: roleAdmin, Q: "filter-", Limit: 1000})
+	require.NoError(t, err)
+	got = seededSubset(admins)
+	require.Len(t, got, 1)
+	assert.Contains(t, got, "filter-admin@example.com", "role=admin must exclude drivers")
+}
+
+// TestStore_ListUsersPage_FilterByActive checks the opt-in active filter:
+// deactivated accounts are listed by default and hidden only when asked.
+func TestStore_ListUsersPage_FilterByActive(t *testing.T) {
+	store := newTestStore(t)
+	seedFilterUsers(t, store)
+	ctx := context.Background()
+
+	all, err := store.ListUsersPage(ctx, UserFilter{Q: "filter-", Limit: 1000})
+	require.NoError(t, err)
+	assert.Contains(t, seededSubset(all), "filter-retired@example.com", "deactivated users are listed by default")
+
+	activeOnly, err := store.ListUsersPage(ctx, UserFilter{Q: "filter-", ActiveOnly: true, Limit: 1000})
+	require.NoError(t, err)
+	got := seededSubset(activeOnly)
+	assert.Len(t, got, 3)
+	assert.NotContains(t, got, "filter-retired@example.com", "ActiveOnly must hide deactivated users")
+}
+
+// TestStore_ListUsersPage_FiltersCombine checks the filters AND together
+// rather than each merely working alone.
+func TestStore_ListUsersPage_FiltersCombine(t *testing.T) {
+	store := newTestStore(t)
+	seedFilterUsers(t, store)
+
+	got, err := store.ListUsersPage(context.Background(), UserFilter{
+		Role:       roleDriver,
+		Q:          "filter-",
+		ActiveOnly: true,
+		Limit:      1000,
+	})
+	require.NoError(t, err)
+
+	subset := seededSubset(got)
+	assert.Len(t, subset, 2, "role, q and the active filter must AND together")
+	assert.NotContains(t, subset, "filter-admin@example.com")
+	assert.NotContains(t, subset, "filter-retired@example.com")
+}
+
+// TestStore_ListUsersPage_FilterWithPaging checks the filter survives the
+// LIMIT/OFFSET window: the two pages of a filtered result tile the matching
+// set exactly, with nothing skipped, repeated, or leaking in from outside
+// the filter.
+func TestStore_ListUsersPage_FilterWithPaging(t *testing.T) {
+	store := newTestStore(t)
+	seedFilterUsers(t, store)
+	ctx := context.Background()
+
+	filter := UserFilter{Role: roleDriver, Q: "filter-", ActiveOnly: true, Limit: 1}
+	first, err := store.ListUsersPage(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+
+	filter.Offset = 1
+	second, err := store.ListUsersPage(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, second, 1, "page 2 must still be filtered, not the unfiltered remainder")
+
+	seen := make(map[string]int, 2)
+	for _, page := range [][]UserResponse{first, second} {
+		for _, u := range page {
+			seen[u.Email]++
+		}
+	}
+	assert.Len(t, seen, 2, "the two pages together must cover both matching drivers")
+	for _, email := range []string{"filter-amina@example.com", "filter-brian@example.com"} {
+		assert.Equal(t, 1, seen[email], "user %s must appear on exactly one page", email)
+	}
 }

--- a/store_vehicles.go
+++ b/store_vehicles.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/OneBusAway/vehicle-positions/db"
@@ -34,7 +35,18 @@ type VehicleManager interface {
 // trip-filter dropdowns, the live map — keep using
 // VehicleManager.ListVehicles, which pagination would silently truncate.
 type VehiclePager interface {
-	ListVehiclesPage(ctx context.Context, includeInactive bool, limit, offset int32) ([]VehicleResponse, error)
+	ListVehiclesPage(ctx context.Context, f VehicleFilter) ([]VehicleResponse, error)
+}
+
+// VehicleFilter narrows the vehicle list. Zero values mean "no filter", so a
+// zero-value filter lists the active fleet exactly as the unfiltered page
+// always has.
+type VehicleFilter struct {
+	IncludeInactive bool   // false hides deactivated vehicles
+	AgencyTag       string // "" = all agencies
+	Q               string // ILIKE substring on id and label
+	Limit           int32  // callers pass limit+1 to detect hasMore
+	Offset          int32
 }
 
 // VehicleInfoUpdater updates a vehicle's label/agency tag without touching
@@ -72,29 +84,53 @@ func (s *Store) ListVehicles(ctx context.Context) ([]VehicleResponse, error) {
 }
 
 // ListVehiclesPage returns one page of vehicles in the same order as
-// ListVehicles. includeInactive=false filters deactivated vehicles out in
-// SQL rather than after the fetch, so a page of the admin list holds a full
-// page of rows.
-func (s *Store) ListVehiclesPage(ctx context.Context, includeInactive bool, limit, offset int32) ([]VehicleResponse, error) {
-	if !includeInactive {
-		rows, err := s.queries.ListActiveVehiclesPage(ctx, db.ListActiveVehiclesPageParams{Limit: limit, Offset: offset})
-		if err != nil {
-			return nil, fmt.Errorf("list active vehicles page: %w", err)
-		}
-		vehicles := make([]VehicleResponse, 0, len(rows))
-		for _, row := range rows {
-			vehicles = append(vehicles, toVehicleResponse(row.ID, row.Label, row.AgencyTag, row.Active, row.CreatedAt, row.UpdatedAt))
-		}
-		return vehicles, nil
+// ListVehicles, narrowed by f. Every filter runs in SQL rather than after
+// the fetch, so a page of the admin list holds a full page of rows.
+//
+// Dynamic WHERE clauses make this a hand-written query rather than sqlc, the
+// same trade ListTrips documents: three optional filters would be eight sqlc
+// variants. Every value goes through arg(), so only $N placeholders ever
+// reach the SQL string.
+func (s *Store) ListVehiclesPage(ctx context.Context, f VehicleFilter) ([]VehicleResponse, error) {
+	query := `
+		SELECT id, label, agency_tag, active, created_at, updated_at
+		FROM vehicles`
+	var conds []string
+	var args []any
+	arg := func(v any) string { args = append(args, v); return fmt.Sprintf("$%d", len(args)) }
+	if !f.IncludeInactive {
+		conds = append(conds, "active")
 	}
+	if f.AgencyTag != "" {
+		conds = append(conds, "agency_tag = "+arg(f.AgencyTag))
+	}
+	if f.Q != "" {
+		p := arg(likeSubstringPattern(f.Q))
+		conds = append(conds, fmt.Sprintf("(id ILIKE %s OR label ILIKE %s)", p, p))
+	}
+	if len(conds) > 0 {
+		query += " WHERE " + strings.Join(conds, " AND ")
+	}
+	query += " ORDER BY created_at DESC, id DESC LIMIT " + arg(f.Limit) + " OFFSET " + arg(f.Offset)
 
-	rows, err := s.queries.ListVehiclesPage(ctx, db.ListVehiclesPageParams{Limit: limit, Offset: offset})
+	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list vehicles page: %w", err)
 	}
-	vehicles := make([]VehicleResponse, 0, len(rows))
-	for _, row := range rows {
-		vehicles = append(vehicles, toVehicleResponse(row.ID, row.Label, row.AgencyTag, row.Active, row.CreatedAt, row.UpdatedAt))
+	defer rows.Close()
+
+	vehicles := make([]VehicleResponse, 0)
+	for rows.Next() {
+		var id, label, agencyTag string
+		var active bool
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&id, &label, &agencyTag, &active, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan vehicle: %w", err)
+		}
+		vehicles = append(vehicles, toVehicleResponse(id, label, agencyTag, active, createdAt, updatedAt))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list vehicles page: %w", err)
 	}
 	return vehicles, nil
 }

--- a/store_vehicles_test.go
+++ b/store_vehicles_test.go
@@ -338,11 +338,11 @@ func TestStore_ListVehiclesPage(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	first, err := store.ListVehiclesPage(ctx, true, 3, 0)
+	first, err := store.ListVehiclesPage(ctx, VehicleFilter{IncludeInactive: true, Limit: 3, Offset: 0})
 	require.NoError(t, err)
 	require.Len(t, first, 3)
 
-	second, err := store.ListVehiclesPage(ctx, true, 3, 3)
+	second, err := store.ListVehiclesPage(ctx, VehicleFilter{IncludeInactive: true, Limit: 3, Offset: 3})
 	require.NoError(t, err)
 	require.Len(t, second, 2)
 
@@ -357,7 +357,7 @@ func TestStore_ListVehiclesPage(t *testing.T) {
 		assert.Equal(t, 1, seen[id], "vehicle %s must appear on exactly one page", id)
 	}
 
-	past, err := store.ListVehiclesPage(ctx, true, 3, 100)
+	past, err := store.ListVehiclesPage(ctx, VehicleFilter{IncludeInactive: true, Limit: 3, Offset: 100})
 	require.NoError(t, err)
 	assert.NotNil(t, past, "an offset past the end should be [], not nil")
 	assert.Empty(t, past)
@@ -367,7 +367,7 @@ func TestStore_ListVehiclesPage_Empty(t *testing.T) {
 	store := newTestStore(t)
 	cleanupVehicles(t, store)
 
-	vehicles, err := store.ListVehiclesPage(context.Background(), true, 50, 0)
+	vehicles, err := store.ListVehiclesPage(context.Background(), VehicleFilter{IncludeInactive: true, Limit: 50, Offset: 0})
 	require.NoError(t, err)
 	assert.NotNil(t, vehicles, "empty page should be [], not nil")
 	assert.Empty(t, vehicles)
@@ -388,12 +388,12 @@ func TestStore_ListVehiclesPage_ExcludesInactive(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, store.DeactivateVehicle(ctx, "page-retired"))
 
-	activeOnly, err := store.ListVehiclesPage(ctx, false, 50, 0)
+	activeOnly, err := store.ListVehiclesPage(ctx, VehicleFilter{Limit: 50, Offset: 0})
 	require.NoError(t, err)
 	require.Len(t, activeOnly, 1)
 	assert.Equal(t, "page-active", activeOnly[0].ID)
 
-	all, err := store.ListVehiclesPage(ctx, true, 50, 0)
+	all, err := store.ListVehiclesPage(ctx, VehicleFilter{IncludeInactive: true, Limit: 50, Offset: 0})
 	require.NoError(t, err)
 	assert.Len(t, all, 2, "includeInactive must return deactivated vehicles too")
 }
@@ -413,4 +413,176 @@ func TestStore_ListVehicles_SafetyBound(t *testing.T) {
 	vehicles, err := store.ListVehicles(ctx)
 	require.NoError(t, err)
 	assert.Len(t, vehicles, 1000, "ListVehicles must stop at its 1000-row safety bound")
+}
+
+// TestStore_ListVehiclesPage_EmptyFilterMatchesAll pins the behaviour every
+// existing caller relied on before filters existed: a filter carrying only
+// paging returns the active fleet, newest-first, exactly as the unfiltered
+// page always did.
+func TestStore_ListVehiclesPage_EmptyFilterMatchesAll(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+	ctx := context.Background()
+
+	for _, id := range []string{"empty-a", "empty-b", "empty-c"} {
+		_, err := store.UpsertVehicle(ctx, id, "Label "+id, "agency")
+		require.NoError(t, err)
+	}
+	require.NoError(t, store.DeactivateVehicle(ctx, "empty-c"))
+
+	vehicles, err := store.ListVehiclesPage(ctx, VehicleFilter{Limit: 50, Offset: 0})
+	require.NoError(t, err)
+	require.Len(t, vehicles, 2, "a zero-value filter must still hide deactivated vehicles")
+
+	ids := []string{vehicles[0].ID, vehicles[1].ID}
+	assert.ElementsMatch(t, []string{"empty-a", "empty-b"}, ids)
+}
+
+// TestStore_ListVehiclesPage_FilterByQ covers the free-text search: it must
+// match on id as well as label, and must be case-insensitive (ILIKE), since
+// an operator hunting for a bus types whatever is painted on its side.
+func TestStore_ListVehiclesPage_FilterByQ(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+	ctx := context.Background()
+
+	_, err := store.UpsertVehicle(ctx, "kbz-1042", "Nairobi Express", "agency")
+	require.NoError(t, err)
+	_, err = store.UpsertVehicle(ctx, "kbz-2000", "Mombasa Local", "agency")
+	require.NoError(t, err)
+
+	byID, err := store.ListVehiclesPage(ctx, VehicleFilter{Q: "1042", Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, byID, 1, "q must match on id")
+	assert.Equal(t, "kbz-1042", byID[0].ID)
+
+	byLabel, err := store.ListVehiclesPage(ctx, VehicleFilter{Q: "mombasa", Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, byLabel, 1, "q must match on label, case-insensitively")
+	assert.Equal(t, "kbz-2000", byLabel[0].ID)
+
+	none, err := store.ListVehiclesPage(ctx, VehicleFilter{Q: "kisumu", Limit: 50})
+	require.NoError(t, err)
+	assert.NotNil(t, none, "no matches should be [], not nil")
+	assert.Empty(t, none)
+}
+
+// TestStore_ListVehiclesPage_QEscapesWildcards is the guard for the shared
+// LIKE escaping. Vehicle ids permit dots, hyphens and underscores, so an
+// underscore in a search term is a realistic input, not a theoretical one:
+// unescaped it is a single-character wildcard, and "bus_1" would also match
+// "bus-1". A bare "%" must likewise match nothing rather than everything.
+func TestStore_ListVehiclesPage_QEscapesWildcards(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+	ctx := context.Background()
+
+	for _, id := range []string{"bus_1", "bus-1"} {
+		_, err := store.UpsertVehicle(ctx, id, "Label "+id, "agency")
+		require.NoError(t, err)
+	}
+
+	underscore, err := store.ListVehiclesPage(ctx, VehicleFilter{Q: "bus_1", Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, underscore, 1, "the underscore must be a literal, not a wildcard")
+	assert.Equal(t, "bus_1", underscore[0].ID)
+
+	percent, err := store.ListVehiclesPage(ctx, VehicleFilter{Q: "%", Limit: 50})
+	require.NoError(t, err)
+	assert.Empty(t, percent, "a literal %% matches no id or label here, so it must not return everything")
+}
+
+// TestStore_ListVehiclesPage_FilterByAgency covers the exact-match agency
+// filter: an agency tag selects only its own fleet, and the filter is not a
+// substring match.
+func TestStore_ListVehiclesPage_FilterByAgency(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+	ctx := context.Background()
+
+	_, err := store.UpsertVehicle(ctx, "agency-a1", "A One", "nairobi")
+	require.NoError(t, err)
+	_, err = store.UpsertVehicle(ctx, "agency-b1", "B One", "mombasa")
+	require.NoError(t, err)
+
+	nairobi, err := store.ListVehiclesPage(ctx, VehicleFilter{AgencyTag: "nairobi", Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, nairobi, 1)
+	assert.Equal(t, "agency-a1", nairobi[0].ID)
+
+	partial, err := store.ListVehiclesPage(ctx, VehicleFilter{AgencyTag: "nair", Limit: 50})
+	require.NoError(t, err)
+	assert.Empty(t, partial, "agency_tag is an exact match, not a substring one")
+}
+
+// TestStore_ListVehiclesPage_FiltersCombine checks the filters AND together
+// rather than each merely working alone: only the vehicle satisfying all
+// three conditions comes back.
+func TestStore_ListVehiclesPage_FiltersCombine(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+	ctx := context.Background()
+
+	seed := []struct {
+		id, label, agency string
+		deactivate        bool
+	}{
+		{"combo-match", "Express One", "nairobi", false},
+		{"combo-other-agency", "Express Two", "mombasa", false},
+		{"combo-inactive", "Express Three", "nairobi", true},
+		{"combo-no-match", "Local Four", "nairobi", false},
+	}
+	for _, s := range seed {
+		_, err := store.UpsertVehicle(ctx, s.id, s.label, s.agency)
+		require.NoError(t, err)
+		if s.deactivate {
+			require.NoError(t, store.DeactivateVehicle(ctx, s.id))
+		}
+	}
+
+	got, err := store.ListVehiclesPage(ctx, VehicleFilter{AgencyTag: "nairobi", Q: "express", Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "q, agency_tag and the active filter must AND together")
+	assert.Equal(t, "combo-match", got[0].ID)
+}
+
+// TestStore_ListVehiclesPage_FilterWithPaging checks the filter survives the
+// LIMIT/OFFSET window: the two pages of a filtered result tile the matching
+// set exactly, with nothing skipped, repeated, or leaking in from outside
+// the filter.
+func TestStore_ListVehiclesPage_FilterWithPaging(t *testing.T) {
+	store := newTestStore(t)
+	cleanupVehicles(t, store)
+	ctx := context.Background()
+
+	matching := []string{"pf-match-1", "pf-match-2", "pf-match-3"}
+	for _, id := range matching {
+		_, err := store.UpsertVehicle(ctx, id, "Match "+id, "agency")
+		require.NoError(t, err)
+	}
+	for _, id := range []string{"pf-other-1", "pf-other-2"} {
+		_, err := store.UpsertVehicle(ctx, id, "Other "+id, "agency")
+		require.NoError(t, err)
+	}
+
+	filter := VehicleFilter{Q: "pf-match", Limit: 2}
+	first, err := store.ListVehiclesPage(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+
+	filter.Offset = 2
+	second, err := store.ListVehiclesPage(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, second, 1, "page 2 must still be filtered, not the unfiltered remainder")
+
+	seen := make(map[string]int, len(matching))
+	for _, page := range [][]VehicleResponse{first, second} {
+		for _, v := range page {
+			seen[v.ID]++
+		}
+	}
+	assert.Len(t, seen, len(matching), "the two pages together must cover every match")
+	for _, id := range matching {
+		assert.Equal(t, 1, seen[id], "vehicle %s must appear on exactly one page", id)
+	}
 }

--- a/user_handlers.go
+++ b/user_handlers.go
@@ -25,8 +25,10 @@ type UpdateUserRequest struct {
 }
 
 // handleListUsers returns one page of users, newest first, bounded by the
-// limit/offset query params. The response stays a bare JSON array rather
-// than a paging envelope so existing clients keep working.
+// limit/offset query params and narrowed by the optional q and role filters.
+// Deactivated users are included, as they always have been. The response
+// stays a bare JSON array rather than a paging envelope so existing clients
+// keep working.
 func handleListUsers(store UserPager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		limit, offset, ok := parseListPageParams(w, r)
@@ -34,7 +36,24 @@ func handleListUsers(store UserPager) http.HandlerFunc {
 			return
 		}
 
-		users, err := store.ListUsersPage(r.Context(), int32(limit), int32(offset))
+		query := r.URL.Query()
+		q := query.Get("q")
+		if err := validateListQuery(q); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		role := query.Get("role")
+		if !validUserRoleFilter(role) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": `role must be "", "driver", or "admin"`})
+			return
+		}
+
+		users, err := store.ListUsersPage(r.Context(), UserFilter{
+			Role:   role,
+			Q:      q,
+			Limit:  int32(limit),
+			Offset: int32(offset),
+		})
 		if err != nil {
 			slog.Error("failed to list users", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})

--- a/user_handlers_test.go
+++ b/user_handlers_test.go
@@ -22,18 +22,19 @@ type mockUserPager struct {
 	users []UserResponse
 	err   error
 
-	// Recorded by ListUsersPage so paging tests can assert what the handler
-	// asked the store for.
-	gotLimit  int32
-	gotOffset int32
+	// Recorded by ListUsersPage so paging and filter tests can assert what
+	// the handler asked the store for.
+	gotFilter UserFilter
 }
 
-func (m *mockUserPager) ListUsersPage(_ context.Context, limit, offset int32) ([]UserResponse, error) {
-	m.gotLimit, m.gotOffset = limit, offset
+// Role, Q and ActiveOnly are recorded rather than applied — matching them is
+// the store's job, tested against Postgres.
+func (m *mockUserPager) ListUsersPage(_ context.Context, filter UserFilter) ([]UserResponse, error) {
+	m.gotFilter = filter
 	if m.err != nil {
 		return nil, m.err
 	}
-	return pageSlice(m.users, limit, offset), nil
+	return pageSlice(m.users, filter.Limit, filter.Offset), nil
 }
 
 type mockUserGetter struct {
@@ -168,8 +169,8 @@ func TestHandleListUsers_PagingParams(t *testing.T) {
 				assert.Equal(t, tt.wantError, decodeErrorResponse(t, w))
 				return
 			}
-			assert.Equal(t, tt.wantLimit, store.gotLimit, "limit passed to the store")
-			assert.Equal(t, tt.wantOffset, store.gotOffset, "offset passed to the store")
+			assert.Equal(t, tt.wantLimit, store.gotFilter.Limit, "limit passed to the store")
+			assert.Equal(t, tt.wantOffset, store.gotFilter.Offset, "offset passed to the store")
 		})
 	}
 }
@@ -732,4 +733,83 @@ func TestHandleDeleteUser_DBError(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Equal(t, "internal server error", decodeErrorResponse(t, w))
+}
+
+// TestHandleListUsers_FilterParams is the validation table for the search and
+// role filters. Every case asserts the filter the handler handed the store,
+// or the exact error message, so a case can't pass for the wrong reason. The
+// 255/256 pair is the boundary guard on q's length cap.
+func TestHandleListUsers_FilterParams(t *testing.T) {
+	qError := fmt.Sprintf("q must be at most %d characters", maxFieldLength)
+	const roleError = `role must be "", "driver", or "admin"`
+
+	tests := []struct {
+		name       string
+		query      string
+		wantStatus int
+		wantError  string
+		wantQ      string
+		wantRole   string
+	}{
+		{name: "no filters", query: "", wantStatus: http.StatusOK},
+		{name: "search term", query: "?q=amina", wantStatus: http.StatusOK, wantQ: "amina"},
+		{name: "empty q does not filter", query: "?q=", wantStatus: http.StatusOK},
+		{name: "role driver", query: "?role=driver", wantStatus: http.StatusOK, wantRole: "driver"},
+		{name: "role admin", query: "?role=admin", wantStatus: http.StatusOK, wantRole: "admin"},
+		{name: "empty role means all roles", query: "?role=", wantStatus: http.StatusOK},
+		{name: "unknown role", query: "?role=superuser", wantStatus: http.StatusBadRequest, wantError: roleError},
+		{name: "role is case-sensitive", query: "?role=Driver", wantStatus: http.StatusBadRequest, wantError: roleError},
+		{name: "both filters", query: "?q=amina&role=driver", wantStatus: http.StatusOK, wantQ: "amina", wantRole: "driver"},
+		{
+			name:       "q at the maximum length",
+			query:      "?q=" + strings.Repeat("a", maxFieldLength),
+			wantStatus: http.StatusOK,
+			wantQ:      strings.Repeat("a", maxFieldLength),
+		},
+		{
+			name:       "q one past the maximum length",
+			query:      "?q=" + strings.Repeat("a", maxFieldLength+1),
+			wantStatus: http.StatusBadRequest,
+			wantError:  qError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &mockUserPager{}
+			handler := handleListUsers(store)
+			req := httptest.NewRequest("GET", "/api/v1/admin/users"+tt.query, nil)
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code)
+			if tt.wantStatus != http.StatusOK {
+				assert.Equal(t, tt.wantError, decodeErrorResponse(t, w))
+				return
+			}
+			assert.Equal(t, tt.wantQ, store.gotFilter.Q, "q passed to the store")
+			assert.Equal(t, tt.wantRole, store.gotFilter.Role, "role passed to the store")
+		})
+	}
+}
+
+// TestHandleListUsers_IncludesInactive pins that the endpoint still lists
+// deactivated users, which it has always done — the admin page's active-only
+// filter must not leak into the API.
+func TestHandleListUsers_IncludesInactive(t *testing.T) {
+	store := &mockUserPager{users: []UserResponse{
+		{ID: 1, Name: "Active", Email: "active@example.com", Role: "driver", Active: true},
+		{ID: 2, Name: "Retired", Email: "retired@example.com", Role: "driver", Active: false},
+	}}
+
+	handler := handleListUsers(store)
+	req := httptest.NewRequest("GET", "/api/v1/admin/users", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, store.gotFilter.ActiveOnly, "the API must not narrow to active users only")
+	var users []UserResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&users))
+	assert.Len(t, users, 2)
 }

--- a/user_store.go
+++ b/user_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OneBusAway/vehicle-positions/db"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -35,7 +36,18 @@ type UserLister interface {
 // list and the users API endpoint. UserLister.ListUsers stays the call for
 // anything that needs every user in one go.
 type UserPager interface {
-	ListUsersPage(ctx context.Context, limit, offset int32) ([]UserResponse, error)
+	ListUsersPage(ctx context.Context, f UserFilter) ([]UserResponse, error)
+}
+
+// UserFilter narrows the user list. Zero values mean "no filter", so a
+// zero-value filter lists every user — active and deactivated alike — as the
+// unfiltered list always has.
+type UserFilter struct {
+	Role       string // "" = all roles
+	Q          string // ILIKE substring on name and email
+	ActiveOnly bool   // false = both active and deactivated users
+	Limit      int32  // callers pass limit+1 to detect hasMore
+	Offset     int32
 }
 
 type UserGetter interface {
@@ -95,24 +107,54 @@ func (s *Store) ListUsers(ctx context.Context) ([]UserResponse, error) {
 	return users, nil
 }
 
-// ListUsersPage returns one page of users in the same order as ListUsers.
-func (s *Store) ListUsersPage(ctx context.Context, limit, offset int32) ([]UserResponse, error) {
-	rows, err := s.queries.ListUsersPage(ctx, db.ListUsersPageParams{Limit: limit, Offset: offset})
+// ListUsersPage returns one page of users in the same order as ListUsers,
+// narrowed by f. Filtering runs in SQL rather than after the fetch, so a
+// page of the admin list holds a full page of rows.
+//
+// Dynamic WHERE clauses make this a hand-written query rather than sqlc, the
+// same trade ListTrips documents. Every value goes through arg(), so only $N
+// placeholders ever reach the SQL string.
+func (s *Store) ListUsersPage(ctx context.Context, f UserFilter) ([]UserResponse, error) {
+	query := `
+		SELECT id, name, email, role, active, created_at, updated_at
+		FROM users`
+	var conds []string
+	var args []any
+	arg := func(v any) string { args = append(args, v); return fmt.Sprintf("$%d", len(args)) }
+	if f.Role != "" {
+		conds = append(conds, "role = "+arg(f.Role))
+	}
+	if f.ActiveOnly {
+		conds = append(conds, "active")
+	}
+	if f.Q != "" {
+		p := arg(likeSubstringPattern(f.Q))
+		conds = append(conds, fmt.Sprintf("(name ILIKE %s OR email ILIKE %s)", p, p))
+	}
+	if len(conds) > 0 {
+		query += " WHERE " + strings.Join(conds, " AND ")
+	}
+	query += " ORDER BY created_at DESC, id DESC LIMIT " + arg(f.Limit) + " OFFSET " + arg(f.Offset)
+
+	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list users page: %w", err)
 	}
+	defer rows.Close()
 
-	users := make([]UserResponse, 0, len(rows))
-	for _, row := range rows {
-		users = append(users, UserResponse{
-			ID:        row.ID,
-			Name:      row.Name,
-			Email:     row.Email,
-			Role:      row.Role,
-			Active:    row.Active,
-			CreatedAt: row.CreatedAt.Time,
-			UpdatedAt: row.UpdatedAt.Time,
-		})
+	users := make([]UserResponse, 0)
+	for rows.Next() {
+		var u UserResponse
+		var createdAt, updatedAt pgtype.Timestamptz
+		if err := rows.Scan(&u.ID, &u.Name, &u.Email, &u.Role, &u.Active, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan user: %w", err)
+		}
+		u.CreatedAt = createdAt.Time
+		u.UpdatedAt = updatedAt.Time
+		users = append(users, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list users page: %w", err)
 	}
 	return users, nil
 }

--- a/web/templates/views/users.html
+++ b/web/templates/views/users.html
@@ -7,7 +7,7 @@
         <p class="mt-0.5 text-xs text-slate-400">{{len .Users}} accounts on this page</p>
       </div>
       <div class="flex flex-wrap items-center gap-3">
-        {{/* No page param: applying a filter starts over at page 1. active rides along so a search survives the toggle. */}}
+        {{/* No page param: a new search starts over at page 1. active rides along so the search survives the toggle. */}}
         <form method="get" action="/admin/users" class="flex flex-wrap items-center gap-2">
           {{if .ActiveOnly}}<input type="hidden" name="active" value="1">{{end}}
           <select name="role" class="rounded-2xl border border-line bg-white px-3 py-2 text-xs text-slate-700 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">

--- a/web/templates/views/users.html
+++ b/web/templates/views/users.html
@@ -1,12 +1,26 @@
 {{define "content"}}
 <div class="p-4 lg:p-5">
   <div class="table-card overflow-hidden rounded-[20px] border border-white/80">
-    <div class="flex items-center justify-between border-b border-slate-200/60 px-5 py-4">
+    <div class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200/60 px-5 py-4">
       <div>
         <h3 class="display-font text-lg font-bold text-slate-900">All Users</h3>
         <p class="mt-0.5 text-xs text-slate-400">{{len .Users}} accounts on this page</p>
       </div>
-      <a href="/admin/users/new" class="inline-flex items-center justify-center rounded-2xl bg-ink px-4 py-2 text-xs font-semibold text-white transition hover:bg-slate-800">New user</a>
+      <div class="flex flex-wrap items-center gap-3">
+        {{/* No page param: applying a filter starts over at page 1. active rides along so a search survives the toggle. */}}
+        <form method="get" action="/admin/users" class="flex flex-wrap items-center gap-2">
+          {{if .ActiveOnly}}<input type="hidden" name="active" value="1">{{end}}
+          <select name="role" class="rounded-2xl border border-line bg-white px-3 py-2 text-xs text-slate-700 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+            <option value="" {{if eq .Role ""}}selected{{end}}>All roles</option>
+            <option value="driver" {{if eq .Role "driver"}}selected{{end}}>Driver</option>
+            <option value="admin" {{if eq .Role "admin"}}selected{{end}}>Admin</option>
+          </select>
+          <input type="text" name="q" placeholder="Search name or email" value="{{.Q}}" class="rounded-2xl border border-line bg-white px-3 py-2 text-xs text-slate-700 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+          <button type="submit" class="rounded-2xl border border-slate-200 bg-white/75 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50">Apply</button>
+        </form>
+        <a href="{{.ToggleActiveURL}}" class="text-xs font-semibold text-sky-600 hover:text-sky-800">{{if .ActiveOnly}}Show deactivated{{else}}Hide deactivated{{end}}</a>
+        <a href="/admin/users/new" class="inline-flex items-center justify-center rounded-2xl bg-ink px-4 py-2 text-xs font-semibold text-white transition hover:bg-slate-800">New user</a>
+      </div>
     </div>
     <div class="overflow-x-auto">
       <table class="min-w-full text-sm">

--- a/web/templates/views/vehicles.html
+++ b/web/templates/views/vehicles.html
@@ -7,7 +7,7 @@
         <p class="mt-0.5 text-xs text-slate-400">{{len .Vehicles}} {{if .IncludeInactive}}shown{{else}}active{{end}} on this page</p>
       </div>
       <div class="flex flex-wrap items-center gap-3">
-        {{/* No page param: applying a filter starts over at page 1. include_inactive rides along so a search survives the toggle. */}}
+        {{/* No page param: a new search starts over at page 1. include_inactive rides along so the search survives the toggle. */}}
         <form method="get" action="/admin/vehicles" class="flex flex-wrap items-center gap-2">
           {{if .IncludeInactive}}<input type="hidden" name="include_inactive" value="1">{{end}}
           <input type="text" name="q" placeholder="Search id or label" value="{{.Q}}" class="rounded-2xl border border-line bg-white px-3 py-2 text-xs text-slate-700 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">

--- a/web/templates/views/vehicles.html
+++ b/web/templates/views/vehicles.html
@@ -1,17 +1,20 @@
 {{define "content"}}
 <div class="p-4 lg:p-5">
   <div class="table-card overflow-hidden rounded-[20px] border border-white/80">
-    <div class="flex items-center justify-between border-b border-slate-200/60 px-5 py-4">
+    <div class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200/60 px-5 py-4">
       <div>
         <h3 class="display-font text-lg font-bold text-slate-900">All Vehicles</h3>
         <p class="mt-0.5 text-xs text-slate-400">{{len .Vehicles}} {{if .IncludeInactive}}shown{{else}}active{{end}} on this page</p>
       </div>
-      <div class="flex items-center gap-3">
-        {{if .IncludeInactive}}
-        <a href="/admin/vehicles" class="text-xs font-semibold text-sky-600 hover:text-sky-800">Hide deactivated</a>
-        {{else}}
-        <a href="/admin/vehicles?include_inactive=1" class="text-xs font-semibold text-sky-600 hover:text-sky-800">Show deactivated</a>
-        {{end}}
+      <div class="flex flex-wrap items-center gap-3">
+        {{/* No page param: applying a filter starts over at page 1. include_inactive rides along so a search survives the toggle. */}}
+        <form method="get" action="/admin/vehicles" class="flex flex-wrap items-center gap-2">
+          {{if .IncludeInactive}}<input type="hidden" name="include_inactive" value="1">{{end}}
+          <input type="text" name="q" placeholder="Search id or label" value="{{.Q}}" class="rounded-2xl border border-line bg-white px-3 py-2 text-xs text-slate-700 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+          <input type="text" name="agency_tag" placeholder="Agency tag" value="{{.AgencyTag}}" class="rounded-2xl border border-line bg-white px-3 py-2 text-xs text-slate-700 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100">
+          <button type="submit" class="rounded-2xl border border-slate-200 bg-white/75 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm hover:bg-slate-50">Apply</button>
+        </form>
+        <a href="{{.ToggleInactiveURL}}" class="text-xs font-semibold text-sky-600 hover:text-sky-800">{{if .IncludeInactive}}Hide deactivated{{else}}Show deactivated{{end}}</a>
         <a href="/admin/vehicles/new" class="inline-flex items-center justify-center rounded-2xl bg-ink px-4 py-2 text-xs font-semibold text-white transition hover:bg-slate-800">New vehicle</a>
       </div>
     </div>


### PR DESCRIPTION
# Search and filter the admin vehicle and user lists
## Summary
`/admin/trips` filters by status, vehicle and free-text search. `/admin/vehicles` has only `include_inactive`, and `/admin/users` has nothing. #99 gave both pages pagination, so an operator can page through a large fleet — but cannot find a specific bus or driver, which is the question the admin UI exists to answer.
This adds free-text search to both, plus an agency filter on vehicles and role and active filters on users, using the same shapes #92 established for trips. `q`, `agency_tag` and `role` are available on the JSON endpoints too, since an agency's own tooling hits the API rather than the admin UI.
| Page | Before | After |
|---|---|---|
| Vehicles | `include_inactive` | `q` (id + label), `agency_tag`, `include_inactive` |
| Users | nothing | `q` (name + email), `role`, `active` |
## Why these queries are hand-written rather than sqlc
`ListTrips` already documents the reason: *"Dynamic WHERE clauses make this a hand-written query rather than sqlc."* The vehicle path shows why it's unavoidable — it currently branches between two whole sqlc queries for one boolean, and three optional filters would be eight variants; users' two would be four. Enumerating them is worse than one parameterised builder by every measure.
Every value goes through the same `arg()` closure `ListTrips` uses, so only `$N` placeholders reach the SQL string — no user input is ever concatenated into it. The now-unused `ListVehiclesPage`, `ListActiveVehiclesPage` and `ListUsersPage` sqlc queries are deleted and `db/query.sql.go` regenerated rather than left behind.
The LIKE-metacharacter escaping is now a shared `likeSubstringPattern` helper rather than a third copy, and `ListTrips` calls it too. Without it a search for `bus_1` also matches `bus-1` — vehicle ids permit `_`, so that's a real input, not a theoretical one — and a search for `%` returns everything. `TestStore_ListVehiclesPage_QEscapesWildcards` is the guard.
## Behaviour
No change with no filters set. An empty filter returns exactly what each page returned before, pinned by `TestStore_ListVehiclesPage_EmptyFilterMatchesAll` and `TestStore_ListUsersPage_EmptyFilterMatchesAll`. The JSON endpoints keep their bare-array shape, and both still list deactivated rows as they always have.
One naming note worth flagging: vehicles keep `?include_inactive=1` (deactivated hidden by default, unchanged). Users get `?active=1` instead — opt-in — because `/admin/users` and `GET /api/v1/admin/users` list deactivated accounts today, and adopting the vehicles default would silently hide accounts and change the API's result set. Aligning the two defaults is a separate behaviour change and belongs in its own PR.
Filters are threaded through the prev/next links and the show/hide-deactivated toggle, so page 2 of a search stays filtered and toggling doesn't discard a search in progress. `q` is capped at `maxFieldLength` (255) on all four entry points; `role` is validated by reusing `validUserRole`.
## Why no index in this PR
`ILIKE '%term%'` can't use a btree index, so these searches are sequential scans. At the scale this admin UI serves — thousands of rows, not millions — that's fine, and the queries are already `LIMIT`-bounded. A `pg_trgm` GIN index would be a migration for a performance problem nobody has measured, so it's a follow-up that needs `EXPLAIN ANALYZE` evidence first.
## Test plan
- [x] `go fmt` / `go vet` / `go build` / `go test` / `go mod tidy` clean; suite green **with** `DATABASE_URL` (535 pass, 0 fail, store tests confirmed run rather than skipped)
- [x] Store: each filter alone, filters combined, filtered paging tiles the match set exactly, and wildcard escaping (`bus_1` vs `bus-1`)
- [x] Handlers: validation tables incl. the 255/256 boundary pair and invalid role, each asserting the error message rather than only the status
- [x] Page-URL tests pin that every filter survives to page 2, plus a rendered page-2 request asserting the store received the same filter
- [x] Manual: 200 vehicles and 200 users seeded, searched and paged through both pages, wildcard escaping confirmed in the browser
## Follow-ups
- `pg_trgm` GIN index on the searched columns, if search latency becomes measurable on a real fleet
- Sorting by column
- `has_more` on the JSON endpoints — a breaking shape change, its own decision
- Aligning the users page's default active filter with the vehicles page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added free-text search and filtering to admin vehicle and user lists.
  - Vehicle filters support agency tags and inactive-status visibility.
  - User filters support roles, active status, and name or email searches.
  - Filter selections persist across pagination and visibility toggles.
  - Added responsive filter forms with prefilled values.

- **Bug Fixes**
  - Search terms now treat special characters literally.
  - Invalid roles and overly long search queries return clear validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->